### PR TITLE
DR-1283 First half of 'Snapshot Full Dataset' flow

### DIFF
--- a/src/components/dataset/details/CreateFullSnapshotView.jsx
+++ b/src/components/dataset/details/CreateFullSnapshotView.jsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withStyles } from '@material-ui/styles';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Typography,
+  TextField,
+  Button,
+} from '@material-ui/core';
+
+const styles = (theme) => ({
+  root: {
+    padding: theme.spacing(2),
+  },
+  textField: {
+    marginBottom: theme.spacing(1),
+  },
+  buttonContainer: {
+    justifyContent: 'space-between',
+  },
+});
+
+class CreateFullSnapshotView extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {
+      name: '',
+      description: '',
+    };
+  }
+
+  static propTypes = {
+    classes: PropTypes.object,
+    open: PropTypes.bool,
+    openSnapshotCreation: PropTypes.bool,
+  };
+
+  handleCancel = () => {
+    const { openSnapshotCreation } = this.props;
+    this.setState({ name: '', description: '' });
+    openSnapshotCreation(false);
+  };
+
+  render() {
+    const { classes, open } = this.props;
+    const { name, description } = this.state;
+    return (
+      <Dialog open={open} fullWidth>
+        <DialogTitle>Name and Describe Snapshot</DialogTitle>
+        <DialogContent>
+          <Typography variant="subtitle2">Snapshot Name</Typography>
+          <TextField
+            id="snapshotName"
+            variant="outlined"
+            size="small"
+            fullWidth
+            className={classes.textField}
+            onChange={(event) => this.setState({ name: event.target.value })}
+            value={name}
+          />
+          <Typography variant="subtitle2">Description</Typography>
+          <TextField
+            id="snapshotDescription"
+            variant="outlined"
+            size="small"
+            multiline
+            rows={5}
+            fullWidth
+            className={classes.textField}
+            onChange={(event) => this.setState({ description: event.target.value })}
+            value={description}
+          />
+        </DialogContent>
+        <DialogActions className={classes.buttonContainer}>
+          <Button onClick={this.handleCancel}>Cancel</Button>
+          <Button variant="contained" disabled={name === ''}>
+            Save snapshot
+          </Button>
+        </DialogActions>
+      </Dialog>
+    );
+  }
+}
+
+export default withStyles(styles)(CreateFullSnapshotView);

--- a/src/components/dataset/details/DatasetDetailView.jsx
+++ b/src/components/dataset/details/DatasetDetailView.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { withStyles } from '@material-ui/core/styles';
 import { getDatasetById, getDatasetPolicy } from 'actions/index';
 import DatasetInfoCard from './DatasetInfoCard';
+import CreateFullSnapshotView from './CreateFullSnapshotView';
 
 const styles = (theme) => ({
   root: {
@@ -20,6 +21,13 @@ const styles = (theme) => ({
 });
 
 class DatasetDetailView extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {
+      creatingSnapshot: false,
+    };
+  }
+
   static propTypes = {
     classes: PropTypes.object,
     dataset: PropTypes.object,
@@ -35,14 +43,27 @@ class DatasetDetailView extends React.PureComponent {
     dispatch(getDatasetPolicy(uuid));
   }
 
+  openSnapshotCreation = (isOpen) => {
+    this.setState({ creatingSnapshot: isOpen });
+  };
+
   render() {
     const { classes, dataset, datasetPolicies, match } = this.props;
+    const { creatingSnapshot } = this.state;
     const { uuid } = match.params;
     if (dataset && datasetPolicies && dataset.id === uuid) {
       return (
         <div className={classes.root}>
           <div className={classes.headerText}>Dataset Information</div>
-          <DatasetInfoCard dataset={dataset} datasetPolicies={datasetPolicies} />
+          <DatasetInfoCard
+            dataset={dataset}
+            datasetPolicies={datasetPolicies}
+            openSnapshotCreation={this.openSnapshotCreation}
+          />
+          <CreateFullSnapshotView
+            open={creatingSnapshot}
+            openSnapshotCreation={this.openSnapshotCreation}
+          />
         </div>
       );
     }

--- a/src/components/dataset/details/DatasetInfoCard.jsx
+++ b/src/components/dataset/details/DatasetInfoCard.jsx
@@ -38,10 +38,11 @@ export class DatasetInfoCard extends React.PureComponent {
     classes: PropTypes.object,
     dataset: PropTypes.object,
     datasetPolicies: PropTypes.array,
+    openSnapshotCreation: PropTypes.func,
   };
 
   render() {
-    const { classes, dataset, datasetPolicies } = this.props;
+    const { classes, dataset, datasetPolicies, openSnapshotCreation } = this.props;
     const datasetCustodiansObj = datasetPolicies.find((policy) => policy.name === 'custodian');
     const datasetCustodians = (datasetCustodiansObj && datasetCustodiansObj.members) || [];
     const bigQueryUrl = `https://console.cloud.google.com/bigquery?project=${dataset.dataProject}&supportedpurview=project&p=${dataset.dataProject}&d=datarepo_${dataset.name}&page=dataset`;
@@ -72,7 +73,11 @@ export class DatasetInfoCard extends React.PureComponent {
             </a>
             <Launch fontSize="small" />
           </div>
-          <Button className={classes.button} variant="outlined">
+          <Button
+            className={classes.button}
+            variant="outlined"
+            onClick={() => openSnapshotCreation(true)}
+          >
             Snapshot full dataset
           </Button>
         </div>


### PR DESCRIPTION
![full-snapshot](https://user-images.githubusercontent.com/52389456/91608006-c296d680-e942-11ea-972e-16586a35f4b1.gif)
Opens a dialog to add details for a new snapshot when the "Snapshot Full Dataset" button is clicked. The "Save Snapshot" button, which will take the dialog to the next step in the flow, is not hooked up yet. The cancel button closes the dialog and discards the snapshot.