### PR TITLE
Short term fix for a user to stay signed in

### DIFF
--- a/src/components/WelcomeView.jsx
+++ b/src/components/WelcomeView.jsx
@@ -82,11 +82,16 @@ class WelcomeView extends React.PureComponent {
           Welcome to the Jade Data Repository
           </div>
           <div>
-            <GoogleLogin // stealing clientId from Terra
+            <GoogleLogin // TODO this component may be unuseable once we require a terra registration
+              // stealing clientId from Terra
               clientId="500025638838-s2v23ar3spugtd5t2v1vgfa2sp7ppg0d.apps.googleusercontent.com"
               buttonText="Sign in with Google"
               onSuccess={onSignInSuccess}
               onFailure={onSignInFailure}
+              isSignedIn
+              cookiePolicy={'single_host_origin'}
+              prompt="select_account"
+              scope="openid profile email"
               theme="dark"
             />
           </div>


### PR DESCRIPTION
This returns the google user obj on load, so as long as signed somewhere in the browser, the user shouldn't be logged out

This is a shim --
Once we have SAM and Terra registration integrated, we may need to roll our own component rather than using the react-google-login
Should be a straightforward process given the code already used by the Terra team

![signinui](https://user-images.githubusercontent.com/6863459/54886219-0f2bd780-4e5c-11e9-8dfd-cc7ae916f930.gif)
