### PR TITLE
add job type information to the job poller

### DIFF
--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -10,6 +10,8 @@ import { ActionTypes } from 'constants/index';
 
 export const { createDataset } = createActions({
   [ActionTypes.CREATE_DATASET]: dataset => dataset,
+  [ActionTypes.CREATE_DATASET_SUCCESS]: dataset => dataset,
+  [ActionTypes.CREATE_DATASET_FAILURE]: dataset => dataset,
 });
 
 export const { getStudies } = createActions({
@@ -30,9 +32,4 @@ export const { getDatasetById } = createActions({
 export const { getStudyById } = createActions({
   [ActionTypes.GET_STUDY_BY_ID]: study => study,
   [ActionTypes.GET_STUDY_BY_ID_SUCCESS]: study => study,
-});
-
-export const { getJobById } = createActions({
-  [ActionTypes.GET_JOB_BY_ID_SUCCESS]: datasets => datasets,
-  [ActionTypes.GET_JOB_BY_ID]: datasets => datasets,
 });

--- a/src/components/DatasetDetailView.jsx
+++ b/src/components/DatasetDetailView.jsx
@@ -29,7 +29,6 @@ const styles = theme => ({
   card: {
     display: 'inline-block',
     padding: theme.spacing.unit * 4,
-    width: '200px',
   },
   header: {
     fontSize: '14px',

--- a/src/components/DatasetPreviewView.jsx
+++ b/src/components/DatasetPreviewView.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { withStyles } from '@material-ui/core/styles';
 import Card from '@material-ui/core/Card';
@@ -23,7 +24,6 @@ const styles = theme => ({
   card: {
     display: 'inline-block',
     padding: theme.spacing.unit * 4,
-    width: '200px',
   },
   header: {
     fontSize: '14px',
@@ -38,6 +38,7 @@ const styles = theme => ({
 export class DatasetPreviewView extends React.PureComponent {
   static propTypes = {
     classes: PropTypes.object.isRequired,
+    createdDataset: PropTypes.object,
     dataset: PropTypes.object,
     dispatch: PropTypes.func.isRequired,
   };
@@ -61,20 +62,25 @@ export class DatasetPreviewView extends React.PureComponent {
   }
 
   render() {
-    const { classes, dataset } = this.props;
+    const { classes, createdDataset, dataset } = this.props;
     // TODO when the job is completed -- what happens?
     // what happens if you got to this page and we havent loaded data properly?
     // what if it fails vs succeeds
-
     return (
       <div>
         <div className={classes.title}>Preview Dataset</div>
-        <p>Your new dataset is being created.</p>
+        {createdDataset.id && createdDataset.name === dataset.name?
+          (<p>Your new dataset has been created.</p>)
+          : (<p>Your new dataset is being created.</p>)
+        }
+
         <div className={classes.container}>
           <div className={classes.card}>
             <div className={classes.header}> Dataset Name: </div>
-            {/* Does the dataset exist yet? if yes -- make this a link*/}
-            <div className={classes.values}> {dataset.name} </div>
+            {createdDataset.id && createdDataset.name === dataset.name?
+              (<div className={classes.values}><Link to={`/dataset/${createdDataset.id}`}>{dataset.name}</Link></div>)
+              :(<div className={classes.values}>{dataset.name}</div>)
+            }
             <div className={classes.header}> Description: </div>
             <div className={classes.values}> {dataset.description} </div>
           </div>
@@ -93,6 +99,7 @@ export class DatasetPreviewView extends React.PureComponent {
 /* istanbul ignore next */
 function mapStateToProps(state) {
   return {
+    createdDataset: state.datasets.createdDataset,
     dataset: state.dataset,
   };
 }

--- a/src/components/DatasetPreviewView.jsx
+++ b/src/components/DatasetPreviewView.jsx
@@ -69,18 +69,21 @@ export class DatasetPreviewView extends React.PureComponent {
     return (
       <div>
         <div className={classes.title}>Preview Dataset</div>
-        {createdDataset.id && createdDataset.name === dataset.name?
-          (<p>Your new dataset has been created.</p>)
-          : (<p>Your new dataset is being created.</p>)
-        }
-
+        {createdDataset.id && createdDataset.name === dataset.name ? (
+          <p>Your new dataset has been created.</p>
+        ) : (
+          <p>Your new dataset is being created.</p>
+        )}
         <div className={classes.container}>
           <div className={classes.card}>
             <div className={classes.header}> Dataset Name: </div>
-            {createdDataset.id && createdDataset.name === dataset.name?
-              (<div className={classes.values}><Link to={`/dataset/${createdDataset.id}`}>{dataset.name}</Link></div>)
-              :(<div className={classes.values}>{dataset.name}</div>)
-            }
+            {createdDataset.id && createdDataset.name === dataset.name ? (
+              <div className={classes.values}>
+                <Link to={`/dataset/${createdDataset.id}`}>{dataset.name}</Link>
+              </div>
+            ) : (
+              <div className={classes.values}>{dataset.name}</div>
+            )}
             <div className={classes.header}> Description: </div>
             <div className={classes.values}> {dataset.description} </div>
           </div>

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -19,7 +19,9 @@ export const ActionTypes = keyMirror({
   USER_LOGOUT_SUCCESS: undefined,
   USER_LOGOUT_FAILURE: undefined,
   CREATE_DATASET: undefined,
-  DATASET_CREATE_SUCCESS: undefined,
+  CREATE_DATASET_JOB: undefined,
+  CREATE_DATASET_SUCCESS: undefined,
+  CREATE_DATASET_FAILURE: undefined,
   GET_STUDIES: undefined,
   GET_STUDIES_SUCCESS: undefined,
   GET_STUDY_BY_ID: undefined,
@@ -43,7 +45,7 @@ export const STATUS = {
   IDLE: 'idle',
   RUNNING: 'running',
   READY: 'ready',
-  SUCCESS: 'success',
+  SUCCESS: 'success', // should this be succeeded ?
   ERROR: 'error',
 };
 

--- a/src/reducers/dataset.js
+++ b/src/reducers/dataset.js
@@ -6,7 +6,7 @@ import { ActionTypes } from 'constants/index';
 export const datasetState = {
   dataset: {},
   datasets: [],
-  createDatasetJob: '',
+  createdDataset: {},
 };
 
 export default {
@@ -17,9 +17,9 @@ export default {
           datasets: { $set: action.datasets.data.data },
         });
       },
-      [ActionTypes.DATASET_CREATE_SUCCESS]: (state, action) => {
+      [ActionTypes.CREATE_DATASET_SUCCESS]: (state, action) => {
         return immutable(state, {
-          createDatasetJob: { $set: action.payload.data.data },
+          createdDataset: { $set: action.payload.jobResult },
         });
       },
       [ActionTypes.GET_DATASET_BY_ID_SUCCESS]: (state, action) => {

--- a/src/sagas/repository.js
+++ b/src/sagas/repository.js
@@ -63,7 +63,12 @@ export function* createDataset({ payload }) {
       type: ActionTypes.CREATE_DATASET_JOB,
       payload: { data: response, createdDataset: payload },
     });
-    yield call(pollJobWorker, jobId, ActionTypes.CREATE_DATASET_SUCCESS, ActionTypes.CREATE_DATASET_FAILURE);
+    yield call(
+      pollJobWorker,
+      jobId,
+      ActionTypes.CREATE_DATASET_SUCCESS,
+      ActionTypes.CREATE_DATASET_FAILURE,
+    );
   } catch (err) {
     yield put({
       type: ActionTypes.EXCEPTION,


### PR DESCRIPTION
keep the poller as general as possible, while still allowing job info to pass thru

On the preview page--once the dataset has been created, show a link to the dataset details page
![s9NHgp7JcA](https://user-images.githubusercontent.com/6863459/54966692-7bd1cf80-4f4b-11e9-82e6-e7dc4d1e6847.gif)

gd, this page is boring af

Is this too long of a time frame for a material ui progress bar?
https://material-ui.com/demos/progress/
