### PR TITLE
DR-783 type decimals in range filter

### DIFF
--- a/src/components/dataset/query/sidebar/AppliedFilterList.jsx
+++ b/src/components/dataset/query/sidebar/AppliedFilterList.jsx
@@ -12,7 +12,7 @@ import { applyFilters } from '../../../../actions';
 import { Chip, Collapse, Badge } from '@material-ui/core';
 import { ExpandLess } from '@material-ui/icons';
 
-const styles = theme => ({
+const styles = (theme) => ({
   filterHeader: {
     paddingTop: theme.spacing(1),
     paddingBottom: theme.spacing(0.5),
@@ -35,7 +35,7 @@ const styles = theme => ({
   },
 });
 
-const StyledBadge = withStyles(theme => ({
+const StyledBadge = withStyles((theme) => ({
   badge: {
     right: 12,
     top: 0,
@@ -67,7 +67,6 @@ export class AppliedFilterList extends React.PureComponent {
 
   clearFilter = (table, filter, datum) => {
     const { dispatch, filterData, dataset, selected } = this.props;
-    const { relationships } = dataset.schema;
     const clonedData = _.cloneDeep(filterData);
     const clonedFilter = clonedData[table][filter];
     const filterValue = clonedFilter.value;
@@ -89,14 +88,14 @@ export class AppliedFilterList extends React.PureComponent {
       delete clonedData[table];
     }
 
-    dispatch(applyFilters(clonedData, relationships, selected, dataset));
+    dispatch(applyFilters(clonedData, selected, dataset));
   };
 
   render() {
     const { classes, filterData, table } = this.props;
     const { open } = this.state;
     let numFilters = 0;
-    const listFilters = _.keys(filterData[table]).map(filter => {
+    const listFilters = _.keys(filterData[table]).map((filter) => {
       const data = _.get(filterData[table], filter);
       let dataString = data.value;
 

--- a/src/components/dataset/query/sidebar/QueryViewSidebarItem.jsx
+++ b/src/components/dataset/query/sidebar/QueryViewSidebarItem.jsx
@@ -74,7 +74,8 @@ export class QueryViewSidebarItem extends React.PureComponent {
   invalidChange = (filterMap) => {
     const { value } = filterMap;
     if (filterMap.type === 'range') {
-      return _.some(value, (v) => v.endsWith('.')) || parseFloat(value[0]) >= parseFloat(value[1]);
+      const badNumber = (number) => number === '' || number.endsWith('.') || isNaN(number);
+      return _.some(value, badNumber) || parseFloat(value[0]) >= parseFloat(value[1]);
     }
     return _.isEmpty(value);
   };

--- a/src/components/dataset/query/sidebar/QueryViewSidebarItem.jsx
+++ b/src/components/dataset/query/sidebar/QueryViewSidebarItem.jsx
@@ -75,7 +75,7 @@ export class QueryViewSidebarItem extends React.PureComponent {
     const { value } = filterMap;
     if (filterMap.type === 'range') {
       const badNumber = (number) => number === '' || number.endsWith('.') || isNaN(number);
-      return _.some(value, badNumber) || parseFloat(value[0]) >= parseFloat(value[1]);
+      return _.some(value, badNumber) || parseFloat(value[0]) > parseFloat(value[1]);
     }
     return _.isEmpty(value);
   };

--- a/src/components/dataset/query/sidebar/QueryViewSidebarItem.jsx
+++ b/src/components/dataset/query/sidebar/QueryViewSidebarItem.jsx
@@ -42,7 +42,7 @@ export class QueryViewSidebarItem extends React.PureComponent {
     const { filterMap } = this.state;
     // enable the button when there are unsaved changes
     if (!_.isEqual(prevState.filterMap, filterMap)) {
-      this.setState({ disableButton: _.isEmpty(filterMap.value) });
+      this.setState({ disableButton: this.invalidChange(filterMap) });
     }
     // disable the button when filters have just been applied
     if (!_.isEqual(prevProps.filterData, filterData)) {
@@ -69,6 +69,14 @@ export class QueryViewSidebarItem extends React.PureComponent {
   toggleExclude = (boxIsChecked) => {
     const { filterMap } = this.state;
     this.setState({ filterMap: { ...filterMap, exclude: boxIsChecked } });
+  };
+
+  invalidChange = (filterMap) => {
+    const { value } = filterMap;
+    if (filterMap.type === 'range') {
+      return _.some(value, (v) => v.endsWith('.')) || parseFloat(value[0]) >= parseFloat(value[1]);
+    }
+    return _.isEmpty(value);
   };
 
   render() {

--- a/src/components/dataset/query/sidebar/filter/RangeFilter.jsx
+++ b/src/components/dataset/query/sidebar/filter/RangeFilter.jsx
@@ -48,7 +48,7 @@ export class RangeFilter extends React.PureComponent {
 
   handleSliderValue = (event, newValue) => {
     const { handleChange } = this.props;
-    handleChange(newValue);
+    handleChange(newValue.map(_.toString));
   };
 
   handleMinLabelValue = (event) => {

--- a/src/components/dataset/query/sidebar/filter/RangeFilter.jsx
+++ b/src/components/dataset/query/sidebar/filter/RangeFilter.jsx
@@ -11,9 +11,8 @@ export class RangeFilter extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {
-      minVal: 0,
-      maxVal: 1000,
-      value: [0, 1000],
+      minVal: '0',
+      maxVal: '1000',
       step: 1,
     };
 
@@ -21,8 +20,8 @@ export class RangeFilter extends React.PureComponent {
     const bq = new BigQuery();
 
     bq.getColumnMinMax(column.name, dataset, tableName, token).then((response) => {
-      const min = parseFloat(response[0].v, 10);
-      const max = parseFloat(response[1].v, 10);
+      const min = response[0].v;
+      const max = response[1].v;
 
       let step = 1;
       if (max - min <= 1) {
@@ -53,15 +52,19 @@ export class RangeFilter extends React.PureComponent {
   };
 
   handleMinLabelValue = (event) => {
-    const { value } = this.state;
-    const newValue = [parseInt(event.target.value, 10), value[1]];
+    const { filterMap } = this.props;
+    const { maxVal } = this.state;
+    const upper = _.get(filterMap, ['value', 1], maxVal);
+    const newValue = [event.target.value, upper];
 
     this.handleSliderValue(null, newValue);
   };
 
   handleMaxLabelValue = (event) => {
-    const { value } = this.state;
-    const newValue = [value[0], parseInt(event.target.value, 10)];
+    const { filterMap } = this.props;
+    const { minVal } = this.state;
+    const lower = _.get(filterMap, ['value', 0], minVal);
+    const newValue = [lower, event.target.value];
 
     this.handleSliderValue(null, newValue);
   };
@@ -96,12 +99,12 @@ export class RangeFilter extends React.PureComponent {
         <Grid container={true}>
           <Fragment>
             <Slider
-              value={value}
+              value={value.map(parseFloat)}
               onChange={this.handleSliderValue}
               valueLabelDisplay="off"
               aria-labelledby="range-slider"
-              min={minVal}
-              max={maxVal}
+              min={parseFloat(minVal)}
+              max={parseFloat(maxVal)}
               step={step}
             />
           </Fragment>

--- a/src/components/dataset/query/sidebar/filter/RangeInput.jsx
+++ b/src/components/dataset/query/sidebar/filter/RangeInput.jsx
@@ -8,10 +8,10 @@ export class RangeInput extends React.PureComponent {
     handleChange: PropTypes.func,
     handleFilters: PropTypes.func,
     labelName: PropTypes.string,
-    value: PropTypes.number,
+    value: PropTypes.string,
   };
 
-  handleReturn = event => {
+  handleReturn = (event) => {
     const { handleFilters } = this.props;
 
     if (event.key === 'Enter') {

--- a/src/modules/bigquery.js
+++ b/src/modules/bigquery.js
@@ -75,10 +75,11 @@ export default class BigQuery {
             const datasetName = !dataset ? '' : dataset.name + '.';
             const property = `${datasetName}${table}.${key}`;
             const keyValue = filters[key].value;
+            const isRange = filters[key].type === 'range';
             const notClause = filters[key].exclude ? 'NOT' : '';
 
             if (_.isArray(keyValue)) {
-              if (_.isNumber(keyValue[0])) {
+              if (isRange) {
                 statementClauses.push(`${property} BETWEEN ${keyValue[0]} AND ${keyValue[1]}`);
               } else if (_.isString(keyValue[0])) {
                 const selections = keyValue.map((selection) => `"${selection}"`).join(',');


### PR DESCRIPTION
![range-slider](https://user-images.githubusercontent.com/52389456/86022836-e009fb80-b9f8-11ea-8bb5-e00cd3c1ab40.gif)
The TextField part of the range filter is tricky because the value gets inputted as text but stored as a number for our filtering purposes. We currently parse out the number as the text gets entered, which is problematic for decimals, since `parseFloat('0.')` returns `0`.

It turns out that filters on our columns of type 'integer' or 'float' don't even need to be stored in the `filterData` as numbers. We get the min and max values from BigQuery as strings, parse out the numbers, then put the filters back into another query as a string. This PR takes out that middle step and keeps the range values as strings, allowing the user to freely enter text into the range filters. Number validation is left at a higher level, and the "apply filters" button disables for bad inputs.