### PR TITLE
DR-913 Back button is broken after navigating to dataset page

### DIFF
--- a/src/modules/hist.js
+++ b/src/modules/hist.js
@@ -1,24 +1,6 @@
-// @flow
 import { createBrowserHistory } from 'history';
 
-import qs from 'qs';
-
 const history = createBrowserHistory();
-
-history.location = {
-  ...history.location,
-  query: qs.parse(history.location.search.substr(1)),
-  state: {},
-};
-
-history.listen(() => {
-  history.location = {
-    ...history.location,
-    query: qs.parse(history.location.search.substr(1)),
-    state: history.location.state || {},
-  };
-});
-
 const { go, goBack, push, replace } = history;
 
 export { go, goBack, push, replace };


### PR DESCRIPTION
So, we had some code that was overriding history.listen and adding some extra properties that we're not actually using. On chrome, this is causing 5 entries to be added to the history for every link you click -- so the back button wasn't broken, there were just extra pages. I think all of these entries had different key values, and somehow firefox was able to determine that they were all actually the same page which is why it isn't broken there.

We aren't actually using any of this extra stuff so I'm just going to get rid of it.