### PR TITLE
DR-977: Bump action version to 0.6.0

### DIFF
--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -21,7 +21,7 @@ jobs:
           token: ${{ secrets.HELM_REPO_TOKEN }}
           path: datarepo-helm-definitions
       - name: "Get gcp credentials"
-        uses: broadinstitute/datarepo-actions@0.5.0
+        uses: broadinstitute/datarepo-actions@0.6.0
         with:
           actions_subcommand: 'skip'
           role_id: ${{ secrets.ROLE_ID }}
@@ -46,13 +46,13 @@ jobs:
           gcloud auth configure-docker --quiet
           docker push gcr.io/broad-jade-dev/jade-data-repo-ui:${GCR_TAG}
       - name: "Check and edit Helm definition for dev"
-        uses: broadinstitute/datarepo-actions@0.5.0
+        uses: broadinstitute/datarepo-actions@0.6.0
         with:
           actions_subcommand: 'deploytagupdate'
           helm_env_prefix: dev
           helm_imagetag_update: ui
       - name: "Check and edit Helm definition for integration"
-        uses: broadinstitute/datarepo-actions@0.5.0
+        uses: broadinstitute/datarepo-actions@0.6.0
         with:
           actions_subcommand: 'deploytagupdate'
           helm_env_prefix: 'integration-1,integration-2,integration-3,integration-4,integration-5'


### PR DESCRIPTION
The latest version of the GitHub action cleans the IAM policy before it is run:

- https://github.com/broadinstitute/datarepo-actions/pull/8
- https://github.com/broadinstitute/datarepo-actions/pull/9

The action version was automatically bumped and released: https://github.com/broadinstitute/datarepo-actions/releases/tag/0.6.0