### PR TITLE
[DR-1826] Add region to snapshot table

### DIFF
--- a/src/components/table/SnapshotTable.jsx
+++ b/src/components/table/SnapshotTable.jsx
@@ -48,10 +48,10 @@ class SnapshotTable extends React.PureComponent {
         render: (row) => moment(row.createdDate).fromNow(),
       },
       {
-        label: 'Storage',
+        label: 'Storage Regions',
         property: 'storage',
         render: (row) => Array.from(new Set(row.storage.map((s) => s.region))).join(', '),
-    },
+      },
     ];
     return (
       <div>

--- a/src/components/table/SnapshotTable.jsx
+++ b/src/components/table/SnapshotTable.jsx
@@ -47,6 +47,11 @@ class SnapshotTable extends React.PureComponent {
         property: 'created_date',
         render: (row) => moment(row.createdDate).fromNow(),
       },
+      {
+        label: 'Storage',
+        property: 'storage',
+        render: (row) => Array.from(new Set(row.storage.map((s) => s.region))).join(', '),
+    },
     ];
     return (
       <div>


### PR DESCRIPTION
### Home tab:
<img width="1098" alt="Screen Shot 2021-05-24 at 12 32 19 PM" src="https://user-images.githubusercontent.com/6414394/119378414-42609000-bc8c-11eb-9d49-0b78029c9525.png">


### Snapshots tab:
<img width="1100" alt="Screen Shot 2021-05-24 at 12 32 25 PM" src="https://user-images.githubusercontent.com/6414394/119378392-3bd21880-bc8c-11eb-862d-b06d8b259874.png">
