### PR TITLE
Add multi-stage build for Dockerfile

### DIFF
--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -57,13 +57,6 @@ jobs:
         uses: "broadinstitute/github-action-get-previous-tag@master"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Build nmp build for new ui container
-        run: |
-          git pull
-          GCR_TAG=$(git rev-parse --short HEAD)
-          echo "GCR_TAG=$(echo ${GCR_TAG})" >> $GITHUB_ENV
-          npm ci
-          npm run-script build
       # Build the Docker image
       - name: Build docker container
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ RUN set -x \
   && git clone https://github.com/DataBiosphere/jade-data-repo-ui \
   && cd jade-data-repo-ui \
   && git checkout $(git describe --tags --abbrev=0) \
-  && npm install \
+  && npm ci \
   && npm run build --production
 
 FROM nginxinc/nginx-unprivileged:stable-alpine

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,10 @@
+FROM node:14
+RUN set -x \
+  && git clone https://github.com/DataBiosphere/jade-data-repo-ui \
+  && cd jade-data-repo-ui \
+  && git checkout $(git describe --tags --abbrev=0) \
+  && npm install \
+  && npm run build --production
+
 FROM nginxinc/nginx-unprivileged:stable-alpine
-COPY ./build /usr/share/nginx/html
+COPY --from=0 /jade-data-repo-ui/build /usr/share/nginx/html


### PR DESCRIPTION
Includes a build stage in the Dockerfile so a developer does not first need to manually build the jade-data-repo-ui. This will be useful for the appsec team when they implement the Trivy action.