### PR TITLE
DR-1011 Fix table pagination not showing up in dataset table

### DIFF
--- a/src/components/table/LightTable.jsx
+++ b/src/components/table/LightTable.jsx
@@ -185,7 +185,7 @@ export class LightTable extends React.PureComponent {
               )}
             </TableBody>
           </Table>
-          {!summary && rows && rows.length < DEFAULT_PAGE_SIZE && (
+          {!summary && rows && totalCount > rowsPerPage && (
             <TablePagination
               rowsPerPageOptions={ROWS_PER_PAGE}
               component="div"


### PR DESCRIPTION
A nice little one-line PR.
Some context, so you don't have to dig through the rest of the file:
- `rows.length` = the number of rows returned by BigQuery with the `rowsPerPage` limit. So, this number is always less than or equal to `rowsPerPage`.
- `DEFAULT_PAGE_SIZE` = 10.
- `totalRows` = the number of datasets in the repo.
- `rowsPerPage` = the current set page size. It is equal to `DEFAULT_PAGE_SIZE` unless the user changes it.

Hopefully that is enough to explain why the original code was buggy and what the new code does. Basically, it makes the pagination bar visible when there are more datasets than can fit on one page--even when the page size is changed.