### PR TITLE
DR-1023 update snapshot creation modal

### DIFF
--- a/cypress/integration/queryBuilder.spec.js
+++ b/cypress/integration/queryBuilder.spec.js
@@ -53,16 +53,6 @@ describe('test query builder', () => {
           .invoke('getState')
           .its('snapshots')
           .its('snapshotRequest')
-          .its('joinStatement')
-          .should(
-            'equal',
-            'FROM V2F_GWAS_Summary_Stats.variant, V2F_GWAS_Summary_Stats.ancestry_specific_meta_analysis ',
-          );
-        cy.window()
-          .its('store')
-          .invoke('getState')
-          .its('snapshots')
-          .its('snapshotRequest')
           .its('filterStatement')
           .should(
             'equal',
@@ -191,6 +181,13 @@ describe('test query builder', () => {
       // 'next' button should bring user to share panel
       cy.get('[data-cy=next]').click();
       cy.contains('Share Snapshot').should('be.visible');
+      cy.window()
+        .its('store')
+        .invoke('getState')
+        .its('snapshots')
+        .its('snapshotRequest')
+        .its('joinStatement')
+        .should('equal', 'FROM V2F_GWAS_Summary_Stats.variant ');
     });
   });
 });

--- a/cypress/integration/snapshotCreation.spec.js
+++ b/cypress/integration/snapshotCreation.spec.js
@@ -9,57 +9,53 @@ describe('test snapshot creation', () => {
       url: '/api/repository/v1/snapshots',
       status: 200,
       response: {
-        id: 'jello',
+        id: 'jobId',
       },
     });
     cy.route({
       method: 'GET',
-      url: '/api/repository/v1/jobs/jello',
+      url: '/api/repository/v1/jobs/jobId',
       status: 200,
       response: {
-        completed: 'string',
-        description: 'string',
-        id: 'jello',
+        id: 'jobId',
         job_status: 'succeeded',
-        status_code: 0,
-        submitted: 'string',
       },
     });
     cy.route({
       method: 'GET',
-      url: '/api/repository/v1/jobs/jello/result',
+      url: '/api/repository/v1/jobs/jobId/result',
       status: 200,
       response: {
-        name: 'jello_snapshot',
-        description: 'hello jello',
-        id: 'jello',
-        createdDate: '',
-        profileId: 'jello',
+        name: 'mock_snapshot',
+        description: '',
+        id: 'snapshotId',
+        createdDate: '2020-06-24',
+        profileId: 'profileId',
       },
     });
     cy.route({
       method: 'GET',
-      url: '/api/repository/v1/snapshots/jello',
+      url: '/api/repository/v1/snapshots/snapshotId',
       status: 200,
       response: {
-        name: 'jello_snapshot',
-        description: 'hello jello',
-        id: 'jello',
-        createdDate: '2017-04-14',
-        profileId: 'jello',
-        source: [{ name: 'jello' }],
+        name: 'mock_snapshot',
+        description: '',
+        id: 'snapshotId',
+        createdDate: '2020-06-24',
+        profileId: 'profileId',
+        source: [{ name: 'dataset' }],
         tables: [{ rowCount: 2 }],
       },
     });
     cy.route({
       method: 'GET',
-      url: '/api/repository/v1/snapshots/jello/policies',
+      url: '/api/repository/v1/snapshots/snapshotId/policies',
       status: 200,
       response: {
         policies: [
           {
             name: 'reader',
-            members: ['jelloworld@nox.com'],
+            members: ['email@gmail.com'],
           },
         ],
       },
@@ -82,14 +78,14 @@ describe('test snapshot creation', () => {
   it('opens modal', () => {
     cy.get('div.MuiButtonBase-root:nth-child(2) > svg:nth-child(1)').click();
     cy.get('[data-cy=createSnapshot]').click();
-    cy.get('[data-cy=textFieldName]').type('jello_snapshot');
+    cy.get('[data-cy=textFieldName]').type('mock_snapshot');
     cy.get('[data-cy=selectAsset]').click();
     cy.get('[data-cy=menuItem-Variant]').click();
     cy.get('[data-cy=next]').click();
     cy.get('[data-cy=releaseDataset]').click();
 
-    cy.get('[data-cy=snapshotName]').should('contain', 'jello_snapshot');
-    cy.get('[data-cy=snapshotReaders]').should('contain', 'jelloworld@nox.com');
+    cy.get('[data-cy=snapshotName]').should('contain', 'mock_snapshot');
+    cy.get('[data-cy=snapshotReaders]').should('contain', 'email@gmail.com');
     cy.url().should('include', '/snapshots');
   });
 });

--- a/cypress/integration/snapshotCreation.spec.js
+++ b/cypress/integration/snapshotCreation.spec.js
@@ -1,0 +1,95 @@
+describe('test snapshot creation', () => {
+  beforeEach(() => {
+    cy.server();
+
+    cy.route('GET', 'api/repository/v1/datasets/**').as('getDataset');
+    cy.route('GET', 'api/repository/v1/datasets/**/policies').as('getDatasetPolicies');
+    cy.route({
+      method: 'POST',
+      url: '/api/repository/v1/snapshots',
+      status: 200,
+      response: {
+        id: 'jello',
+      },
+    });
+    cy.route({
+      method: 'GET',
+      url: '/api/repository/v1/jobs/jello',
+      status: 200,
+      response: {
+        completed: 'string',
+        description: 'string',
+        id: 'jello',
+        job_status: 'succeeded',
+        status_code: 0,
+        submitted: 'string',
+      },
+    });
+    cy.route({
+      method: 'GET',
+      url: '/api/repository/v1/jobs/jello/result',
+      status: 200,
+      response: {
+        name: 'jello_snapshot',
+        description: 'hello jello',
+        id: 'jello',
+        createdDate: '',
+        profileId: 'jello',
+      },
+    });
+    cy.route({
+      method: 'GET',
+      url: '/api/repository/v1/snapshots/jello',
+      status: 200,
+      response: {
+        name: 'jello_snapshot',
+        description: 'hello jello',
+        id: 'jello',
+        createdDate: '2017-04-14',
+        profileId: 'jello',
+        source: [{ name: 'jello' }],
+        tables: [{ rowCount: 2 }],
+      },
+    });
+    cy.route({
+      method: 'GET',
+      url: '/api/repository/v1/snapshots/jello/policies',
+      status: 200,
+      response: {
+        policies: [
+          {
+            name: 'reader',
+            members: ['jelloworld@nox.com'],
+          },
+        ],
+      },
+    });
+
+    cy.visit('/login/e2e');
+    cy.get('#tokenInput').type(Cypress.env('GOOGLE_TOKEN'), {
+      log: false,
+      delay: 0,
+    });
+    cy.get('#e2eLoginButton').click();
+
+    cy.contains('See all Datasets').click();
+    cy.contains('Date created').click();
+    cy.contains('V2F_GWAS_Summary_Stats').should('be.visible');
+    cy.contains('V2F_GWAS_Summary_Stats').click();
+    cy.wait(['@getDataset', '@getDatasetPolicies']);
+  });
+
+  it('opens modal', () => {
+    cy.get('div.MuiButtonBase-root:nth-child(2) > svg:nth-child(1)').click();
+    cy.get('[data-cy=createSnapshot]').click();
+    cy.get('[data-cy=textFieldName]').type('jello_snapshot');
+    cy.get('[data-cy=selectAsset]').click();
+    cy.get('[data-cy=menuItem-Variant]').click();
+    cy.get('[data-cy=next]').click();
+    cy.get('[data-cy=releaseDataset]').click();
+
+    cy.get('[data-cy=snapshotName]').should('contain', 'jello_snapshot');
+    cy.get('[data-cy=snapshotReaders]').should('contain', 'jelloworld@nox.com');
+    cy.url().should('include', '/snapshots');
+  });
+});

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -7,12 +7,16 @@
 import { createActions } from 'redux-actions';
 
 import { ActionTypes } from 'constants/index';
+import { push } from 'modules/hist';
 
 export const { createSnapshot } = createActions({
   [ActionTypes.CREATE_SNAPSHOT]: () => ({}),
   [ActionTypes.CREATE_SNAPSHOT_JOB]: (snapshot) => snapshot,
-  [ActionTypes.CREATE_SNAPSHOT_SUCCESS]: (snapshot) => snapshot,
   [ActionTypes.CREATE_SNAPSHOT_FAILURE]: (snapshot) => snapshot,
+  [ActionTypes.CREATE_SNAPSHOT_SUCCESS]: (snapshot) => {
+    push('/snapshots');
+    return snapshot;
+  },
 });
 
 export const { getSnapshots } = createActions({

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -164,10 +164,12 @@ export const { countResults } = createActions({
 });
 
 export const { snapshotCreateDetails } = createActions({
-  [ActionTypes.SNAPSHOT_CREATE_DETAILS]: (name, description, assetName) => ({
+  [ActionTypes.SNAPSHOT_CREATE_DETAILS]: (name, description, assetName, filterData, dataset) => ({
     name,
     description,
     assetName,
+    filterData,
+    dataset,
   }),
 });
 

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -7,16 +7,12 @@
 import { createActions } from 'redux-actions';
 
 import { ActionTypes } from 'constants/index';
-import { push } from 'modules/hist';
 
 export const { createSnapshot } = createActions({
   [ActionTypes.CREATE_SNAPSHOT]: () => ({}),
   [ActionTypes.CREATE_SNAPSHOT_JOB]: (snapshot) => snapshot,
+  [ActionTypes.CREATE_SNAPSHOT_SUCCESS]: (snapshot) => snapshot,
   [ActionTypes.CREATE_SNAPSHOT_FAILURE]: (snapshot) => snapshot,
-  [ActionTypes.CREATE_SNAPSHOT_SUCCESS]: (snapshot) => {
-    push('/snapshots');
-    return snapshot;
-  },
 });
 
 export const { getSnapshots } = createActions({

--- a/src/components/Logo.jsx
+++ b/src/components/Logo.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { withStyles } from '@material-ui/core';
 import PropTypes from 'prop-types';
-import push from 'modules/hist';
+import { push } from 'modules/hist';
 
 import TerraIcon from '../../assets/media/brand/logo-wShadow.svg';
 
-const styles = theme => ({
+const styles = (theme) => ({
   logoContainer: {
     display: 'flex',
     alignItems: 'center',

--- a/src/components/dataset/query/QueryView.jsx
+++ b/src/components/dataset/query/QueryView.jsx
@@ -21,6 +21,7 @@ import QueryViewDropdown from './QueryViewDropdown';
 import JadeTable from '../../table/JadeTable';
 import InfoView from './sidebar/panels/InfoView';
 import ShareSnapshot from './sidebar/panels/ShareSnapshot';
+import SnapshotPopup from '../../snapshot/SnapshotPopup';
 
 const styles = (theme) => ({
   wrapper: {
@@ -195,6 +196,7 @@ export class QueryView extends React.PureComponent {
           table={table}
           selected={selected}
         />
+        <SnapshotPopup />
       </Fragment>
     );
   }

--- a/src/components/dataset/query/sidebar/panels/CreateSnapshotPanel.jsx
+++ b/src/components/dataset/query/sidebar/panels/CreateSnapshotPanel.jsx
@@ -53,6 +53,7 @@ export class CreateSnapshotPanel extends React.PureComponent {
   static propTypes = {
     classes: PropTypes.object,
     dataset: PropTypes.object,
+    filterData: PropTypes.object,
     handleCreateSnapshot: PropTypes.func,
     handleSaveSnapshot: PropTypes.func,
     handleSelectAsset: PropTypes.func,
@@ -61,9 +62,9 @@ export class CreateSnapshotPanel extends React.PureComponent {
   };
 
   saveNameAndDescription = () => {
-    const { dispatch, switchPanels } = this.props;
+    const { dispatch, switchPanels, filterData, dataset } = this.props;
     const { name, description, assetName } = this.state;
-    dispatch(snapshotCreateDetails(name, description, assetName));
+    dispatch(snapshotCreateDetails(name, description, assetName, filterData, dataset));
     switchPanels(ShareSnapshot);
   };
 
@@ -134,6 +135,7 @@ function mapStateToProps(state) {
   return {
     snapshots: state.snapshots,
     dataset: state.datasets.dataset,
+    filterData: state.query.filterData,
   };
 }
 

--- a/src/components/dataset/query/sidebar/panels/CreateSnapshotPanel.jsx
+++ b/src/components/dataset/query/sidebar/panels/CreateSnapshotPanel.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import clsx from 'clsx';
 import { withStyles } from '@material-ui/core/styles';
-import { actions } from 'react-redux-form';
 import { connect } from 'react-redux';
 
 import { Button, TextField, Typography } from '@material-ui/core';

--- a/src/components/dataset/query/sidebar/panels/ShareSnapshot.jsx
+++ b/src/components/dataset/query/sidebar/panels/ShareSnapshot.jsx
@@ -19,7 +19,6 @@ import { MoreVert } from '@material-ui/icons';
 import Autocomplete from '@material-ui/lab/Autocomplete';
 import { isEmail } from 'validator';
 import { createSnapshot, addReadersToSnapshot } from 'actions/index';
-import { push } from 'modules/hist';
 
 const drawerWidth = 600;
 const sidebarWidth = 56;
@@ -194,7 +193,6 @@ export class ShareSnapshot extends React.PureComponent {
   saveSnapshot = () => {
     const { dispatch } = this.props;
     dispatch(createSnapshot());
-    push('/snapshots');
   };
 
   render() {

--- a/src/components/snapshot/SnapshotPopup.jsx
+++ b/src/components/snapshot/SnapshotPopup.jsx
@@ -159,13 +159,17 @@ export class SnapshotPopup extends React.PureComponent {
                   {rows.toLocaleString()} {rowLabel}
                 </Typography>
               </div>
-              <Typography variant="subtitle1" color="primary">
-                Properties
-              </Typography>
+              {!_.isEmpty(tables) && (
+                <Typography variant="subtitle1" color="primary">
+                  Properties
+                </Typography>
+              )}
               <div>{tables}</div>
-              <Typography variant="subtitle1" color="primary">
-                Shared With
-              </Typography>
+              {!_.isEmpty(readers) && (
+                <Typography variant="subtitle1" color="primary">
+                  Shared With
+                </Typography>
+              )}
               <div className={classes.bodyText}>
                 {readers.map((r) => (
                   <li className={classes.listItem}>{r}</li>

--- a/src/components/snapshot/SnapshotPopup.jsx
+++ b/src/components/snapshot/SnapshotPopup.jsx
@@ -176,7 +176,9 @@ export class SnapshotPopup extends React.PureComponent {
               )}
               <div className={classes.bodyText} data-cy="snapshotReaders">
                 {readers.map((r) => (
-                  <li className={classes.listItem}>{r}</li>
+                  <li key={r} className={classes.listItem}>
+                    {r}
+                  </li>
                 ))}
               </div>
               <div className={clsx(classes.light, classes.withIcon)}>

--- a/src/components/snapshot/SnapshotPopup.jsx
+++ b/src/components/snapshot/SnapshotPopup.jsx
@@ -73,11 +73,13 @@ export class SnapshotPopup extends React.PureComponent {
    * We want to use that snapshot id to get the full object and the policies for the dialog.
    */
   componentDidUpdate(prevProps) {
-    const { dispatch, snapshot } = this.props;
+    const { dispatch, snapshot, policies } = this.props;
     if (_.isEmpty(prevProps.snapshot) && !_.isEmpty(snapshot)) {
-      push('/snapshots');
       dispatch(getSnapshotById(snapshot.id));
       dispatch(getSnapshotPolicy(snapshot.id));
+    }
+    if (_.isEmpty(prevProps.policies) && !_.isEmpty(policies)) {
+      push('/snapshots');
     }
   }
 
@@ -151,7 +153,9 @@ export class SnapshotPopup extends React.PureComponent {
           <Paper variant="outlined">
             <div className={clsx(classes.snapshotName, classes.content, classes.withIcon)}>
               <CameraAlt className={classes.inline} />
-              <Typography variant="h6">{snapshot.name}</Typography>
+              <Typography variant="h6" data-cy="snapshotName">
+                {snapshot.name}
+              </Typography>
             </div>
             <div className={classes.content}>
               <div className={classes.bodyText}>
@@ -170,7 +174,7 @@ export class SnapshotPopup extends React.PureComponent {
                   Shared With
                 </Typography>
               )}
-              <div className={classes.bodyText}>
+              <div className={classes.bodyText} data-cy="snapshotReaders">
                 {readers.map((r) => (
                   <li className={classes.listItem}>{r}</li>
                 ))}

--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -30,7 +30,7 @@ import SignOutSVG from '../../assets/media/icons/logout-line.svg';
 
 const drawerWidth = 240;
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles((theme) => ({
   root: {
     display: 'flex',
     fontFamily: theme.typography.fontFamily,
@@ -135,7 +135,7 @@ const useStyles = makeStyles(theme => ({
     position: 'absolute',
     right: 0,
     width: theme.spacing(40),
-    zIndex: '100',
+    zIndex: 1201,
   },
   userName: {
     height: 15,
@@ -162,7 +162,7 @@ export function App(props) {
   const [anchorEl, setAnchorEl] = useState(null);
   const open = Boolean(anchorEl);
 
-  const handleMenu = event => {
+  const handleMenu = (event) => {
     setAnchorEl(event.currentTarget);
   };
 
@@ -228,12 +228,13 @@ export function App(props) {
       </AppBar>
       <div className={classes.content}>
         <div className={classes.appBarSpacer} />
-        <div className={classes.errorPanel}>
-          {alerts &&
-            alerts.map((alert, i) => (
+        {alerts.length > 0 && (
+          <div className={classes.errorPanel}>
+            {alerts.map((alert, i) => (
               <Toast dispatch={dispatch} errorMsg={alert && alert.toString()} index={i} key={i} />
             ))}
-        </div>
+          </div>
+        )}
         <Switch>
           <RoutePublic
             isAuthenticated={user.isAuthenticated}

--- a/src/modules/bigquery.js
+++ b/src/modules/bigquery.js
@@ -248,23 +248,20 @@ export default class BigQuery {
   };
 
   // wrapper for snapshot creation:
-  buildSnapshotJoinStatement = (filterMap, table, dataset) => {
+  buildSnapshotJoinStatement = (filterMap, assetName, dataset) => {
     if (_.isEmpty(dataset.schema.assets)) {
       return '';
     }
     const schema = dataset.schema.relationships;
-    const rootTable = dataset.schema.assets[0].rootTable; // TODO: asset thing
-    const relationships = this.buildAllJoins(filterMap, schema, table);
+    const selectedAsset = dataset.schema.assets.find((a) => a.name === assetName);
+    const rootTable = selectedAsset.rootTable;
+    const relationships = this.buildAllJoins(filterMap, schema, rootTable);
     let joins = relationships.map((relationship) => {
       const { to, from } = relationship;
       return `JOIN ${dataset.name}.${from.table} ON ${dataset.name}.${from.table}.${from.column} = ${dataset.name}.${to.table}.${to.column}`;
     });
     joins = _.uniq(joins);
-    let fromStatement = '';
-    if (_.isEmpty(joins) && rootTable !== table) {
-      fromStatement = `, ${dataset.name}.${table}`;
-    }
-    return `FROM ${dataset.name}.${rootTable}${fromStatement} ${joins.join(' ')}`;
+    return `FROM ${dataset.name}.${rootTable} ${joins.join(' ')}`;
   };
 
   // helper method used by both:

--- a/src/reducers/dataset.js
+++ b/src/reducers/dataset.js
@@ -18,7 +18,7 @@ export default {
           datasets: { $set: action.datasets.data.data.items },
           datasetsCount: { $set: action.datasets.data.data.total },
         }),
-      [ActionTypes.GET_DATASET_BY_ID]: state =>
+      [ActionTypes.GET_DATASET_BY_ID]: (state) =>
         immutable(state, {
           dataset: {},
         }),
@@ -38,12 +38,8 @@ export default {
         immutable(state, {
           datasetPolicies: { $set: action.policy.data.policies },
         }),
-      [ActionTypes.CREATE_SNAPSHOT_JOB]: state =>
-        immutable(state, {
-          dataset: { $set: {} },
-        }),
       [ActionTypes.GET_DATASET_TABLE_PREVIEW_SUCCESS]: (state, action) => {
-        const i = state.dataset.schema.tables.findIndex(table => table.name === action.tableName);
+        const i = state.dataset.schema.tables.findIndex((table) => table.name === action.tableName);
         return immutable(state, {
           dataset: { schema: { tables: { [i]: { preview: { $set: action.preview.data.rows } } } } },
         });

--- a/src/reducers/query.js
+++ b/src/reducers/query.js
@@ -74,7 +74,8 @@ export default {
         });
       },
       [LOCATION_CHANGE]: (state, action) => {
-        if (!action.payload.location.pathname.includes('/query')) {
+        if (action.payload.location.pathname.includes('/datasets/details/')) {
+          // michael can you help us with this
           return immutable(state, {
             filterData: { $set: {} },
             filterStatement: { $set: '' },

--- a/src/reducers/snapshot.js
+++ b/src/reducers/snapshot.js
@@ -78,17 +78,26 @@ export default {
         const { filters, table, dataset } = action.payload;
 
         const filterStatement = bigquery.buildSnapshotFilterStatement(filters, dataset);
-        const joinStatement = bigquery.buildSnapshotJoinStatement(filters, table, dataset);
 
-        const snapshotRequest = { ...state.snapshotRequest, filterStatement, joinStatement };
+        const snapshotRequest = { ...state.snapshotRequest, filterStatement };
 
         return immutable(state, {
           snapshotRequest: { $set: snapshotRequest },
         });
       },
       [ActionTypes.SNAPSHOT_CREATE_DETAILS]: (state, action) => {
-        const { name, description, assetName } = action.payload;
-        const snapshotRequest = { ...state.snapshotRequest, name, description, assetName };
+        const bigquery = new BigQuery();
+        const { name, description, assetName, filterData, dataset } = action.payload;
+
+        const joinStatement = bigquery.buildSnapshotJoinStatement(filterData, assetName, dataset);
+        const snapshotRequest = {
+          ...state.snapshotRequest,
+          name,
+          description,
+          assetName,
+          joinStatement,
+        };
+
         return immutable(state, {
           snapshotRequest: { $set: snapshotRequest },
         });

--- a/src/reducers/snapshot.js
+++ b/src/reducers/snapshot.js
@@ -75,14 +75,12 @@ export default {
         }),
       [ActionTypes.APPLY_FILTERS]: (state, action) => {
         const bigquery = new BigQuery();
-        const { filters, table, dataset } = action.payload;
+        const { filters, dataset } = action.payload;
 
         const filterStatement = bigquery.buildSnapshotFilterStatement(filters, dataset);
 
-        const snapshotRequest = { ...state.snapshotRequest, filterStatement };
-
         return immutable(state, {
-          snapshotRequest: { $set: snapshotRequest },
+          snapshotRequest: { filterStatement: { $set: filterStatement } },
         });
       },
       [ActionTypes.SNAPSHOT_CREATE_DETAILS]: (state, action) => {

--- a/src/reducers/snapshot.js
+++ b/src/reducers/snapshot.js
@@ -67,6 +67,7 @@ export default {
       [ActionTypes.EXCEPTION]: (state) =>
         immutable(state, {
           exception: { $set: true },
+          dialogIsOpen: { $set: false },
         }),
       [ActionTypes.OPEN_SNAPSHOT_DIALOG]: (state, action) =>
         immutable(state, {


### PR DESCRIPTION
![confirmation-dialog](https://user-images.githubusercontent.com/52389456/85591766-90e85300-b613-11ea-95ec-bd11c8a04f68.gif)
This PR makes several updates to the dialog that opens when a snapshot is created.
Changes:
- Loading dialog opens on top of the Query Builder while a snapshot is being created
- If snapshot creation fails, dialog closes on the Query Builder, revealing the error box
- If snapshot is successfully created, page navigates to the snapshot list and dialog displays a snapshot summary
- Snapshot query statement is fixed to join correctly on the root table of the selected asset
- [DR-909](https://broadworkbench.atlassian.net/browse/DR-909) is fixed so sidebar doesn't hide error box