### PR TITLE
MK DR-891 Add description box to the 'save snapshot' panel

### DIFF
--- a/src/components/dataset/query/sidebar/QueryViewSidebar.jsx
+++ b/src/components/dataset/query/sidebar/QueryViewSidebar.jsx
@@ -10,6 +10,7 @@ import QueryViewSidebarItem from './QueryViewSidebarItem';
 import QuerySidebarPanel from './QuerySidebarPanel';
 import { applyFilters, openSnapshotDialog } from '../../../../actions';
 import CreateSnapshotPanel from './panels/CreateSnapshotPanel';
+import { push } from 'modules/hist';
 
 const drawerWidth = 400;
 
@@ -22,7 +23,7 @@ const styles = theme => ({
     gridTemplateRows: 'calc(100vh - 125px) 100px',
   },
   createSnapshotGrid: {
-    gridTemplateRows: 'calc(100vh - 200px) 125px',
+    gridTemplateRows: 'calc(100vh - 275px) 200px',
   },
   hide: {
     display: 'none',

--- a/src/components/dataset/query/sidebar/panels/CreateSnapshotPanel.jsx
+++ b/src/components/dataset/query/sidebar/panels/CreateSnapshotPanel.jsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React, { useState } from 'react';
 import clsx from 'clsx';
 import { withStyles } from '@material-ui/core/styles';
 
@@ -23,40 +22,60 @@ const styles = theme => ({
   cancelButton: {
     alignSelf: 'flex-end',
   },
+  textField: {
+    backgroundColor: theme.palette.common.white,
+    borderRadius: '5px',
+    marginBottom: theme.spacing(1),
+  },
 });
 
-export class CreateSnapshotPanel extends React.PureComponent {
-  static propTypes = {
-    classes: PropTypes.object,
-    handleCreateSnapshot: PropTypes.func,
-    handleSaveSnapshot: PropTypes.func,
-  };
+function CreateSnapshotPanel(props) {
+  const { classes, handleCreateSnapshot, handleSaveSnapshot } = props;
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
 
-  render() {
-    const { classes, handleCreateSnapshot, handleSaveSnapshot } = this.props;
-
-    return (
-      <div className={clsx(classes.rowTwo, classes.saveButtonContainer)}>
-        <TextField id="snapshotName" label="Snapshot Name" />
-        <div className={classes.buttonContainer}>
-          <Button
-            variant="contained"
-            className={clsx(classes.saveButton, { [classes.hide]: !open })}
-            onClick={() => handleCreateSnapshot(false)}
-          >
-            Cancel
-          </Button>
-          <Button
-            variant="contained"
-            className={clsx(classes.cancelButton, { [classes.hide]: !open })}
-            onClick={() => handleSaveSnapshot()}
-          >
-            Save Snapshot
-          </Button>
-        </div>
+  return (
+    <div className={clsx(classes.rowTwo, classes.saveButtonContainer)}>
+      <TextField
+        id="snapshotName"
+        label="Name"
+        variant="outlined"
+        size="small"
+        fullWidth
+        className={classes.textField}
+        onChange={event => setName(event.target.value)}
+        value={name}
+      />
+      <TextField
+        id="snapshotDescription"
+        label="Description"
+        variant="outlined"
+        size="small"
+        multiline
+        rows={3}
+        fullWidth
+        className={classes.textField}
+        onChange={event => setDescription(event.target.value)}
+        value={description}
+      />
+      <div className={classes.buttonContainer}>
+        <Button
+          variant="contained"
+          className={clsx(classes.saveButton, { [classes.hide]: !open })}
+          onClick={() => handleCreateSnapshot(false)}
+        >
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          className={clsx(classes.cancelButton, { [classes.hide]: !open })}
+          onClick={() => handleSaveSnapshot()}
+        >
+          Save Snapshot
+        </Button>
       </div>
-    );
-  }
+    </div>
+  );
 }
 
 export default withStyles(styles)(CreateSnapshotPanel);

--- a/src/components/dataset/query/sidebar/panels/CreateSnapshotPanel.jsx
+++ b/src/components/dataset/query/sidebar/panels/CreateSnapshotPanel.jsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { withStyles } from '@material-ui/core/styles';
 
@@ -29,53 +30,67 @@ const styles = theme => ({
   },
 });
 
-function CreateSnapshotPanel(props) {
-  const { classes, handleCreateSnapshot, handleSaveSnapshot } = props;
-  const [name, setName] = useState('');
-  const [description, setDescription] = useState('');
+export class CreateSnapshotPanel extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {
+      name: '',
+      description: '',
+    };
+  }
 
-  return (
-    <div className={clsx(classes.rowTwo, classes.saveButtonContainer)}>
-      <TextField
-        id="snapshotName"
-        label="Name"
-        variant="outlined"
-        size="small"
-        fullWidth
-        className={classes.textField}
-        onChange={event => setName(event.target.value)}
-        value={name}
-      />
-      <TextField
-        id="snapshotDescription"
-        label="Description"
-        variant="outlined"
-        size="small"
-        multiline
-        rows={3}
-        fullWidth
-        className={classes.textField}
-        onChange={event => setDescription(event.target.value)}
-        value={description}
-      />
-      <div className={classes.buttonContainer}>
-        <Button
-          variant="contained"
-          className={clsx(classes.saveButton, { [classes.hide]: !open })}
-          onClick={() => handleCreateSnapshot(false)}
-        >
-          Cancel
-        </Button>
-        <Button
-          variant="contained"
-          className={clsx(classes.cancelButton, { [classes.hide]: !open })}
-          onClick={() => handleSaveSnapshot()}
-        >
-          Save Snapshot
-        </Button>
+  static propTypes = {
+    classes: PropTypes.object,
+    handleCreateSnapshot: PropTypes.func,
+    handleSaveSnapshot: PropTypes.func,
+  };
+
+  render() {
+    const { classes, handleCreateSnapshot, handleSaveSnapshot } = this.props;
+    const { name, description } = this.state;
+    return (
+      <div className={clsx(classes.rowTwo, classes.saveButtonContainer)}>
+        <TextField
+          id="snapshotName"
+          label="Name"
+          variant="outlined"
+          size="small"
+          fullWidth
+          className={classes.textField}
+          onChange={event => this.setState({ name: event.target.value })}
+          value={name}
+        />
+        <TextField
+          id="snapshotDescription"
+          label="Description"
+          variant="outlined"
+          size="small"
+          multiline
+          rows={3}
+          fullWidth
+          className={classes.textField}
+          onChange={event => this.setState({ description: event.target.value })}
+          value={description}
+        />
+        <div className={classes.buttonContainer}>
+          <Button
+            variant="contained"
+            className={clsx(classes.saveButton, { [classes.hide]: !open })}
+            onClick={() => handleCreateSnapshot(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            className={clsx(classes.cancelButton, { [classes.hide]: !open })}
+            onClick={() => handleSaveSnapshot()}
+          >
+            Save Snapshot
+          </Button>
+        </div>
       </div>
-    </div>
-  );
+    );
+  }
 }
 
 export default withStyles(styles)(CreateSnapshotPanel);


### PR DESCRIPTION
<img width="398" alt="Screen Shot 2020-04-08 at 12 42 07 PM" src="https://user-images.githubusercontent.com/52389456/78810479-6aad0280-7996-11ea-9604-53c0e9ffab3a.png">
I didn't make too many changes since we're gonna want to move this component to its own panel in the near future. I just adjusted the size for now and added the text box.
Also fixed a quick bug that was preventing the save button from pushing to the snapshots page!