### PR TITLE
DR-1072 format timestamps as a readable date format

### DIFF
--- a/src/modules/bigquery.js
+++ b/src/modules/bigquery.js
@@ -39,6 +39,10 @@ export default class BigQuery {
         if (columnType === 'FLOAT') {
           value = this.significantDigits(value);
         }
+
+        if (columnType === 'TIMESTAMP') {
+          value = new Date(value * 1000).toLocaleString();
+        }
       }
       if (columnId === 'datarepo_row_id') {
         res.datarepo_id = value;


### PR DESCRIPTION
Columns of datatype 'TIMESTAMP' were being formatted as floats instead of dates, so this PR adds formatting to have them read like a date.