### PR TITLE
DR-1006 link snapshot details panel to share panel

### DIFF
--- a/cypress/integration/queryBuilder.spec.js
+++ b/cypress/integration/queryBuilder.spec.js
@@ -163,4 +163,29 @@ describe('test query builder', () => {
       cy.get('[data-cy=readers]').should('not.contain', ' zie@gmail.com');
     });
   });
+
+  describe('test wizard flow', () => {
+    it('transitions to share panel', () => {
+      // open filter panel
+      cy.get('div.MuiButtonBase-root:nth-child(2) > svg:nth-child(1)').click();
+
+      // create snapshot button should open 'Add details' panel
+      cy.get('[data-cy=createSnapshot]').click();
+      cy.contains('Add Details').should('be.visible');
+      cy.get('[data-cy=next]').should('be.disabled');
+
+      // enter snapshot name
+      cy.get('[data-cy=textFieldName]').type('mySnapshot');
+      cy.get('[data-cy=next]').should('be.disabled');
+
+      // select asset
+      cy.get('[data-cy=selectAsset]').click();
+      cy.get('[data-cy=menuItem-Variant]').click();
+      cy.get('[data-cy=next]').should('not.be.disabled');
+
+      // 'next' button should bring user to share panel
+      cy.get('[data-cy=next]').click();
+      cy.contains('Share Snapshot').should('be.visible');
+    });
+  });
 });

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -9,7 +9,7 @@ import { createActions } from 'redux-actions';
 import { ActionTypes } from 'constants/index';
 
 export const { createSnapshot } = createActions({
-  [ActionTypes.CREATE_SNAPSHOT]: (assetName) => assetName,
+  [ActionTypes.CREATE_SNAPSHOT]: () => ({}),
   [ActionTypes.CREATE_SNAPSHOT_JOB]: (snapshot) => snapshot,
   [ActionTypes.CREATE_SNAPSHOT_SUCCESS]: (snapshot) => snapshot,
   [ActionTypes.CREATE_SNAPSHOT_FAILURE]: (snapshot) => snapshot,

--- a/src/components/dataset/query/JadeDropdown.jsx
+++ b/src/components/dataset/query/JadeDropdown.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import _ from 'lodash';
 import PropTypes from 'prop-types';
 import { MenuItem, FormControl, Select } from '@material-ui/core';
 
@@ -26,10 +27,11 @@ export class JadeDropdown extends React.PureComponent {
             }}
             displayEmpty
             renderValue={(value) => (!value ? name : value)}
+            data-cy={_.camelCase(name)}
           >
-            {options.map((name) => (
-              <MenuItem key={name} value={name}>
-                {name}
+            {options.map((opt) => (
+              <MenuItem key={opt} value={opt} data-cy={`menuItem-${opt}`}>
+                {opt}
               </MenuItem>
             ))}
           </Select>

--- a/src/components/dataset/query/QueryViewDropdown.jsx
+++ b/src/components/dataset/query/QueryViewDropdown.jsx
@@ -1,55 +1,41 @@
 import React from 'react';
-import { withStyles } from '@material-ui/core/styles';
 import PropTypes from 'prop-types';
 import JadeDropdown from './JadeDropdown';
-
-const styles = () => ({
-  root: {
-    width: '100%',
-  },
-});
 
 export class QueryViewDropdown extends React.PureComponent {
   constructor(props) {
     super(props);
     const { onSelectedItem, options } = this.props;
-
     this.state = {
-      values: {
-        table: options[0],
-        name: '',
-      },
+      table: options[0],
     };
     onSelectedItem(options[0]);
   }
 
   static propTypes = {
-    classes: PropTypes.object,
     onSelectedItem: PropTypes.func,
     options: PropTypes.array,
   };
 
   handleChange = (event) => {
     const { onSelectedItem } = this.props;
-    this.setState({
-      values: { ...this.values, [event.target.name]: event.target.value },
-    });
+    this.setState({ table: event.target.value });
     onSelectedItem(event.target.value);
   };
 
   render() {
-    const { classes, options } = this.props;
-    const { values } = this.state;
+    const { options } = this.props;
+    const { table } = this.state;
 
     return (
       <JadeDropdown
         onSelectedItem={this.handleChange}
         options={options}
-        value={values.table}
+        value={table}
         name="Select Table"
       />
     );
   }
 }
 
-export default withStyles(styles)(QueryViewDropdown);
+export default QueryViewDropdown;

--- a/src/components/dataset/query/sidebar/CreateSnapshotDropdown.jsx
+++ b/src/components/dataset/query/sidebar/CreateSnapshotDropdown.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
 import JadeDropdown from '../JadeDropdown';
 
 export class CreateSnapshotDropdown extends React.PureComponent {

--- a/src/components/dataset/query/sidebar/CreateSnapshotDropdown.jsx
+++ b/src/components/dataset/query/sidebar/CreateSnapshotDropdown.jsx
@@ -7,14 +7,20 @@ export class CreateSnapshotDropdown extends React.PureComponent {
   static propTypes = {
     options: PropTypes.array,
     onSelectedItem: PropTypes.func,
+    value: PropTypes.string,
   };
 
   render() {
-    const { options, onSelectedItem } = this.props;
+    const { value, options, onSelectedItem } = this.props;
     const assetNames = options.map((opt) => opt.name);
 
     return (
-      <JadeDropdown options={assetNames} onSelectedItem={onSelectedItem} name="Select Asset" />
+      <JadeDropdown
+        options={assetNames}
+        onSelectedItem={onSelectedItem}
+        value={value}
+        name="Select Asset"
+      />
     );
   }
 }

--- a/src/components/dataset/query/sidebar/QueryViewSidebar.jsx
+++ b/src/components/dataset/query/sidebar/QueryViewSidebar.jsx
@@ -2,9 +2,7 @@ import React from 'react';
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import FilterPanel from './panels/FilterPanel';
-import { openSnapshotDialog, createSnapshot } from '../../../../actions';
 import CreateSnapshotPanel from './panels/CreateSnapshotPanel';
-import { push } from 'modules/hist';
 
 export class QueryViewSidebar extends React.PureComponent {
   constructor(props) {
@@ -15,7 +13,6 @@ export class QueryViewSidebar extends React.PureComponent {
   }
 
   static propTypes = {
-    dispatch: PropTypes.func.isRequired,
     open: PropTypes.bool,
     selected: PropTypes.string,
     switchPanels: PropTypes.func,
@@ -24,13 +21,6 @@ export class QueryViewSidebar extends React.PureComponent {
 
   handleCreateSnapshot = (isSavingSnapshot) => {
     this.setState({ isSavingSnapshot });
-  };
-
-  handleSaveSnapshot = (assetName) => {
-    const { dispatch } = this.props;
-    dispatch(createSnapshot(assetName));
-    dispatch(openSnapshotDialog(true));
-    push('/snapshots');
   };
 
   render() {

--- a/src/components/dataset/query/sidebar/QueryViewSidebar.jsx
+++ b/src/components/dataset/query/sidebar/QueryViewSidebar.jsx
@@ -1,194 +1,29 @@
 import React from 'react';
 import _ from 'lodash';
-import clsx from 'clsx';
-import { connect } from 'react-redux';
-import { withStyles } from '@material-ui/core/styles';
 import PropTypes from 'prop-types';
-import {
-  Box,
-  Typography,
-  Button,
-  Grid,
-  InputBase,
-  ListItem,
-  Collapse,
-  Tooltip,
-} from '@material-ui/core';
-import { ExpandMore, ExpandLess, Search } from '@material-ui/icons';
-import QueryViewSidebarItem from './QueryViewSidebarItem';
-import QuerySidebarPanel from './QuerySidebarPanel';
-import { applyFilters, openSnapshotDialog, createSnapshot } from '../../../../actions';
+import FilterPanel from './panels/FilterPanel';
+import { openSnapshotDialog, createSnapshot } from '../../../../actions';
 import CreateSnapshotPanel from './panels/CreateSnapshotPanel';
 import { push } from 'modules/hist';
-
-const drawerWidth = 400;
-
-const styles = (theme) => ({
-  root: {
-    margin: theme.spacing(1),
-    display: 'grid',
-  },
-  defaultGrid: {
-    gridTemplateRows: 'calc(100vh - 125px) 100px',
-  },
-  createSnapshotGrid: {
-    gridTemplateRows: 'calc(100vh - 325px) 200px',
-  },
-  hide: {
-    display: 'none',
-  },
-  toolbar: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'flex-end',
-    padding: '0 8px',
-    ...theme.mixins.toolbar,
-  },
-  filterPanel: {
-    marginBottom: '8px',
-  },
-  sidebarTitle: {
-    flexDirection: 'column',
-    display: 'flex',
-    justifyContent: 'center',
-  },
-  panelBottomBorder: {
-    borderBottom: `1px solid ${theme.palette.divider}`,
-  },
-  stickyButton: {
-    position: '-webkit-sticky',
-    // eslint-disable-next-line no-dupe-keys
-    position: 'fixed',
-    bottom: '0',
-    marginBottom: theme.spacing(1),
-    width: drawerWidth / 2 - theme.spacing(2),
-    backgroundColor: theme.palette.primary.main,
-    '&:hover': {
-      backgroundColor: theme.palette.primary.hover,
-    },
-  },
-  snapshotButton: {
-    backgroundColor: `${theme.palette.primary.dark} !important`,
-  },
-  snapshotButtonContainer: {
-    display: 'flex',
-    justifyContent: 'flex-end',
-  },
-  panelContent: {
-    padding: `0px ${theme.spacing(2)}px`,
-  },
-  rowOne: {
-    gridRowStart: 1,
-    gridRowEnd: 2,
-    overflowY: 'auto',
-    overflowX: 'hidden',
-  },
-  rowTwo: {
-    gridRowStart: 2,
-    gridRowEnd: 3,
-  },
-  searchBar: {
-    display: 'flex',
-    alignItems: 'center',
-    borderRadius: '4px',
-  },
-  inputBase: {
-    paddingLeft: theme.spacing(0.5),
-  },
-  filterListItem: {
-    justifyContent: 'space-between',
-    fontWeight: '500',
-  },
-  highlighted: {
-    backgroundColor: theme.palette.primary.focus,
-    borderRadius: '4px',
-    paddingBottom: theme.spacing(0.5),
-  },
-  tooltip: {
-    pointerEvents: 'auto !important',
-    color: 'red',
-  },
-});
 
 export class QueryViewSidebar extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {
-      filterMap: {},
       isSavingSnapshot: false,
-      searchString: '',
-      openFilter: {},
-      selectedAsset: {},
     };
   }
 
   static propTypes = {
-    classes: PropTypes.object,
-    dataset: PropTypes.object,
     dispatch: PropTypes.func.isRequired,
-    filterData: PropTypes.object,
-    filterStatement: PropTypes.string,
-    joinStatement: PropTypes.string,
     open: PropTypes.bool,
     selected: PropTypes.string,
     switchPanels: PropTypes.func,
     table: PropTypes.object,
-    token: PropTypes.string,
   };
 
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    const { filterMap } = this.state;
-
-    if (!_.isEqual(nextProps.filterData, filterMap)) {
-      this.setState({
-        filterMap: nextProps.filterData,
-      });
-    }
-  }
-
-  handleDrawerOpen = () => {
-    this.setState({ open: true });
-  };
-
-  handleDrawerClose = () => {
-    this.setState({ open: false });
-  };
-
-  handleCreateSnapshot = (isSaving) => {
-    this.setState({ isSavingSnapshot: isSaving });
-  };
-
-  handleChange = (column, filter, table) => {
-    const { filterMap } = this.state;
-    const clonedMap = _.cloneDeep(filterMap);
-    if (filter.value == null || filter.value.length === 0) {
-      delete clonedMap[table][column];
-      if (_.isEmpty(clonedMap[table])) {
-        delete clonedMap[table];
-      }
-    } else if (_.isPlainObject(clonedMap[table])) {
-      clonedMap[table][column] = {
-        exclude: filter.exclude,
-        value: filter.value,
-        type: filter.type,
-      };
-    } else {
-      clonedMap[table] = {
-        [column]: {
-          exclude: filter.exclude,
-          value: filter.value,
-          type: filter.type,
-        },
-      };
-    }
-    this.setState({ filterMap: clonedMap }, this.handleFilters);
-  };
-
-  handleFilters = () => {
-    const { dispatch, table, dataset } = this.props;
-    const { filterMap } = this.state;
-    const tableName = table.name;
-    dispatch(applyFilters(filterMap, tableName, dataset));
+  handleCreateSnapshot = (isSavingSnapshot) => {
+    this.setState({ isSavingSnapshot });
   };
 
   handleSaveSnapshot = (assetName) => {
@@ -198,119 +33,21 @@ export class QueryViewSidebar extends React.PureComponent {
     push('/snapshots');
   };
 
-  handleSearchString = (event) => {
-    this.setState({ searchString: event.target.value });
-  };
-
-  handleOpenFilter = (filter) => {
-    const { openFilter } = this.state;
-    if (filter === openFilter) {
-      this.setState({ openFilter: {} });
-    } else {
-      this.setState({ openFilter: filter });
-    }
-  };
-
   render() {
-    const {
-      classes,
-      dataset,
-      filterData,
-      filterStatement,
-      open,
-      table,
-      token,
-      joinStatement,
-      selected,
-      switchPanels,
-    } = this.props;
-    const { isSavingSnapshot, searchString, openFilter } = this.state;
-    const filteredColumns = table.columns.filter((column) => column.name.includes(searchString));
+    const { open, table, selected, switchPanels } = this.props;
+    const { isSavingSnapshot } = this.state;
 
     return (
-      <div
-        className={clsx(classes.root, {
-          [classes.defaultGrid]: !isSavingSnapshot,
-          [classes.createSnapshotGrid]: isSavingSnapshot,
-        })}
-      >
-        <div className={classes.rowOne}>
-          <Box className={!open ? classes.hide : ''}>
-            <Grid container={true} spacing={1}>
-              <Grid item xs={10} className={classes.sidebarTitle}>
-                <Typography variant="h6" display="block">
-                  Data Snapshot
-                </Typography>
-              </Grid>
-            </Grid>
-          </Box>
-          <div className={clsx(classes.filterPanel, { [classes.hide]: !open })}>
-            <QuerySidebarPanel selected={selected} data-cy="snapshotCard" />
-          </div>
-          <ListItem button className={clsx(classes.searchBar, classes.panelContent)}>
-            <Search color="primary" fontSize={'small'} />
-            <InputBase
-              placeholder="Search filters"
-              className={classes.inputBase}
-              onChange={this.handleSearchString}
-            />
-          </ListItem>
-          {table &&
-            table.name &&
-            filteredColumns.map((c) => (
-              <div
-                className={clsx({ [classes.highlighted]: c === openFilter })}
-                data-cy="filterItem"
-              >
-                <ListItem
-                  button
-                  className={classes.filterListItem}
-                  onClick={() => this.handleOpenFilter(c)}
-                >
-                  {c.name}
-                  {c === openFilter ? <ExpandLess /> : <ExpandMore />}
-                </ListItem>
-                <Collapse in={c === openFilter} timeout="auto" className={classes.panelContent}>
-                  <QueryViewSidebarItem
-                    column={c}
-                    dataset={dataset}
-                    filterData={filterData}
-                    filterStatement={filterStatement}
-                    joinStatement={joinStatement}
-                    handleChange={this.handleChange}
-                    handleFilters={this.handleFilters}
-                    tableName={table.name}
-                    token={token}
-                  />
-                </Collapse>
-              </div>
-            ))}
-        </div>
-        {!isSavingSnapshot && (
-          <div className={classes.rowTwo}>
-            <Tooltip
-              title={_.isEmpty(dataset.schema.assets) ? 'Please add an asset to this dataset' : ''}
-            >
-              <div className={classes.snapshotButtonContainer}>
-                <Button
-                  variant="contained"
-                  disabled={_.isEmpty(dataset.schema.assets)}
-                  className={clsx(classes.stickyButton, classes.snapshotButton, {
-                    [classes.hide]: !open,
-                    [classes.tooltip]: _.isEmpty(dataset.schema.assets),
-                  })}
-                  onClick={() => this.handleCreateSnapshot(true)}
-                  data-cy="createSnapshot"
-                >
-                  Create Snapshot
-                </Button>
-              </div>
-            </Tooltip>
-          </div>
-        )}
-        {isSavingSnapshot && (
+      <div>
+        {!isSavingSnapshot ? (
+          <FilterPanel
+            open={open}
+            table={table}
+            selected={selected}
+            handleCreateSnapshot={this.handleCreateSnapshot}
+          />
+        ) : (
           <CreateSnapshotPanel
-            dataset={dataset}
             handleCreateSnapshot={this.handleCreateSnapshot}
             handleSaveSnapshot={this.handleSaveSnapshot}
             handleSelectAsset={this.handleSelectAsset}
@@ -322,14 +59,4 @@ export class QueryViewSidebar extends React.PureComponent {
   }
 }
 
-function mapStateToProps(state) {
-  return {
-    dataset: state.datasets.dataset,
-    filterData: state.query.filterData,
-    filterStatement: state.query.filterStatement,
-    joinStatement: state.query.joinStatement,
-    token: state.user.token,
-  };
-}
-
-export default connect(mapStateToProps)(withStyles(styles)(QueryViewSidebar));
+export default QueryViewSidebar;

--- a/src/components/dataset/query/sidebar/QueryViewSidebar.jsx
+++ b/src/components/dataset/query/sidebar/QueryViewSidebar.jsx
@@ -131,6 +131,7 @@ export class QueryViewSidebar extends React.PureComponent {
     joinStatement: PropTypes.string,
     open: PropTypes.bool,
     selected: PropTypes.string,
+    switchPanels: PropTypes.func,
     table: PropTypes.object,
     token: PropTypes.string,
   };
@@ -221,8 +222,9 @@ export class QueryViewSidebar extends React.PureComponent {
       token,
       joinStatement,
       selected,
+      switchPanels,
     } = this.props;
-    const { isSavingSnapshot, searchString, openFilter, selectedAsset } = this.state;
+    const { isSavingSnapshot, searchString, openFilter } = this.state;
     const filteredColumns = table.columns.filter((column) => column.name.includes(searchString));
 
     return (
@@ -312,6 +314,7 @@ export class QueryViewSidebar extends React.PureComponent {
             handleCreateSnapshot={this.handleCreateSnapshot}
             handleSaveSnapshot={this.handleSaveSnapshot}
             handleSelectAsset={this.handleSelectAsset}
+            switchPanels={switchPanels}
           />
         )}
       </div>

--- a/src/components/dataset/query/sidebar/SidebarDrawer.jsx
+++ b/src/components/dataset/query/sidebar/SidebarDrawer.jsx
@@ -4,7 +4,7 @@ import { withStyles, makeStyles } from '@material-ui/core/styles';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 
-const styles = theme => ({
+const styles = (theme) => ({
   root: {
     backgroundColor: theme.palette.primary.lightContrast,
     position: 'absolute',
@@ -22,7 +22,7 @@ const styles = theme => ({
   drawerPosition: {
     position: 'absolute',
   },
-  drawerOpen: props => ({
+  drawerOpen: (props) => ({
     width: props.width,
     transition: theme.transitions.create('width', {
       easing: theme.transitions.easing.sharp,
@@ -40,9 +40,6 @@ const styles = theme => ({
       width: 0,
     },
   },
-  iconList: {
-    color: theme.palette.primary.light,
-  },
   active: {
     backgroundColor: theme.palette.primary.light,
   },
@@ -52,10 +49,7 @@ export class SidebarDrawer extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {
-      open: false,
-      currentKey: null,
       PanelComponent: null,
-      dataset: null,
     };
   }
 
@@ -68,33 +62,23 @@ export class SidebarDrawer extends React.PureComponent {
     table: PropTypes.object,
   };
 
-  handleDrawerOpen = () => {
-    this.setState({ open: true });
-  };
+  handleOpenPanel = (PanelComponent) => {
+    const { handleDrawerWidth, panels } = this.props;
+    // look through panels prop for the width of the given PanelComponent
+    const { width } = panels.find((panel) => panel.component === PanelComponent);
 
-  handleDrawerClose = () => {
-    this.setState({ open: false });
-  };
-
-  handleButtonClick = (key, PanelComponent, dataset, width) => {
-    const { currentKey, open } = this.state;
-    const { handleDrawerWidth } = this.props;
-
-    if (currentKey == null || !open) {
-      handleDrawerWidth(width);
-      this.setState({ open: true, currentKey: key, PanelComponent, dataset });
-    } else if (currentKey !== key && open) {
-      handleDrawerWidth(width);
-      this.setState({ currentKey: key, PanelComponent, dataset });
+    if (this.state.PanelComponent === PanelComponent) {
+      this.setState({ PanelComponent: null });
     } else {
-      this.setState({ open: false, currentKey: null });
+      handleDrawerWidth(width);
+      this.setState({ PanelComponent });
     }
   };
 
   render() {
     const { panels, classes, table, selected } = this.props;
-    const { open, PanelComponent, dataset, currentKey } = this.state;
-
+    const { PanelComponent } = this.state;
+    const open = PanelComponent !== null;
     return (
       <Fragment>
         <Drawer
@@ -113,7 +97,12 @@ export class SidebarDrawer extends React.PureComponent {
           open={open}
         >
           {PanelComponent != null && (
-            <PanelComponent open={open} table={table} dataset={dataset} selected={selected} />
+            <PanelComponent
+              open={open}
+              table={table}
+              selected={selected}
+              switchPanels={this.handleOpenPanel}
+            />
           )}
         </Drawer>
         <Box className={classes.root}>
@@ -123,13 +112,11 @@ export class SidebarDrawer extends React.PureComponent {
               return (
                 <ListItem
                   className={clsx({
-                    [classes.active]: i === currentKey,
+                    [classes.active]: panel.component === PanelComponent,
                   })}
                   button
                   key={i}
-                  onClick={() =>
-                    this.handleButtonClick(i, panel.component, panel.dataset, panel.width)
-                  }
+                  onClick={() => this.handleOpenPanel(panel.component)}
                 >
                   <IconComponent />
                 </ListItem>

--- a/src/components/dataset/query/sidebar/panels/CreateSnapshotPanel.jsx
+++ b/src/components/dataset/query/sidebar/panels/CreateSnapshotPanel.jsx
@@ -91,6 +91,7 @@ export class CreateSnapshotPanel extends React.PureComponent {
             className={classes.textField}
             onChange={(event) => this.setState({ name: event.target.value })}
             value={name}
+            data-cy="textFieldName"
           />
           <Typography variant="subtitle2">Description</Typography>
           <TextField
@@ -109,6 +110,7 @@ export class CreateSnapshotPanel extends React.PureComponent {
             options={dataset.schema.assets}
             onSelectedItem={this.handleSelectAsset}
             value={assetName}
+            data-cy="selectAsset"
           />
         </div>
         <div className={classes.rowTwo}>
@@ -118,6 +120,7 @@ export class CreateSnapshotPanel extends React.PureComponent {
               variant="contained"
               onClick={this.saveNameAndDescription}
               disabled={assetName === '' || name === ''}
+              data-cy="next"
             >
               Next
             </Button>

--- a/src/components/dataset/query/sidebar/panels/CreateSnapshotPanel.jsx
+++ b/src/components/dataset/query/sidebar/panels/CreateSnapshotPanel.jsx
@@ -5,27 +5,31 @@ import { withStyles } from '@material-ui/core/styles';
 import { actions } from 'react-redux-form';
 import { connect } from 'react-redux';
 
-import { Button, TextField } from '@material-ui/core';
+import { Button, TextField, Typography } from '@material-ui/core';
 import CreateSnapshotDropdown from '../CreateSnapshotDropdown';
 import ShareSnapshot from './ShareSnapshot';
 
 const styles = (theme) => ({
+  root: {
+    margin: theme.spacing(1),
+    display: 'grid',
+    gridTemplateRows: 'calc(100vh - 125px) 100px',
+  },
+  rowOne: {
+    gridRowStart: 1,
+    gridRowEnd: 2,
+    overflowY: 'auto',
+    overflowX: 'hidden',
+    padding: theme.spacing(1),
+  },
+  rowTwo: {
+    gridRowStart: 2,
+    gridRowEnd: 3,
+  },
   buttonContainer: {
     display: 'flex',
-    justifyContent: 'space-between',
-  },
-  saveButtonContainer: {
-    backgroundColor: theme.palette.primary.light,
-    marginBottom: theme.spacing(1),
-    padding: theme.spacing(1),
-    marginTop: theme.spacing(1),
-  },
-  saveButton: {
-    marginTop: theme.spacing(1),
-    alignSelf: 'flex-start',
-  },
-  cancelButton: {
-    alignSelf: 'flex-end',
+    justifyContent: 'flex-end',
+    paddingTop: theme.spacing(1),
   },
   textField: {
     backgroundColor: theme.palette.common.white,
@@ -75,50 +79,48 @@ export class CreateSnapshotPanel extends React.PureComponent {
     const { classes, dataset, handleCreateSnapshot } = this.props;
     const { name, description, assetName } = this.state;
     return (
-      <div className={clsx(classes.rowTwo, classes.saveButtonContainer)}>
-        <TextField
-          id="snapshotName"
-          label="Name"
-          variant="outlined"
-          size="small"
-          fullWidth
-          className={classes.textField}
-          onChange={(event) => this.setState({ name: event.target.value })}
-          value={name}
-        />
-        <TextField
-          id="snapshotDescription"
-          label="Description"
-          variant="outlined"
-          size="small"
-          multiline
-          rows={3}
-          fullWidth
-          className={classes.textField}
-          onChange={(event) => this.setState({ description: event.target.value })}
-          value={description}
-        />
-        {/* TODO: decide what to do when there's only one asset */}
-        <CreateSnapshotDropdown
-          options={dataset.schema.assets}
-          onSelectedItem={this.handleSelectAsset}
-        />
-        <div className={classes.buttonContainer}>
-          <Button
-            variant="contained"
-            className={clsx(classes.saveButton, { [classes.hide]: !open })}
-            onClick={() => handleCreateSnapshot(false)}
-          >
-            Cancel
-          </Button>
-          <Button
-            variant="contained"
-            className={clsx(classes.cancelButton, { [classes.hide]: !open })}
-            onClick={this.saveNameAndDescription}
-            disabled={assetName === '' || name === ''}
-          >
-            Next
-          </Button>
+      <div className={classes.root}>
+        <div className={classes.rowOne}>
+          <Typography variant="h6">Add Details</Typography>
+          <Typography variant="subtitle2">Snapshot Name</Typography>
+          <TextField
+            id="snapshotName"
+            variant="outlined"
+            size="small"
+            fullWidth
+            className={classes.textField}
+            onChange={(event) => this.setState({ name: event.target.value })}
+            value={name}
+          />
+          <Typography variant="subtitle2">Description</Typography>
+          <TextField
+            id="snapshotDescription"
+            variant="outlined"
+            size="small"
+            multiline
+            rows={10}
+            fullWidth
+            className={classes.textField}
+            onChange={(event) => this.setState({ description: event.target.value })}
+            value={description}
+          />
+          {/* TODO: decide what to do when there's only one asset */}
+          <CreateSnapshotDropdown
+            options={dataset.schema.assets}
+            onSelectedItem={this.handleSelectAsset}
+          />
+        </div>
+        <div className={classes.rowTwo}>
+          <div className={classes.buttonContainer}>
+            <Button onClick={() => handleCreateSnapshot(false)}>Cancel</Button>
+            <Button
+              variant="contained"
+              onClick={this.saveNameAndDescription}
+              disabled={assetName === '' || name === ''}
+            >
+              Next
+            </Button>
+          </div>
         </div>
       </div>
     );
@@ -129,6 +131,7 @@ function mapStateToProps(state) {
   return {
     snapshot: state.snapshot,
     snapshots: state.snapshots,
+    dataset: state.datasets.dataset,
   };
 }
 

--- a/src/components/dataset/query/sidebar/panels/CreateSnapshotPanel.jsx
+++ b/src/components/dataset/query/sidebar/panels/CreateSnapshotPanel.jsx
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
 
 import { Button, TextField } from '@material-ui/core';
 import CreateSnapshotDropdown from '../CreateSnapshotDropdown';
+import ShareSnapshot from './ShareSnapshot';
 
 const styles = (theme) => ({
   buttonContainer: {
@@ -52,14 +53,15 @@ export class CreateSnapshotPanel extends React.PureComponent {
     handleSaveSnapshot: PropTypes.func,
     handleSelectAsset: PropTypes.func,
     snapshot: PropTypes.object,
+    switchPanels: PropTypes.func,
   };
 
   saveNameAndDescription = () => {
-    const { dispatch, handleSaveSnapshot } = this.props;
+    const { dispatch, switchPanels } = this.props;
     const { name, description, assetName } = this.state;
     dispatch(actions.change('snapshot.name', name));
     dispatch(actions.change('snapshot.description', description));
-    handleSaveSnapshot(assetName);
+    switchPanels(ShareSnapshot);
   };
 
   handleSelectAsset = (event) => {

--- a/src/components/dataset/query/sidebar/panels/CreateSnapshotPanel.jsx
+++ b/src/components/dataset/query/sidebar/panels/CreateSnapshotPanel.jsx
@@ -33,7 +33,7 @@ const styles = (theme) => ({
   },
   textField: {
     backgroundColor: theme.palette.common.white,
-    borderRadius: '5px',
+    borderRadius: theme.shape.borderRadius,
     marginBottom: theme.spacing(1),
   },
 });
@@ -41,8 +41,7 @@ const styles = (theme) => ({
 export class CreateSnapshotPanel extends React.PureComponent {
   constructor(props) {
     super(props);
-    const { name, description } = this.props.snapshot;
-    const { assetName } = this.props.snapshots;
+    const { name, description, assetName } = this.props.snapshot;
     this.state = {
       name,
       description,
@@ -65,6 +64,7 @@ export class CreateSnapshotPanel extends React.PureComponent {
     const { name, description, assetName } = this.state;
     dispatch(actions.change('snapshot.name', name));
     dispatch(actions.change('snapshot.description', description));
+    dispatch(actions.change('snapshot.assetName', assetName));
     switchPanels(ShareSnapshot);
   };
 
@@ -108,6 +108,7 @@ export class CreateSnapshotPanel extends React.PureComponent {
           <CreateSnapshotDropdown
             options={dataset.schema.assets}
             onSelectedItem={this.handleSelectAsset}
+            value={assetName}
           />
         </div>
         <div className={classes.rowTwo}>

--- a/src/components/dataset/query/sidebar/panels/FilterPanel.jsx
+++ b/src/components/dataset/query/sidebar/panels/FilterPanel.jsx
@@ -1,0 +1,250 @@
+import React from 'react';
+import _ from 'lodash';
+import clsx from 'clsx';
+import { connect } from 'react-redux';
+import { withStyles } from '@material-ui/core/styles';
+import PropTypes from 'prop-types';
+import { Box, Typography, Button, Grid, InputBase, ListItem, Collapse } from '@material-ui/core';
+import { ExpandMore, ExpandLess, Search } from '@material-ui/icons';
+import QueryViewSidebarItem from '../QueryViewSidebarItem';
+import QuerySidebarPanel from '../QuerySidebarPanel';
+import { applyFilters } from '../../../../../actions';
+
+const styles = (theme) => ({
+  root: {
+    margin: theme.spacing(1),
+    display: 'grid',
+    gridTemplateRows: 'calc(100vh - 125px) 100px',
+  },
+  hide: {
+    display: 'none',
+  },
+  filterPanel: {
+    marginBottom: '8px',
+  },
+  sidebarTitle: {
+    flexDirection: 'column',
+    display: 'flex',
+    justifyContent: 'center',
+  },
+  snapshotBtnCntnr: {
+    textAlign: 'end',
+    paddingTop: theme.spacing(1),
+  },
+  panelContent: {
+    padding: `0px ${theme.spacing(2)}px`,
+  },
+  rowOne: {
+    gridRowStart: 1,
+    gridRowEnd: 2,
+    overflowY: 'auto',
+    overflowX: 'hidden',
+  },
+  rowTwo: {
+    gridRowStart: 2,
+    gridRowEnd: 3,
+  },
+  searchBar: {
+    display: 'flex',
+    alignItems: 'center',
+    borderRadius: theme.shape.borderRadius,
+  },
+  inputBase: {
+    paddingLeft: theme.spacing(0.5),
+  },
+  filterListItem: {
+    justifyContent: 'space-between',
+    fontWeight: '500',
+  },
+  highlighted: {
+    backgroundColor: theme.palette.primary.focus,
+    borderRadius: theme.shape.borderRadius,
+    paddingBottom: theme.spacing(0.5),
+  },
+  tooltip: {
+    pointerEvents: 'auto !important',
+    color: 'red',
+  },
+});
+
+export class FilterPanel extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {
+      filterMap: {},
+      searchString: '',
+      openFilter: {},
+    };
+  }
+
+  static propTypes = {
+    classes: PropTypes.object,
+    dataset: PropTypes.object,
+    dispatch: PropTypes.func.isRequired,
+    filterData: PropTypes.object,
+    filterStatement: PropTypes.string,
+    handleCreateSnapshot: PropTypes.func,
+    joinStatement: PropTypes.string,
+    open: PropTypes.bool,
+    selected: PropTypes.string,
+    table: PropTypes.object,
+    token: PropTypes.string,
+  };
+
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    const { filterMap } = this.state;
+
+    if (!_.isEqual(nextProps.filterData, filterMap)) {
+      this.setState({
+        filterMap: nextProps.filterData,
+      });
+    }
+  }
+
+  handleChange = (column, filter, table) => {
+    const { filterMap } = this.state;
+    const clonedMap = _.cloneDeep(filterMap);
+    if (filter.value == null || filter.value.length === 0) {
+      delete clonedMap[table][column];
+      if (_.isEmpty(clonedMap[table])) {
+        delete clonedMap[table];
+      }
+    } else if (_.isPlainObject(clonedMap[table])) {
+      clonedMap[table][column] = {
+        exclude: filter.exclude,
+        value: filter.value,
+        type: filter.type,
+      };
+    } else {
+      clonedMap[table] = {
+        [column]: {
+          exclude: filter.exclude,
+          value: filter.value,
+          type: filter.type,
+        },
+      };
+    }
+    this.setState({ filterMap: clonedMap }, this.handleFilters);
+  };
+
+  handleFilters = () => {
+    const { dispatch, table, dataset } = this.props;
+    const { filterMap } = this.state;
+    const tableName = table.name;
+    dispatch(applyFilters(filterMap, tableName, dataset));
+  };
+
+  handleSearchString = (event) => {
+    this.setState({ searchString: event.target.value });
+  };
+
+  handleOpenFilter = (filter) => {
+    const { openFilter } = this.state;
+    if (filter === openFilter) {
+      this.setState({ openFilter: {} });
+    } else {
+      this.setState({ openFilter: filter });
+    }
+  };
+
+  render() {
+    const {
+      classes,
+      dataset,
+      filterData,
+      filterStatement,
+      open,
+      table,
+      token,
+      joinStatement,
+      selected,
+      handleCreateSnapshot,
+    } = this.props;
+    const { searchString, openFilter } = this.state;
+    const filteredColumns = table.columns.filter((column) => column.name.includes(searchString));
+
+    return (
+      <div className={classes.root}>
+        <div className={classes.rowOne}>
+          <Box className={!open ? classes.hide : ''}>
+            <Grid container={true} spacing={1}>
+              <Grid item xs={10} className={classes.sidebarTitle}>
+                <Typography variant="h6" display="block">
+                  Data Snapshot
+                </Typography>
+              </Grid>
+            </Grid>
+          </Box>
+          <div className={clsx(classes.filterPanel, { [classes.hide]: !open })}>
+            <QuerySidebarPanel selected={selected} data-cy="snapshotCard" />
+          </div>
+          <ListItem button className={clsx(classes.searchBar, classes.panelContent)}>
+            <Search color="primary" fontSize={'small'} />
+            <InputBase
+              placeholder="Search filters"
+              className={classes.inputBase}
+              onChange={this.handleSearchString}
+            />
+          </ListItem>
+          {table &&
+            table.name &&
+            filteredColumns.map((c) => (
+              <div
+                className={clsx({ [classes.highlighted]: c === openFilter })}
+                data-cy="filterItem"
+                key={c.name}
+              >
+                <ListItem
+                  button
+                  className={classes.filterListItem}
+                  onClick={() => this.handleOpenFilter(c)}
+                >
+                  {c.name}
+                  {c === openFilter ? <ExpandLess /> : <ExpandMore />}
+                </ListItem>
+                <Collapse in={c === openFilter} timeout="auto" className={classes.panelContent}>
+                  <QueryViewSidebarItem
+                    column={c}
+                    dataset={dataset}
+                    filterData={filterData}
+                    filterStatement={filterStatement}
+                    joinStatement={joinStatement}
+                    handleChange={this.handleChange}
+                    handleFilters={this.handleFilters}
+                    tableName={table.name}
+                    token={token}
+                  />
+                </Collapse>
+              </div>
+            ))}
+        </div>
+        <div className={clsx(classes.rowTwo, classes.snapshotBtnCntnr)}>
+          <Button
+            variant="contained"
+            disabled={_.isEmpty(dataset.schema.assets)}
+            className={clsx({
+              [classes.hide]: !open,
+              [classes.tooltip]: _.isEmpty(dataset.schema.assets),
+            })}
+            onClick={() => handleCreateSnapshot(true)}
+            data-cy="createSnapshot"
+          >
+            Create Snapshot
+          </Button>
+        </div>
+      </div>
+    );
+  }
+}
+
+function mapStateToProps(state) {
+  return {
+    dataset: state.datasets.dataset,
+    filterData: state.query.filterData,
+    filterStatement: state.query.filterStatement,
+    joinStatement: state.query.joinStatement,
+    token: state.user.token,
+  };
+}
+
+export default connect(mapStateToProps)(withStyles(styles)(FilterPanel));

--- a/src/components/dataset/query/sidebar/panels/ShareSnapshot.jsx
+++ b/src/components/dataset/query/sidebar/panels/ShareSnapshot.jsx
@@ -19,6 +19,11 @@ import { MoreVert } from '@material-ui/icons';
 import Autocomplete from '@material-ui/lab/Autocomplete';
 import { actions } from 'react-redux-form';
 import { isEmail } from 'validator';
+import { openSnapshotDialog, createSnapshot } from '../../../../../actions';
+import { push } from 'modules/hist';
+
+const drawerWidth = 600;
+const sidebarWidth = 56;
 
 const styles = (theme) => ({
   root: {
@@ -26,12 +31,13 @@ const styles = (theme) => ({
   },
   section: {
     margin: `${theme.spacing(1)}px 0px`,
+    overflowX: 'hidden',
   },
   input: {
     backgroundColor: theme.palette.common.white,
     borderRadius: theme.spacing(0.5),
   },
-  inviteButton: {
+  button: {
     backgroundColor: theme.palette.common.link,
     color: theme.palette.common.white,
     '&:hover': {
@@ -50,6 +56,13 @@ const styles = (theme) => ({
   withIcon: {
     display: 'flex',
     alignItems: 'center',
+  },
+  bottom: {
+    position: 'fixed',
+    bottom: '0',
+    right: `${sidebarWidth + theme.spacing(2)}px`,
+    width: `${drawerWidth - theme.spacing(4)}px`,
+    textAlign: 'end',
   },
 });
 
@@ -172,6 +185,13 @@ export class ShareSnapshot extends React.PureComponent {
     this.setState({ anchor: null });
   };
 
+  saveSnapshot = () => {
+    const { dispatch } = this.props;
+    dispatch(createSnapshot());
+    dispatch(openSnapshotDialog(true));
+    push('/snapshots');
+  };
+
   render() {
     const { classes, readers } = this.props;
     const { policyName, currentInput, usersToAdd, anchor, hasError, errorMsg } = this.state;
@@ -233,17 +253,15 @@ export class ShareSnapshot extends React.PureComponent {
               )}
             </Grid>
           </Grid>
-          <Grid item xs>
-            <Button
-              variant="contained"
-              disableElevation={true}
-              className={classes.inviteButton}
-              onClick={this.invite}
-              data-cy="inviteButton"
-            >
-              Invite
-            </Button>
-          </Grid>
+          <Button
+            variant="contained"
+            disableElevation={true}
+            className={clsx(classes.button, classes.section)}
+            onClick={this.invite}
+            data-cy="inviteButton"
+          >
+            Invite
+          </Button>
         </Grid>
         <Divider />
         <div className={classes.section} data-cy="readers">
@@ -273,6 +291,18 @@ export class ShareSnapshot extends React.PureComponent {
               remove
             </MenuItem>
           </Menu>
+        </div>
+        <div className={classes.bottom}>
+          <Divider />
+          <Button
+            variant="contained"
+            disableElevation={true}
+            className={clsx(classes.button, classes.section)}
+            onClick={this.saveSnapshot}
+            data-cy="releaseDataset"
+          >
+            Release Dataset
+          </Button>
         </div>
       </div>
     );

--- a/src/components/dataset/query/sidebar/panels/ShareSnapshot.jsx
+++ b/src/components/dataset/query/sidebar/panels/ShareSnapshot.jsx
@@ -140,9 +140,7 @@ export class ShareSnapshot extends React.PureComponent {
     let validUsrs = [];
     let invalidUsrs = [];
     _.forEach(usersToAdd, (user) => {
-      console.log(user);
       if (!isEmail(user)) {
-        console.log('bad input');
         hasError = true;
         invalidUsrs.push(user);
       } else {

--- a/src/sagas/repository.js
+++ b/src/sagas/repository.js
@@ -103,14 +103,14 @@ function* pollJobWorker(jobId, jobTypeSuccess, jobTypeFailure) {
  * Snapshots.
  */
 
-export function* createSnapshot({ payload }) {
+export function* createSnapshot() {
   const snapshot = yield select(getCreateSnapshot);
   const snapshots = yield select(getSnapshotState);
   const dataset = yield select(getDataset);
 
   const datasetName = dataset.name;
   const mode = 'byQuery';
-  const selectedAsset = _.find(dataset.schema.assets, (asset) => asset.name === payload);
+  const selectedAsset = _.find(dataset.schema.assets, (asset) => asset.name === snapshot.assetName);
   const rootTable = selectedAsset.rootTable;
   const drRowId = 'datarepo_row_id';
 
@@ -124,7 +124,7 @@ export function* createSnapshot({ payload }) {
         datasetName,
         mode,
         querySpec: {
-          assetName: payload,
+          assetName: snapshot.assetName,
           query: `SELECT ${datasetName}.${rootTable}.${drRowId} ${snapshots.joinStatement} ${snapshots.filterStatement}`,
         },
       },

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -12,9 +12,10 @@ const initialSnapshotState = {
   description: '',
   readers: [],
   dataset: '',
+  assetName: '',
 };
 
-const reducer = hist =>
+const reducer = (hist) =>
   combineReducers({
     router: connectRouter(hist),
     ...rootReducer,


### PR DESCRIPTION
![wizard](https://user-images.githubusercontent.com/52389456/84188942-6a96b500-aa62-11ea-9c4f-1ffe3401dd87.gif)
Implemented a wizard flow that guides the user from one panel to the next when creating a snapshot.

Changes include:
- moved most of QueryViewSidebar to new FilterPanel component
- added 'release dataset' button to share panel, which launches the create snapshot action
- adjusted create snapshot panel to take up full height of the sidebar
- additional miscellaneous styling & code cleanup