### PR TITLE
DR-945 Snapshot details page lists too many datasets

### DIFF
--- a/src/components/DatasetView.jsx
+++ b/src/components/DatasetView.jsx
@@ -27,7 +27,7 @@ const styles = (theme) => ({
 class DatasetView extends React.PureComponent {
   static propTypes = {
     classes: PropTypes.object.isRequired,
-    datasets: PropTypes.object,
+    datasets: PropTypes.array.isRequired,
     datasetsCount: PropTypes.number,
     dispatch: PropTypes.func.isRequired,
   };
@@ -49,9 +49,9 @@ class DatasetView extends React.PureComponent {
         <div className={classes.width}>
           <div className={classes.title}>Datasets</div>
           <div>
-            {datasets && datasets.datasets && (
+            {datasets && (
               <DatasetTable
-                datasets={datasets.datasets}
+                datasets={datasets}
                 datasetsCount={datasetsCount}
                 handleFilterDatasets={this.handleFilterDatasets}
               />
@@ -65,7 +65,7 @@ class DatasetView extends React.PureComponent {
 
 function mapStateToProps(state) {
   return {
-    datasets: state.datasets,
+    datasets: state.datasets.datasets,
     datasetsCount: state.datasets.datasetsCount,
   };
 }

--- a/src/components/DatasetView.jsx
+++ b/src/components/DatasetView.jsx
@@ -28,6 +28,7 @@ class DatasetView extends React.PureComponent {
   static propTypes = {
     classes: PropTypes.object.isRequired,
     datasets: PropTypes.object,
+    datasetsCount: PropTypes.number,
     dispatch: PropTypes.func.isRequired,
   };
 
@@ -36,13 +37,26 @@ class DatasetView extends React.PureComponent {
     dispatch(getDatasets());
   }
 
+  handleFilterDatasets = (limit, offset, sort, sortDirection, searchString) => {
+    const { dispatch } = this.props;
+    dispatch(getDatasets(limit, offset, sort, sortDirection, searchString));
+  };
+
   render() {
-    const { classes, datasets } = this.props;
+    const { classes, datasets, datasetsCount } = this.props;
     return (
       <div className={classes.wrapper}>
         <div className={classes.width}>
           <div className={classes.title}>Datasets</div>
-          <div> {datasets && datasets.datasets && <DatasetTable rows={datasets.datasets} />} </div>
+          <div>
+            {datasets && datasets.datasets && (
+              <DatasetTable
+                datasets={datasets.datasets}
+                datasetsCount={datasetsCount}
+                handleFilterDatasets={this.handleFilterDatasets}
+              />
+            )}
+          </div>
         </div>
       </div>
     );
@@ -52,6 +66,7 @@ class DatasetView extends React.PureComponent {
 function mapStateToProps(state) {
   return {
     datasets: state.datasets,
+    datasetsCount: state.datasets.datasetsCount,
   };
 }
 

--- a/src/components/HomeView.jsx
+++ b/src/components/HomeView.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import { Link } from 'react-router-dom';
 
 import SnapshotTable from './table/SnapshotTable';
 import DatasetTable from './table/DatasetTable';
+import { getDatasets } from 'actions/index';
 
 const styles = (theme) => ({
   header: {
@@ -54,16 +56,23 @@ const styles = (theme) => ({
 class HomeView extends React.PureComponent {
   static propTypes = {
     classes: PropTypes.object.isRequired,
+    datasets: PropTypes.array,
+    dispatch: PropTypes.func.isRequired,
   };
 
+  componentDidMount() {
+    const { dispatch } = this.props;
+    dispatch(getDatasets(5));
+  }
+
   render() {
-    const { classes } = this.props;
+    const { classes, datasets } = this.props;
     return (
       <div className={classes.wrapper}>
         <div className={classes.width}>
           <div className={classes.title}>Terra Data Repository at a glance</div>
           <div className={classes.header}> RECENT DATASETS </div>
-          <DatasetTable summary />
+          <DatasetTable summary datasets={datasets} />
           <div>
             <Link to="/datasets" className={classes.jadeLink}>
               See all Datasets
@@ -83,4 +92,10 @@ class HomeView extends React.PureComponent {
   }
 }
 
-export default withStyles(styles)(HomeView);
+function mapStateToProps(state) {
+  return {
+    datasets: state.datasets.datasets,
+  };
+}
+
+export default connect(mapStateToProps)(withStyles(styles)(HomeView));

--- a/src/components/HomeView.jsx
+++ b/src/components/HomeView.jsx
@@ -4,9 +4,9 @@ import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import { Link } from 'react-router-dom';
 
+import { getDatasets, getSnapshots } from 'actions/index';
 import SnapshotTable from './table/SnapshotTable';
 import DatasetTable from './table/DatasetTable';
-import { getDatasets, getSnapshots } from 'actions/index';
 
 const styles = (theme) => ({
   header: {

--- a/src/components/HomeView.jsx
+++ b/src/components/HomeView.jsx
@@ -6,7 +6,7 @@ import { Link } from 'react-router-dom';
 
 import SnapshotTable from './table/SnapshotTable';
 import DatasetTable from './table/DatasetTable';
-import { getDatasets } from 'actions/index';
+import { getDatasets, getSnapshots } from 'actions/index';
 
 const styles = (theme) => ({
   header: {
@@ -56,17 +56,19 @@ const styles = (theme) => ({
 class HomeView extends React.PureComponent {
   static propTypes = {
     classes: PropTypes.object.isRequired,
-    datasets: PropTypes.array,
+    datasets: PropTypes.array.isRequired,
     dispatch: PropTypes.func.isRequired,
+    snapshots: PropTypes.array.isRequired,
   };
 
   componentDidMount() {
     const { dispatch } = this.props;
     dispatch(getDatasets(5));
+    dispatch(getSnapshots(5));
   }
 
   render() {
-    const { classes, datasets } = this.props;
+    const { classes, datasets, snapshots } = this.props;
     return (
       <div className={classes.wrapper}>
         <div className={classes.width}>
@@ -80,7 +82,7 @@ class HomeView extends React.PureComponent {
           </div>
           <div className={classes.jadeTableSpacer} />
           <div className={classes.header}>RECENT SNAPSHOTS</div>
-          <SnapshotTable summary />
+          <SnapshotTable summary snapshots={snapshots} />
           <div>
             <Link to="/snapshots" className={classes.jadeLink}>
               See all Snapshots
@@ -95,6 +97,7 @@ class HomeView extends React.PureComponent {
 function mapStateToProps(state) {
   return {
     datasets: state.datasets.datasets,
+    snapshots: state.snapshots.snapshots,
   };
 }
 

--- a/src/components/SnapshotDetailView.jsx
+++ b/src/components/SnapshotDetailView.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import _ from 'lodash';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withStyles } from '@material-ui/core/styles';
@@ -13,7 +14,6 @@ import {
 import DetailViewHeader from './DetailViewHeader';
 
 import DatasetTable from './table/DatasetTable';
-import _ from 'lodash';
 
 const styles = (theme) => ({
   wrapper: {

--- a/src/components/SnapshotDetailView.jsx
+++ b/src/components/SnapshotDetailView.jsx
@@ -99,11 +99,13 @@ export class SnapshotDetailView extends React.PureComponent {
 
   handleFilterDatasets = (limit, offset, sort, sortDirection, searchString) => {
     const { snapshot } = this.props;
-    let datasets = snapshot.source.map((s) => s.dataset);
-    datasets = datasets.filter((d) => d.name.toLowerCase().includes(searchString.toLowerCase()));
-    datasets = _.orderBy(datasets, sort, sortDirection);
-    datasets = _.take(_.drop(datasets, offset), limit);
-    this.setState({ filteredDatasets: datasets });
+    const datasets = snapshot.source.map((s) => s.dataset);
+    const filtered = datasets.filter((d) =>
+      d.name.toLowerCase().includes(searchString.toLowerCase()),
+    );
+    const sorted = _.orderBy(filtered, sort, sortDirection);
+    const paged = _.take(_.drop(sorted, offset), limit);
+    this.setState({ filteredDatasets: paged });
   };
 
   render() {

--- a/src/components/SnapshotView.jsx
+++ b/src/components/SnapshotView.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import { withStyles } from '@material-ui/core/styles';
 
+import { getSnapshots } from 'actions/index';
 import SnapshotTable from './table/SnapshotTable';
 import SnapshotPopup from './snapshot/SnapshotPopup';
 
@@ -26,16 +28,33 @@ const styles = (theme) => ({
 class SnapshotView extends React.PureComponent {
   static propTypes = {
     classes: PropTypes.object.isRequired,
+    dispatch: PropTypes.func.isRequired,
+    snapshotCount: PropTypes.number,
+    snapshots: PropTypes.array.isRequired,
+  };
+
+  componentDidMount() {
+    const { dispatch } = this.props;
+    dispatch(getSnapshots());
+  }
+
+  handleFilterSnapshots = (limit, offset, sort, sortDirection, searchString) => {
+    const { dispatch } = this.props;
+    dispatch(getSnapshots(limit, offset, sort, sortDirection, searchString));
   };
 
   render() {
-    const { classes } = this.props;
+    const { classes, snapshotCount, snapshots } = this.props;
     return (
       <div id="snapshots" className={classes.wrapper}>
         <div className={classes.width}>
           <div className={classes.title}>Snapshots</div>
           <div>
-            <SnapshotTable />
+            <SnapshotTable
+              snapshotCount={snapshotCount}
+              snapshots={snapshots}
+              handleFilterSnapshots={this.handleFilterSnapshots}
+            />
           </div>
         </div>
         <SnapshotPopup />
@@ -44,4 +63,11 @@ class SnapshotView extends React.PureComponent {
   }
 }
 
-export default withStyles(styles)(SnapshotView);
+function mapStateToProps(state) {
+  return {
+    snapshots: state.snapshots.snapshots,
+    snapshotCount: state.snapshots.snapshotCount,
+  };
+}
+
+export default connect(mapStateToProps)(withStyles(styles)(SnapshotView));

--- a/src/components/table/DatasetTable.jsx
+++ b/src/components/table/DatasetTable.jsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import { withStyles } from '@material-ui/core/styles';
 import { Link } from 'react-router-dom';
 import moment from 'moment';
 
-import { getDatasets } from 'actions/index';
 import LightTable from './LightTable';
 
 const styles = (theme) => ({
@@ -23,26 +21,12 @@ class DatasetTable extends React.PureComponent {
     classes: PropTypes.object.isRequired,
     datasets: PropTypes.array.isRequired,
     datasetsCount: PropTypes.number,
-    dispatch: PropTypes.func.isRequired,
+    handleFilterDatasets: PropTypes.func,
     summary: PropTypes.bool,
   };
 
-  componentDidMount() {
-    const { dispatch, summary } = this.props;
-    let limit = 5;
-    if (!summary) {
-      limit = 10;
-    }
-    dispatch(getDatasets(limit));
-  }
-
-  handleFilterDatasets = (limit, offset, sort, sortDirection, searchString) => {
-    const { dispatch } = this.props;
-    dispatch(getDatasets(limit, offset, sort, sortDirection, searchString));
-  };
-
   render() {
-    const { classes, summary, datasetsCount, datasets } = this.props;
+    const { classes, datasets, datasetsCount, handleFilterDatasets, summary } = this.props;
     // TODO add back modified_date column
     const columns = [
       {
@@ -67,7 +51,7 @@ class DatasetTable extends React.PureComponent {
     return (
       <LightTable
         columns={columns}
-        handleEnumeration={this.handleFilterDatasets}
+        handleEnumeration={handleFilterDatasets}
         itemType="datasets"
         rows={datasets}
         summary={summary}
@@ -77,12 +61,4 @@ class DatasetTable extends React.PureComponent {
   }
 }
 
-function mapStateToProps(state) {
-  return {
-    datasetsTest: state.datasets,
-    datasets: state.datasets.datasets,
-    datasetsCount: state.datasets.datasetsCount,
-  };
-}
-
-export default connect(mapStateToProps)(withStyles(styles)(DatasetTable));
+export default withStyles(styles)(DatasetTable);

--- a/src/components/table/LightTable.jsx
+++ b/src/components/table/LightTable.jsx
@@ -159,6 +159,7 @@ export class LightTable extends React.PureComponent {
               onRequestSort={this.handleRequestSort}
               orderDirection={orderDirection}
               orderBy={orderBy}
+              summary={summary}
             />
             <TableBody>
               {rows && rows.length > 0 ? (

--- a/src/components/table/LightTableHead.jsx
+++ b/src/components/table/LightTableHead.jsx
@@ -27,6 +27,7 @@ export class LightTableHead extends React.PureComponent {
     onRequestSort: PropTypes.func.isRequired,
     orderBy: PropTypes.string.isRequired,
     orderDirection: PropTypes.string.isRequired,
+    summary: PropTypes.bool,
   };
 
   createSortHandler = (property) => (event) => {
@@ -35,7 +36,7 @@ export class LightTableHead extends React.PureComponent {
   };
 
   render() {
-    const { classes, columns, orderDirection, orderBy } = this.props;
+    const { classes, columns, orderDirection, orderBy, summary } = this.props;
 
     return (
       <TableHead className={classes.head}>
@@ -49,19 +50,23 @@ export class LightTableHead extends React.PureComponent {
                 padding={col.disablePadding ? 'none' : 'default'}
                 sortDirection={orderBy === col.id ? orderDirection : false}
               >
-                <Tooltip
-                  title="Sort"
-                  placement={col.numeric ? 'bottom-end' : 'bottom-start'}
-                  enterDelay={300}
-                >
-                  <TableSortLabel
-                    active={orderBy === col.property}
-                    direction={orderDirection}
-                    onClick={this.createSortHandler(col.property)}
+                {summary ? (
+                  col.label
+                ) : (
+                  <Tooltip
+                    title="Sort"
+                    placement={col.numeric ? 'bottom-end' : 'bottom-start'}
+                    enterDelay={300}
                   >
-                    {col.label}
-                  </TableSortLabel>
-                </Tooltip>
+                    <TableSortLabel
+                      active={orderBy === col.property}
+                      direction={orderDirection}
+                      onClick={this.createSortHandler(col.property)}
+                    >
+                      {col.label}
+                    </TableSortLabel>
+                  </Tooltip>
+                )}
               </TableCell>
             ),
             this,

--- a/src/components/table/SnapshotTable.jsx
+++ b/src/components/table/SnapshotTable.jsx
@@ -2,10 +2,8 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import moment from 'moment';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import { withStyles } from '@material-ui/core/styles';
 
-import { getSnapshots } from 'actions/index';
 import LightTable from './LightTable';
 
 const styles = (theme) => ({
@@ -21,28 +19,14 @@ const styles = (theme) => ({
 class SnapshotTable extends React.PureComponent {
   static propTypes = {
     classes: PropTypes.object.isRequired,
-    dispatch: PropTypes.func.isRequired,
+    handleFilterSnapshots: PropTypes.func,
     snapshotCount: PropTypes.number,
     snapshots: PropTypes.array.isRequired,
     summary: PropTypes.bool,
   };
 
-  componentDidMount() {
-    const { dispatch, summary } = this.props;
-    let limit = 5;
-    if (!summary) {
-      limit = 10;
-    }
-    dispatch(getSnapshots(limit));
-  }
-
-  handleFilterSnapshots = (limit, offset, sort, sortDirection, searchString) => {
-    const { dispatch } = this.props;
-    dispatch(getSnapshots(limit, offset, sort, sortDirection, searchString));
-  };
-
   render() {
-    const { classes, snapshotCount, snapshots, summary } = this.props;
+    const { classes, handleFilterSnapshots, snapshotCount, snapshots, summary } = this.props;
     // TODO add back modified_date column
     const columns = [
       {
@@ -68,7 +52,7 @@ class SnapshotTable extends React.PureComponent {
       <div>
         <LightTable
           columns={columns}
-          handleEnumeration={this.handleFilterSnapshots}
+          handleEnumeration={handleFilterSnapshots}
           itemType="snapshots"
           rows={snapshots}
           summary={summary}
@@ -79,11 +63,4 @@ class SnapshotTable extends React.PureComponent {
   }
 }
 
-function mapStateToProps(state) {
-  return {
-    snapshots: state.snapshots.snapshots,
-    snapshotCount: state.snapshots.snapshotCount,
-  };
-}
-
-export default connect(mapStateToProps)(withStyles(styles)(SnapshotTable));
+export default withStyles(styles)(SnapshotTable);


### PR DESCRIPTION
The details page for a given snapshot includes a table that should list all the datasets included in the snapshot. Instead, this table lists every dataset in the repo.

It turns out that the snapshot details page is passing down the rows to be included in the dataset table, but those rows are being overwritten with the `<DatasetTable/>`'s own `dispatch(getDatasets())`. So, I've taken this method out of the `<DatasetTable/>` component so the rows can be passed down from the parent component. I've also updated all references of `<DatasetTable/>` (and `<SnapshotTable/>`, to be consistent) to behave the same way.

This also meant I had to relocate the methods for filtering and sorting dataset/snapshot tables, and I took this functionality out of the summary tables.