### PR TITLE
DR-1056 asset dropdown

### DIFF
--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -9,7 +9,7 @@ import { createActions } from 'redux-actions';
 import { ActionTypes } from 'constants/index';
 
 export const { createSnapshot } = createActions({
-  [ActionTypes.CREATE_SNAPSHOT]: () => ({}),
+  [ActionTypes.CREATE_SNAPSHOT]: (assetName) => assetName,
   [ActionTypes.CREATE_SNAPSHOT_JOB]: (snapshot) => snapshot,
   [ActionTypes.CREATE_SNAPSHOT_SUCCESS]: (snapshot) => snapshot,
   [ActionTypes.CREATE_SNAPSHOT_FAILURE]: (snapshot) => snapshot,

--- a/src/components/dataset/query/JadeDropdown.jsx
+++ b/src/components/dataset/query/JadeDropdown.jsx
@@ -14,13 +14,14 @@ const styles = () => ({
 export class JadeDropdown extends React.PureComponent {
   static propTypes = {
     classes: PropTypes.object,
+    name: PropTypes.string,
     onSelectedItem: PropTypes.func,
     options: PropTypes.array,
     value: PropTypes.string,
   };
 
   render() {
-    const { classes, options, onSelectedItem, value } = this.props;
+    const { classes, options, onSelectedItem, value, name } = this.props;
 
     return (
       <form autoComplete="off">
@@ -29,11 +30,11 @@ export class JadeDropdown extends React.PureComponent {
             value={value}
             onChange={(event) => onSelectedItem(event)}
             inputProps={{
-              name: 'table', // TODO: this needs to be generalized
-              id: 'table-select',
+              name,
+              id: `${name}-select`,
             }}
             displayEmpty
-            renderValue={(value) => (!value ? 'Select Asset' : value)}
+            renderValue={(value) => (!value ? name : value)}
           >
             {options.map((name) => (
               <MenuItem key={name} value={name}>

--- a/src/components/dataset/query/JadeDropdown.jsx
+++ b/src/components/dataset/query/JadeDropdown.jsx
@@ -27,13 +27,15 @@ export class JadeDropdown extends React.PureComponent {
         <FormControl variant="outlined" className={classes.root}>
           <Select
             value={value}
-            onChange={onSelectedItem}
+            onChange={(event) => onSelectedItem(event)}
             inputProps={{
-              name: 'table',
+              name: 'table', // TODO: this needs to be generalized
               id: 'table-select',
             }}
+            displayEmpty
+            renderValue={(value) => (!value ? 'Select Asset' : value)}
           >
-            {options.map(name => (
+            {options.map((name) => (
               <MenuItem key={name} value={name}>
                 {name}
               </MenuItem>

--- a/src/components/dataset/query/JadeDropdown.jsx
+++ b/src/components/dataset/query/JadeDropdown.jsx
@@ -1,31 +1,22 @@
 import React from 'react';
-import { withStyles } from '@material-ui/core/styles';
 import PropTypes from 'prop-types';
-import MenuItem from '@material-ui/core/MenuItem';
-import FormControl from '@material-ui/core/FormControl';
-import Select from '@material-ui/core/Select';
-
-const styles = () => ({
-  root: {
-    width: '100%',
-  },
-});
+import { MenuItem, FormControl, Select } from '@material-ui/core';
 
 export class JadeDropdown extends React.PureComponent {
   static propTypes = {
-    classes: PropTypes.object,
     name: PropTypes.string,
     onSelectedItem: PropTypes.func,
     options: PropTypes.array,
     value: PropTypes.string,
   };
 
+  // Returns a controlled dropdown component for selecting a single item from a list
   render() {
-    const { classes, options, onSelectedItem, value, name } = this.props;
+    const { options, onSelectedItem, value, name } = this.props;
 
     return (
       <form autoComplete="off">
-        <FormControl variant="outlined" className={classes.root}>
+        <FormControl variant="outlined" fullWidth>
           <Select
             value={value}
             onChange={(event) => onSelectedItem(event)}
@@ -48,4 +39,4 @@ export class JadeDropdown extends React.PureComponent {
   }
 }
 
-export default withStyles(styles)(JadeDropdown);
+export default JadeDropdown;

--- a/src/components/dataset/query/JadeDropdown.jsx
+++ b/src/components/dataset/query/JadeDropdown.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { withStyles } from '@material-ui/core/styles';
+import PropTypes from 'prop-types';
+import MenuItem from '@material-ui/core/MenuItem';
+import FormControl from '@material-ui/core/FormControl';
+import Select from '@material-ui/core/Select';
+
+const styles = () => ({
+  root: {
+    width: '100%',
+  },
+});
+
+export class JadeDropdown extends React.PureComponent {
+  static propTypes = {
+    classes: PropTypes.object,
+    onSelectedItem: PropTypes.func,
+    options: PropTypes.array,
+    value: PropTypes.string,
+  };
+
+  render() {
+    const { classes, options, onSelectedItem, value } = this.props;
+
+    return (
+      <form autoComplete="off">
+        <FormControl variant="outlined" className={classes.root}>
+          <Select
+            value={value}
+            onChange={onSelectedItem}
+            inputProps={{
+              name: 'table',
+              id: 'table-select',
+            }}
+          >
+            {options.map(name => (
+              <MenuItem key={name} value={name}>
+                {name}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </form>
+    );
+  }
+}
+
+export default withStyles(styles)(JadeDropdown);

--- a/src/components/dataset/query/QueryViewDropdown.jsx
+++ b/src/components/dataset/query/QueryViewDropdown.jsx
@@ -42,7 +42,12 @@ export class QueryViewDropdown extends React.PureComponent {
     const { values } = this.state;
 
     return (
-      <JadeDropdown onSelectedItem={this.handleChange} options={options} value={values.table} />
+      <JadeDropdown
+        onSelectedItem={this.handleChange}
+        options={options}
+        value={values.table}
+        name="Select Table"
+      />
     );
   }
 }

--- a/src/components/dataset/query/QueryViewDropdown.jsx
+++ b/src/components/dataset/query/QueryViewDropdown.jsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import PropTypes from 'prop-types';
-import MenuItem from '@material-ui/core/MenuItem';
-import FormControl from '@material-ui/core/FormControl';
-import Select from '@material-ui/core/Select';
+import JadeDropdown from './JadeDropdown';
 
 const styles = () => ({
   root: {
@@ -31,7 +29,7 @@ export class QueryViewDropdown extends React.PureComponent {
     options: PropTypes.array,
   };
 
-  handleChange = event => {
+  handleChange = (event) => {
     const { onSelectedItem } = this.props;
     this.setState({
       values: { ...this.values, [event.target.name]: event.target.value },
@@ -44,24 +42,7 @@ export class QueryViewDropdown extends React.PureComponent {
     const { values } = this.state;
 
     return (
-      <form autoComplete="off">
-        <FormControl variant="outlined" className={classes.root}>
-          <Select
-            value={values.table}
-            onChange={this.handleChange}
-            inputProps={{
-              name: 'table',
-              id: 'table-select',
-            }}
-          >
-            {options.map(name => (
-              <MenuItem key={name} value={name}>
-                {name}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
-      </form>
+      <JadeDropdown onSelectedItem={this.handleChange} options={options} value={values.table} />
     );
   }
 }

--- a/src/components/dataset/query/sidebar/CreateSnapshotDropdown.jsx
+++ b/src/components/dataset/query/sidebar/CreateSnapshotDropdown.jsx
@@ -13,7 +13,9 @@ export class CreateSnapshotDropdown extends React.PureComponent {
     const { options, onSelectedItem } = this.props;
     const assetNames = options.map((opt) => opt.name);
 
-    return <JadeDropdown options={assetNames} onSelectedItem={onSelectedItem} />;
+    return (
+      <JadeDropdown options={assetNames} onSelectedItem={onSelectedItem} name="Select Asset" />
+    );
   }
 }
 

--- a/src/components/dataset/query/sidebar/CreateSnapshotDropdown.jsx
+++ b/src/components/dataset/query/sidebar/CreateSnapshotDropdown.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withStyles } from '@material-ui/core/styles';
+import JadeDropdown from '../JadeDropdown';
+
+export class CreateSnapshotDropdown extends React.PureComponent {
+  static propTypes = {
+    options: PropTypes.array,
+    onSelectedItem: PropTypes.func,
+  };
+
+  render() {
+    const { options, onSelectedItem } = this.props;
+    const assetNames = options.map(opt => opt.name);
+    const initialValue = assetNames[0];
+
+    return (
+      <JadeDropdown options={assetNames} onSelectedItem={onSelectedItem} value={initialValue} />
+    );
+  }
+}
+
+export default CreateSnapshotDropdown;

--- a/src/components/dataset/query/sidebar/CreateSnapshotDropdown.jsx
+++ b/src/components/dataset/query/sidebar/CreateSnapshotDropdown.jsx
@@ -11,12 +11,9 @@ export class CreateSnapshotDropdown extends React.PureComponent {
 
   render() {
     const { options, onSelectedItem } = this.props;
-    const assetNames = options.map(opt => opt.name);
-    const initialValue = assetNames[0];
+    const assetNames = options.map((opt) => opt.name);
 
-    return (
-      <JadeDropdown options={assetNames} onSelectedItem={onSelectedItem} value={initialValue} />
-    );
+    return <JadeDropdown options={assetNames} onSelectedItem={onSelectedItem} />;
   }
 }
 

--- a/src/components/dataset/query/sidebar/QueryViewSidebar.jsx
+++ b/src/components/dataset/query/sidebar/QueryViewSidebar.jsx
@@ -20,7 +20,6 @@ import QuerySidebarPanel from './QuerySidebarPanel';
 import { applyFilters, openSnapshotDialog, createSnapshot } from '../../../../actions';
 import CreateSnapshotPanel from './panels/CreateSnapshotPanel';
 import { push } from 'modules/hist';
-import { NonceProvider } from 'react-select';
 
 const drawerWidth = 400;
 
@@ -119,6 +118,7 @@ export class QueryViewSidebar extends React.PureComponent {
       isSavingSnapshot: false,
       searchString: '',
       openFilter: {},
+      selectedAsset: {},
     };
   }
 
@@ -210,6 +210,15 @@ export class QueryViewSidebar extends React.PureComponent {
     }
   };
 
+  handleSelectAsset = (event) => {
+    const { dataset } = this.props;
+
+    const selectedAsset = _.find(dataset.schema.assets, ['name', event.target.value]);
+    this.setState({
+      selectedAsset,
+    });
+  };
+
   render() {
     const {
       classes,
@@ -222,7 +231,7 @@ export class QueryViewSidebar extends React.PureComponent {
       joinStatement,
       selected,
     } = this.props;
-    const { isSavingSnapshot, searchString, openFilter } = this.state;
+    const { isSavingSnapshot, searchString, openFilter, selectedAsset } = this.state;
     const filteredColumns = table.columns.filter((column) => column.name.includes(searchString));
 
     return (
@@ -308,8 +317,10 @@ export class QueryViewSidebar extends React.PureComponent {
         )}
         {isSavingSnapshot && (
           <CreateSnapshotPanel
+            dataset={dataset}
             handleCreateSnapshot={this.handleCreateSnapshot}
             handleSaveSnapshot={this.handleSaveSnapshot}
+            handleSelectAsset={this.handleSelectAsset}
           />
         )}
       </div>

--- a/src/components/dataset/query/sidebar/QueryViewSidebar.jsx
+++ b/src/components/dataset/query/sidebar/QueryViewSidebar.jsx
@@ -190,9 +190,9 @@ export class QueryViewSidebar extends React.PureComponent {
     dispatch(applyFilters(filterMap, tableName, dataset));
   };
 
-  handleSaveSnapshot = () => {
-    const { dispatch, selected } = this.props;
-    dispatch(createSnapshot());
+  handleSaveSnapshot = (assetName) => {
+    const { dispatch } = this.props;
+    dispatch(createSnapshot(assetName));
     dispatch(openSnapshotDialog(true));
     push('/snapshots');
   };
@@ -208,16 +208,6 @@ export class QueryViewSidebar extends React.PureComponent {
     } else {
       this.setState({ openFilter: filter });
     }
-  };
-
-  handleSelectAsset = (event) => {
-    const { dataset } = this.props;
-    console.log(event);
-    console.log(event.target);
-    const selectedAsset = _.find(dataset.schema.assets, ['name', event.target.value]);
-    this.setState({
-      selectedAsset,
-    });
   };
 
   render() {

--- a/src/components/dataset/query/sidebar/QueryViewSidebar.jsx
+++ b/src/components/dataset/query/sidebar/QueryViewSidebar.jsx
@@ -32,7 +32,7 @@ const styles = (theme) => ({
     gridTemplateRows: 'calc(100vh - 125px) 100px',
   },
   createSnapshotGrid: {
-    gridTemplateRows: 'calc(100vh - 275px) 200px',
+    gridTemplateRows: 'calc(100vh - 325px) 200px',
   },
   hide: {
     display: 'none',
@@ -212,7 +212,8 @@ export class QueryViewSidebar extends React.PureComponent {
 
   handleSelectAsset = (event) => {
     const { dataset } = this.props;
-
+    console.log(event);
+    console.log(event.target);
     const selectedAsset = _.find(dataset.schema.assets, ['name', event.target.value]);
     this.setState({
       selectedAsset,

--- a/src/components/dataset/query/sidebar/panels/CreateSnapshotPanel.jsx
+++ b/src/components/dataset/query/sidebar/panels/CreateSnapshotPanel.jsx
@@ -71,7 +71,7 @@ export class CreateSnapshotPanel extends React.PureComponent {
 
   render() {
     const { classes, dataset, handleCreateSnapshot } = this.props;
-    const { name, description } = this.state;
+    const { name, description, assetName } = this.state;
     return (
       <div className={clsx(classes.rowTwo, classes.saveButtonContainer)}>
         <TextField
@@ -113,6 +113,7 @@ export class CreateSnapshotPanel extends React.PureComponent {
             variant="contained"
             className={clsx(classes.cancelButton, { [classes.hide]: !open })}
             onClick={this.saveNameAndDescription}
+            disabled={assetName === '' || name === ''}
           >
             Next
           </Button>

--- a/src/components/dataset/query/sidebar/panels/CreateSnapshotPanel.jsx
+++ b/src/components/dataset/query/sidebar/panels/CreateSnapshotPanel.jsx
@@ -37,9 +37,11 @@ export class CreateSnapshotPanel extends React.PureComponent {
   constructor(props) {
     super(props);
     const { name, description } = this.props.snapshot;
+    const { assetName } = this.props.snapshots;
     this.state = {
       name,
       description,
+      assetName,
     };
   }
 
@@ -54,20 +56,21 @@ export class CreateSnapshotPanel extends React.PureComponent {
 
   saveNameAndDescription = () => {
     const { dispatch, handleSaveSnapshot } = this.props;
-    const { name, description } = this.state;
+    const { name, description, assetName } = this.state;
     dispatch(actions.change('snapshot.name', name));
     dispatch(actions.change('snapshot.description', description));
-    handleSaveSnapshot();
+    handleSaveSnapshot(assetName);
+  };
+
+  handleSelectAsset = (event) => {
+    const assetName = event.target.value;
+    this.setState({
+      assetName,
+    });
   };
 
   render() {
-    const {
-      classes,
-      dataset,
-      handleCreateSnapshot,
-      handleSaveSnapshot,
-      handleSelectAsset,
-    } = this.props;
+    const { classes, dataset, handleCreateSnapshot } = this.props;
     const { name, description } = this.state;
     return (
       <div className={clsx(classes.rowTwo, classes.saveButtonContainer)}>
@@ -96,7 +99,7 @@ export class CreateSnapshotPanel extends React.PureComponent {
         {/* TODO: decide what to do when there's only one asset */}
         <CreateSnapshotDropdown
           options={dataset.schema.assets}
-          onSelectedItem={handleSelectAsset}
+          onSelectedItem={this.handleSelectAsset}
         />
         <div className={classes.buttonContainer}>
           <Button
@@ -122,6 +125,7 @@ export class CreateSnapshotPanel extends React.PureComponent {
 function mapStateToProps(state) {
   return {
     snapshot: state.snapshot,
+    snapshots: state.snapshots,
   };
 }
 

--- a/src/components/dataset/query/sidebar/panels/CreateSnapshotPanel.jsx
+++ b/src/components/dataset/query/sidebar/panels/CreateSnapshotPanel.jsx
@@ -6,6 +6,7 @@ import { actions } from 'react-redux-form';
 import { connect } from 'react-redux';
 
 import { Button, TextField } from '@material-ui/core';
+import CreateSnapshotDropdown from '../CreateSnapshotDropdown';
 
 const styles = (theme) => ({
   buttonContainer: {
@@ -44,8 +45,10 @@ export class CreateSnapshotPanel extends React.PureComponent {
 
   static propTypes = {
     classes: PropTypes.object,
+    dataset: PropTypes.object,
     handleCreateSnapshot: PropTypes.func,
     handleSaveSnapshot: PropTypes.func,
+    handleSelectAsset: PropTypes.func,
     snapshot: PropTypes.object,
   };
 
@@ -58,7 +61,13 @@ export class CreateSnapshotPanel extends React.PureComponent {
   };
 
   render() {
-    const { classes, handleCreateSnapshot } = this.props;
+    const {
+      classes,
+      dataset,
+      handleCreateSnapshot,
+      handleSaveSnapshot,
+      handleSelectAsset,
+    } = this.props;
     const { name, description } = this.state;
     return (
       <div className={clsx(classes.rowTwo, classes.saveButtonContainer)}>
@@ -83,6 +92,10 @@ export class CreateSnapshotPanel extends React.PureComponent {
           className={classes.textField}
           onChange={(event) => this.setState({ description: event.target.value })}
           value={description}
+        />
+        <CreateSnapshotDropdown
+          options={dataset.schema.assets}
+          onSelectedItem={handleSelectAsset}
         />
         <div className={classes.buttonContainer}>
           <Button

--- a/src/components/dataset/query/sidebar/panels/CreateSnapshotPanel.jsx
+++ b/src/components/dataset/query/sidebar/panels/CreateSnapshotPanel.jsx
@@ -93,6 +93,7 @@ export class CreateSnapshotPanel extends React.PureComponent {
           onChange={(event) => this.setState({ description: event.target.value })}
           value={description}
         />
+        {/* TODO: decide what to do when there's only one asset */}
         <CreateSnapshotDropdown
           options={dataset.schema.assets}
           onSelectedItem={handleSelectAsset}

--- a/src/reducers/snapshot.js
+++ b/src/reducers/snapshot.js
@@ -5,6 +5,7 @@ import BigQuery from 'modules/bigquery';
 import { ActionTypes } from 'constants/index';
 
 export const snapshotState = {
+  assetName: '',
   createdSnapshots: [],
   snapshot: {},
   snapshots: [],

--- a/src/sagas/repository.js
+++ b/src/sagas/repository.js
@@ -103,14 +103,15 @@ function* pollJobWorker(jobId, jobTypeSuccess, jobTypeFailure) {
  * Snapshots.
  */
 
-export function* createSnapshot() {
+export function* createSnapshot({ payload }) {
   const snapshot = yield select(getCreateSnapshot);
   const snapshots = yield select(getSnapshotState);
   const dataset = yield select(getDataset);
 
   const datasetName = dataset.name;
   const mode = 'byQuery';
-  const rootTable = dataset.schema.assets[0].rootTable; // TODO: asset thing
+  const selectedAsset = _.find(dataset.schema.assets, (asset) => asset.name === payload);
+  const rootTable = selectedAsset.rootTable;
   const drRowId = 'datarepo_row_id';
 
   const snapshotRequest = {
@@ -123,8 +124,7 @@ export function* createSnapshot() {
         datasetName,
         mode,
         querySpec: {
-          // TODO: be able to select which asset you wanna use (NOT just the first/only one)
-          assetName: dataset.schema.assets[0].name, // maybe no asset???
+          assetName: payload,
           query: `SELECT ${datasetName}.${rootTable}.${drRowId} ${snapshots.joinStatement} ${snapshots.filterStatement}`,
         },
       },


### PR DESCRIPTION
![create-snapshot](https://user-images.githubusercontent.com/52389456/83790680-90891780-a666-11ea-9ba8-ef6bfcb63168.gif)
The UI includes a dropdown to select an asset, which is necessary for snapshot creation. We had previously hardcoded the first asset in the schema to be used every time.