### PR TITLE
DR-1360 Show arrays in the data browsing table

### DIFF
--- a/cypress/integration/queryBuilder.spec.js
+++ b/cypress/integration/queryBuilder.spec.js
@@ -13,6 +13,7 @@ describe('test query builder', () => {
     cy.get('#e2eLoginButton').click();
 
     cy.contains('See all Datasets').click();
+    cy.get('[placeholder=Search]').type('V2F_GWAS');
     cy.contains('Date created').click();
     cy.contains(/V2F_GWAS_Summary_Stats|V2F_GWAS_Summary_Statistics/g).should('be.visible');
     cy.contains(/V2F_GWAS_Summary_Stats|V2F_GWAS_Summary_Statistics/g).click();
@@ -20,6 +21,25 @@ describe('test query builder', () => {
   });
 
   it('does render', () => {});
+
+  describe('arrays work as expected', () => {
+    beforeEach(() => {
+      cy.get('[data-cy=selectTable]').click();
+      cy.get('[data-cy=menuItem-feature_consequence]').click();
+    });
+
+    it('does show array values', () => {
+      // Click the header to make sure we don't sort or trigger an error
+      cy.get(`[data-cy=columnheader-consequence_terms]`).click();
+
+      for (let i = 0; i < 100; i++) {
+        cy.get(`[data-cy=cellvalue-consequence_terms-${i}]`).should(
+          'have.text',
+          '[regulatory_region_variant]',
+        );
+      }
+    });
+  });
 
   describe('test filter panel', () => {
     beforeEach(() => {

--- a/src/components/dataset/query/QueryView.jsx
+++ b/src/components/dataset/query/QueryView.jsx
@@ -1,5 +1,4 @@
 import React, { Fragment } from 'react';
-import _ from 'lodash';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withStyles } from '@material-ui/core/styles';
@@ -87,13 +86,6 @@ export class QueryView extends React.PureComponent {
         prevState.selected !== selected ||
         prevProps.orderBy !== orderBy)
     ) {
-      const arrayVals = this.findArrayVals(dataset, selected);
-
-      let arraysToExclude = '';
-      if (!_.isEmpty(arrayVals)) {
-        arraysToExclude = `EXCEPT (${arrayVals})`;
-      }
-
       const fromClause = `FROM \`${dataset.dataProject}.datarepo_${dataset.name}.${selected}\` AS ${selected}
           ${joinStatement}
           ${filterStatement}`;
@@ -102,7 +94,7 @@ export class QueryView extends React.PureComponent {
         runQuery(
           dataset.dataProject,
           `#standardSQL
-          SELECT DISTINCT ${selected}.* ${arraysToExclude} ${fromClause}
+          SELECT ${selected}.* ${fromClause}
           ${orderBy}
           LIMIT ${QUERY_LIMIT}`,
           PAGE_SIZE,
@@ -117,12 +109,6 @@ export class QueryView extends React.PureComponent {
       );
     }
   }
-
-  findArrayVals = (dataset, table) => {
-    const tableSchema = _.find(dataset.schema.tables, (t) => t.name === table);
-    const withArray = _.filter(tableSchema.columns, (column) => column.array_of === true);
-    return withArray.map((object) => object.name);
-  };
 
   hasDataset() {
     const { dataset, match } = this.props;

--- a/src/components/dataset/query/sidebar/QuerySidebarPanel.jsx
+++ b/src/components/dataset/query/sidebar/QuerySidebarPanel.jsx
@@ -26,7 +26,7 @@ export class QuerySidebarPanel extends React.PureComponent {
     dataset: PropTypes.object,
     dispatch: PropTypes.func.isRequired,
     filterData: PropTypes.object,
-    results: PropTypes.string,
+    results: PropTypes.number,
     polling: PropTypes.bool,
     selected: PropTypes.string,
   };
@@ -38,8 +38,8 @@ export class QuerySidebarPanel extends React.PureComponent {
 
   render() {
     const { classes, filterData, selected, results, polling } = this.props;
-    const listTables = _.keys(filterData).map((table) => (
-      <AppliedFilterList table={table} selected={selected} />
+    const listTables = _.keys(filterData).map((table, i) => (
+      <AppliedFilterList key={`filter-${i}`} table={table} selected={selected} />
     ));
 
     const rowsLabel = results === 1 ? 'Row' : 'Rows';

--- a/src/components/dataset/query/sidebar/filter/CategoryWrapper.jsx
+++ b/src/components/dataset/query/sidebar/filter/CategoryWrapper.jsx
@@ -18,20 +18,22 @@ export class CategoryWrapper extends React.PureComponent {
     const { column, dataset, tableName, token, filterStatement, joinStatement } = this.props;
     const bq = new BigQuery();
 
-    bq.getColumnDistinct(
-      column.name,
-      dataset,
-      tableName,
-      token,
-      filterStatement,
-      joinStatement,
-    ).then((response) => {
-      const newResponse = this.transformResponse(response);
-      this.setState({
-        values: newResponse,
-        originalValues: newResponse,
+    if (!column.array_of) {
+      bq.getColumnDistinct(
+        column.name,
+        dataset,
+        tableName,
+        token,
+        filterStatement,
+        joinStatement,
+      ).then((response) => {
+        const newResponse = this.transformResponse(response);
+        this.setState({
+          values: newResponse,
+          originalValues: newResponse,
+        });
       });
-    });
+    }
   }
 
   static propTypes = {
@@ -51,24 +53,31 @@ export class CategoryWrapper extends React.PureComponent {
     const { column, dataset, tableName, token, filterStatement, joinStatement } = this.props;
     if (filterStatement !== prevProps.filterStatement || tableName !== prevProps.tableName) {
       const bq = new BigQuery();
-      bq.getColumnDistinct(
-        column.name,
-        dataset,
-        tableName,
-        token,
-        filterStatement,
-        joinStatement,
-      ).then((response) => {
-        const newResponse = this.transformResponse(response);
+      if (column.array_of) {
         this.setState({
-          values: newResponse,
+          values: {},
+          originalValues: {},
         });
-        if (tableName !== prevProps.tableName) {
+      } else {
+        bq.getColumnDistinct(
+          column.name,
+          dataset,
+          tableName,
+          token,
+          filterStatement,
+          joinStatement,
+        ).then((response) => {
+          const newResponse = this.transformResponse(response);
           this.setState({
-            originalValues: newResponse,
+            values: newResponse,
           });
-        }
-      });
+          if (tableName !== prevProps.tableName) {
+            this.setState({
+              originalValues: newResponse,
+            });
+          }
+        });
+      }
     }
   }
 

--- a/src/components/table/JadeTable.jsx
+++ b/src/components/table/JadeTable.jsx
@@ -161,17 +161,22 @@ export class JadeTable extends React.PureComponent {
               />
               {!polling && (
                 <TableBody data-cy="tableBody">
-                  {rows.map((row) => {
+                  {rows.map((row, i) => {
                     const drId = row.datarepo_id;
 
                     return (
                       <TableRow hover tabIndex={-1} key={drId}>
                         {columns.map((column) => {
                           const value = this.handleArrayValues(row[column.id], column);
-
                           return (
                             !_.isUndefined(value) && (
-                              <TableCell key={`${column.id}-${drId}`} className={classes.cell}>{value}</TableCell>
+                              <TableCell
+                                key={`${column.id}-${drId}`}
+                                className={classes.cell}
+                                data-cy={`cellvalue-${column.id}-${i}`}
+                              >
+                                {value}
+                              </TableCell>
                             )
                           );
                         })}

--- a/src/components/table/JadeTable.jsx
+++ b/src/components/table/JadeTable.jsx
@@ -12,6 +12,8 @@ import TableRow from '@material-ui/core/TableRow';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import { pageQuery, applySort } from 'actions/index';
 import { JadeTableHead } from './JadeTableHead';
+import { ellipsis } from '../../libs/styles';
+import { COLUMN_MODES } from '../../constants';
 
 // eslint-disable-next-line no-unused-vars
 const styles = (theme) => ({
@@ -31,6 +33,9 @@ const styles = (theme) => ({
   },
   spinner: {
     margin: 'auto',
+  },
+  cell: {
+    ...ellipsis,
   },
 });
 
@@ -115,9 +120,26 @@ export class JadeTable extends React.PureComponent {
     });
   };
 
-  handleArrayValues = (value) => {
+  handleArrayValues = (value, column) => {
     if (_.isArray(value)) {
-      return `[${value.map((obj) => obj.v).join(', ')}]`;
+      const returnValue = [];
+      if (column.mode === COLUMN_MODES.REPEATED) {
+        returnValue.push(<span key="start">[</span>);
+      }
+      returnValue.push(
+        ...value.flatMap((v, i) => [
+          v,
+          i < value.length - 1 ? (
+            <span key={`sep-${i}`}>
+              ,<br />
+            </span>
+          ) : undefined,
+        ]),
+      );
+      if (column.mode === COLUMN_MODES.REPEATED) {
+        returnValue.push(<span key="end">]</span>);
+      }
+      return returnValue;
     }
     return value;
   };
@@ -145,11 +167,11 @@ export class JadeTable extends React.PureComponent {
                     return (
                       <TableRow hover tabIndex={-1} key={drId}>
                         {columns.map((column) => {
-                          const value = this.handleArrayValues(row[column.id]);
+                          const value = this.handleArrayValues(row[column.id], column);
 
                           return (
                             !_.isUndefined(value) && (
-                              <TableCell key={`${column.id}-${drId}`}>{value}</TableCell>
+                              <TableCell key={`${column.id}-${drId}`} className={classes.cell}>{value}</TableCell>
                             )
                           );
                         })}

--- a/src/components/table/JadeTableHead.jsx
+++ b/src/components/table/JadeTableHead.jsx
@@ -37,6 +37,7 @@ export class JadeTableHead extends React.PureComponent {
                   align={column.numeric ? 'right' : 'left'}
                   padding={column.disablePadding ? 'none' : 'default'}
                   sortDirection={orderBy === column.id ? order : false}
+                  data-cy={`columnheader-${column.id}`}
                 >
                   {column.mode !== COLUMN_MODES.REPEATED && (
                     <TableSortLabel

--- a/src/components/table/JadeTableHead.jsx
+++ b/src/components/table/JadeTableHead.jsx
@@ -6,6 +6,7 @@ import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 import TableCell from '@material-ui/core/TableCell';
 import TableSortLabel from '@material-ui/core/TableSortLabel';
+import { COLUMN_MODES } from '../../constants';
 
 const styles = () => ({
   root: {
@@ -37,13 +38,16 @@ export class JadeTableHead extends React.PureComponent {
                   padding={column.disablePadding ? 'none' : 'default'}
                   sortDirection={orderBy === column.id ? order : false}
                 >
-                  <TableSortLabel
-                    active={orderBy === column.id}
-                    direction={order !== '' ? order : 'desc'}
-                    onClick={() => createSortHandler(column.id)}
-                  >
-                    {column.label}
-                  </TableSortLabel>
+                  {column.mode !== COLUMN_MODES.REPEATED && (
+                    <TableSortLabel
+                      active={orderBy === column.id}
+                      direction={order !== '' ? order : 'desc'}
+                      onClick={() => createSortHandler(column.id)}
+                    >
+                      {column.label}
+                    </TableSortLabel>
+                  )}
+                  {column.mode === COLUMN_MODES.REPEATED && <span>{column.label}</span>}
                 </TableCell>
               ),
           )}

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -94,3 +94,9 @@ export const IMAGE = {
 export const DB_COLUMNS = {
   ROW_ID: 'datarepo_row_id',
 };
+
+export const COLUMN_MODES = {
+  NULLABLE: 'NULLABLE',
+  REPEATED: 'REPEATED',
+  REQUIRED: 'REQUIRED',
+};

--- a/src/libs/styles.js
+++ b/src/libs/styles.js
@@ -1,0 +1,9 @@
+/**
+ * Common style patterns to reuse
+ */
+export const ellipsis = {
+  wordWrap: 'break-word',
+  whiteSpace: 'nowrap',
+  textOverflow: 'ellipsis',
+  overflow: 'hidden',
+};

--- a/src/modules/bigquery.js
+++ b/src/modules/bigquery.js
@@ -1,6 +1,9 @@
+// eslint-disable-next-line no-unused-vars
+import React from 'react';
 import axios from 'axios';
 import _ from 'lodash';
 import AwesomeDebouncePromise from 'awesome-debounce-promise';
+import { COLUMN_MODES } from '../constants';
 
 export default class BigQuery {
   constructor() {
@@ -13,6 +16,7 @@ export default class BigQuery {
       label: field.name,
       minWidth: 100,
       type: field.type,
+      mode: field.mode,
     }));
 
   transformRows = (queryResults, columns) => {
@@ -30,19 +34,27 @@ export default class BigQuery {
       const column = columns[i];
       const columnId = column.id;
       const columnType = column.type;
+      const columnMode = column.mode;
 
       let value = row[i];
       if (value !== null) {
+        // Convert into an array if it's not already one
+        if (columnMode !== COLUMN_MODES.REPEATED) {
+          value = [value];
+        } else {
+          value = value.map((v) => v.v);
+        }
+
         if (columnType === 'INTEGER') {
-          value = this.commaFormatted(value);
+          value = value.map((v) => this.commaFormatted(v));
         }
 
         if (columnType === 'FLOAT') {
-          value = this.significantDigits(value);
+          value = value.map((v) => this.significantDigits(v));
         }
 
         if (columnType === 'TIMESTAMP') {
-          value = new Date(value * 1000).toLocaleString();
+          value = value.map((v) => new Date(v * 1000).toLocaleString());
         }
       }
       if (columnId === 'datarepo_row_id') {


### PR DESCRIPTION
The behavior is mostly unchanged but now we:
- Don't distinct rows in the tables
- Show the array values.  Note: I built the display out of elements so that we could style more easily moving forward
- You can't sort of array values
- You currently can't filter or create snapshots using array filters.  Going to do that in a separate ticket.

Note: all values are now passed around as arrays but whether or not to display as an array is determined by the datatype returned by BigQuery.

Can you see which one is the array field :)
![image](https://user-images.githubusercontent.com/5633787/98596931-312ed380-22a6-11eb-9422-44adf097d519.png)
