### PR TITLE
DR-1252 Landing page for new search ui

### DIFF
--- a/src/components/RoutePrivate.jsx
+++ b/src/components/RoutePrivate.jsx
@@ -2,12 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Route, Redirect } from 'react-router-dom';
 
-const RoutePrivate = ({ component: Component, isAuthenticated, to, ...rest }) => (
+const RoutePrivate = ({ component: Component, features, isAuthenticated, to, ...rest }) => (
   <Route
     {...rest}
     render={(props) =>
       isAuthenticated ? (
-        <Component {...props} />
+        <Component {...props} features={features} />
       ) : (
         <Redirect
           to={{
@@ -22,6 +22,7 @@ const RoutePrivate = ({ component: Component, isAuthenticated, to, ...rest }) =>
 
 RoutePrivate.propTypes = {
   component: PropTypes.oneOfType([PropTypes.func, PropTypes.object]).isRequired,
+  features: PropTypes.object,
   isAuthenticated: PropTypes.bool.isRequired,
   location: PropTypes.object,
   to: PropTypes.string,

--- a/src/components/search/DataExplorerView.jsx
+++ b/src/components/search/DataExplorerView.jsx
@@ -2,22 +2,18 @@ import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
+import { Divider } from '@material-ui/core';
 
 const styles = (theme) => ({
-  wrapper: {
-    display: 'flex',
-    justifyContent: 'center',
-    padding: theme.spacing(4),
-    margin: theme.spacing(4),
-  },
-  width: {
-    width: '70%',
-  },
   title: {
     color: theme.palette.primary.main,
     fontSize: '54px',
     lineHeight: '66px',
-    paddingBottom: theme.spacing(8),
+    padding: theme.spacing(4),
+  },
+  section: {
+    padding: `${theme.spacing(2)}px ${theme.spacing(4)}px`,
+    margin: `${theme.spacing(1)}px 0px`,
   },
 });
 
@@ -30,10 +26,13 @@ class DataExplorerView extends React.PureComponent {
   render() {
     const { classes } = this.props;
     return (
-      <div className={classes.wrapper}>
-        <div className={classes.width}>
-          <div className={classes.title}>This is the data explorer</div>
-        </div>
+      <div>
+        <div className={classes.title}>Data Explorer</div>
+        <div className={classes.section}>This is where the filter options will go</div>
+        <Divider />
+        <div className={classes.section}>This is where the applied filters will go</div>
+        <Divider />
+        <div className={classes.section}>This is where the dataset results will go</div>
       </div>
     );
   }

--- a/src/components/search/DataExplorerView.jsx
+++ b/src/components/search/DataExplorerView.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import { withStyles } from '@material-ui/core/styles';
+
+const styles = (theme) => ({
+  wrapper: {
+    display: 'flex',
+    justifyContent: 'center',
+    padding: theme.spacing(4),
+    margin: theme.spacing(4),
+  },
+  width: {
+    width: '70%',
+  },
+  title: {
+    color: theme.palette.primary.main,
+    fontSize: '54px',
+    lineHeight: '66px',
+    paddingBottom: theme.spacing(8),
+  },
+});
+
+class DataExplorerView extends React.PureComponent {
+  static propTypes = {
+    classes: PropTypes.object.isRequired,
+    dispatch: PropTypes.func.isRequired,
+  };
+
+  render() {
+    const { classes } = this.props;
+    return (
+      <div className={classes.wrapper}>
+        <div className={classes.width}>
+          <div className={classes.title}>This is the data explorer</div>
+        </div>
+      </div>
+    );
+  }
+}
+
+function mapStateToProps(state) {
+  return {};
+}
+
+export default connect(mapStateToProps)(withStyles(styles)(DataExplorerView));

--- a/src/components/search/DataExplorerView.jsx
+++ b/src/components/search/DataExplorerView.jsx
@@ -38,6 +38,7 @@ class DataExplorerView extends React.PureComponent {
   }
 }
 
+// eslint-disable-next-line no-unused-vars
 function mapStateToProps(state) {
   return {};
 }

--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -233,7 +233,12 @@ export function App(props) {
             exact
             component={HeadlessLogin}
           />
-          <RoutePrivate isAuthenticated={user.isAuthenticated} path="/" component={Private} />
+          <RoutePrivate
+            isAuthenticated={user.isAuthenticated}
+            path="/"
+            component={Private}
+            features={user.features}
+          />
           <Route component={NotFound} />
         </Switch>
       </div>

--- a/src/routes/Private.jsx
+++ b/src/routes/Private.jsx
@@ -42,12 +42,13 @@ const styles = (theme) => ({
 class Private extends React.Component {
   static propTypes = {
     classes: PropTypes.object.isRequired,
+    features: PropTypes.object,
   };
 
   static prefixMatcher = new RegExp('/[^/]*');
 
   render() {
-    const { classes } = this.props;
+    const { classes, features } = this.props;
     return (
       <ConnectedRouter history={history}>
         <Router history={history}>
@@ -67,13 +68,15 @@ class Private extends React.Component {
                       to="/"
                       classes={{ root: classes.tabRoot, selected: classes.tabSelected }}
                     />
-                    <Tab
-                      label="Data Explorer"
-                      component={Link}
-                      value="/explorer"
-                      to="/explorer"
-                      classes={{ root: classes.tabRoot, selected: classes.tabSelected }}
-                    />
+                    {features.searchui && (
+                      <Tab
+                        label="Data Explorer"
+                        component={Link}
+                        value="/explorer"
+                        to="/explorer"
+                        classes={{ root: classes.tabRoot, selected: classes.tabSelected }}
+                      />
+                    )}
                     <Tab
                       label="Datasets"
                       component={Link}
@@ -91,7 +94,9 @@ class Private extends React.Component {
                   </Tabs>
                   <Switch>
                     <Route exact path="/" component={HomeView} />
-                    <Route exact path="/explorer" component={DataExplorerView} />
+                    {features.searchui && (
+                      <Route exact path="/explorer" component={DataExplorerView} />
+                    )}
                     <Route exact path="/datasets" component={DatasetsView} />
                     <Route exact path="/datasets/details/:uuid" component={QueryView} />
                     <Route exact path="/snapshots" component={SnapshotView} />

--- a/src/routes/Private.jsx
+++ b/src/routes/Private.jsx
@@ -12,6 +12,7 @@ import DatasetsView from '../components/DatasetView';
 import SnapshotView from '../components/SnapshotView';
 import SnapshotDetailView from '../components/SnapshotDetailView';
 import QueryView from '../components/dataset/query/QueryView';
+import DataExplorerView from '../components/search/DataExplorerView';
 
 const styles = (theme) => ({
   wrapper: {
@@ -67,6 +68,13 @@ class Private extends React.Component {
                       classes={{ root: classes.tabRoot, selected: classes.tabSelected }}
                     />
                     <Tab
+                      label="Data Explorer"
+                      component={Link}
+                      value="/explorer"
+                      to="/explorer"
+                      classes={{ root: classes.tabRoot, selected: classes.tabSelected }}
+                    />
+                    <Tab
                       label="Datasets"
                       component={Link}
                       value="/datasets"
@@ -83,6 +91,7 @@ class Private extends React.Component {
                   </Tabs>
                   <Switch>
                     <Route exact path="/" component={HomeView} />
+                    <Route exact path="/explorer" component={DataExplorerView} />
                     <Route exact path="/datasets" component={DatasetsView} />
                     <Route exact path="/datasets/details/:uuid" component={QueryView} />
                     <Route exact path="/snapshots" component={SnapshotView} />


### PR DESCRIPTION
<img width="1680" alt="Screen Shot 2020-08-18 at 2 40 55 PM" src="https://user-images.githubusercontent.com/52389456/90554651-30cde300-e164-11ea-8869-08745a3d6dc2.png">

- Added a tab to the UI that is rendered only if the logged in user has access to the new search page
- Created a page for the data explorer with a general skeleton for components to be added as they are created