### PR TITLE
DR-1819 Correct the pagination to display accurate totals

### DIFF
--- a/src/components/DatasetView.jsx
+++ b/src/components/DatasetView.jsx
@@ -29,6 +29,7 @@ class DatasetView extends React.PureComponent {
     classes: PropTypes.object.isRequired,
     datasets: PropTypes.array.isRequired,
     datasetsCount: PropTypes.number,
+    filteredDatasetsCount: PropTypes.number,
     dispatch: PropTypes.func.isRequired,
     features: PropTypes.object,
   };
@@ -44,7 +45,7 @@ class DatasetView extends React.PureComponent {
   };
 
   render() {
-    const { classes, datasets, datasetsCount, features } = this.props;
+    const { classes, datasets, datasetsCount, filteredDatasetsCount, features } = this.props;
     return (
       <div className={classes.wrapper}>
         <div className={classes.width}>
@@ -56,6 +57,7 @@ class DatasetView extends React.PureComponent {
                 datasetsCount={datasetsCount}
                 features={features}
                 handleFilterDatasets={this.handleFilterDatasets}
+                filteredDatasetsCount={filteredDatasetsCount}
               />
             )}
           </div>
@@ -69,6 +71,7 @@ function mapStateToProps(state) {
   return {
     datasets: state.datasets.datasets,
     datasetsCount: state.datasets.datasetsCount,
+    filteredDatasetsCount: state.datasets.filteredDatasetsCount,
     features: state.user.features,
   };
 }

--- a/src/components/SnapshotView.jsx
+++ b/src/components/SnapshotView.jsx
@@ -30,6 +30,7 @@ class SnapshotView extends React.PureComponent {
     classes: PropTypes.object.isRequired,
     dispatch: PropTypes.func.isRequired,
     snapshotCount: PropTypes.number,
+    filteredSnapshotCount: PropTypes.number,
     snapshots: PropTypes.array.isRequired,
   };
 
@@ -46,7 +47,7 @@ class SnapshotView extends React.PureComponent {
   };
 
   render() {
-    const { classes, snapshotCount, snapshots } = this.props;
+    const { classes, snapshotCount, filteredSnapshotCount, snapshots } = this.props;
     return (
       <div id="snapshots" className={classes.wrapper}>
         <div className={classes.width}>
@@ -54,6 +55,7 @@ class SnapshotView extends React.PureComponent {
           <div>
             <SnapshotTable
               snapshotCount={snapshotCount}
+              filteredSnapshotCount={filteredSnapshotCount}
               snapshots={snapshots}
               handleFilterSnapshots={this.handleFilterSnapshots}
             />
@@ -69,6 +71,7 @@ function mapStateToProps(state) {
   return {
     snapshots: state.snapshots.snapshots,
     snapshotCount: state.snapshots.snapshotCount,
+    filteredSnapshotCount: state.snapshots.filteredSnapshotCount,
   };
 }
 

--- a/src/components/table/DatasetTable.jsx
+++ b/src/components/table/DatasetTable.jsx
@@ -21,6 +21,7 @@ class DatasetTable extends React.PureComponent {
     classes: PropTypes.object.isRequired,
     datasets: PropTypes.array.isRequired,
     datasetsCount: PropTypes.number,
+    filteredDatasetsCount: PropTypes.number,
     features: PropTypes.object,
     handleFilterDatasets: PropTypes.func,
     summary: PropTypes.bool,
@@ -31,6 +32,7 @@ class DatasetTable extends React.PureComponent {
       classes,
       datasets,
       datasetsCount,
+      filteredDatasetsCount,
       features,
       handleFilterDatasets,
       summary,
@@ -78,6 +80,7 @@ class DatasetTable extends React.PureComponent {
         rows={datasets}
         summary={summary}
         totalCount={datasetsCount}
+        filteredCount={filteredDatasetsCount}
       />
     );
   }

--- a/src/components/table/LightTable.jsx
+++ b/src/components/table/LightTable.jsx
@@ -86,6 +86,7 @@ export class LightTable extends React.PureComponent {
     rows: PropTypes.arrayOf(PropTypes.object),
     summary: PropTypes.bool,
     totalCount: PropTypes.number,
+    filteredCount: PropTypes.number,
   };
 
   handleRequestSort = (event, sort) => {
@@ -127,13 +128,22 @@ export class LightTable extends React.PureComponent {
   };
 
   render() {
-    const { classes, columns, itemType, rows, summary, totalCount, rowKey } = this.props;
+    const {
+      classes,
+      columns,
+      itemType,
+      rows,
+      summary,
+      totalCount,
+      filteredCount,
+      rowKey,
+    } = this.props;
     const { orderBy, orderDirection, page, rowsPerPage } = this.state;
     const ROW_HEIGHT = 50;
     const ROWS_PER_PAGE = [5, 10, 25];
     const emptyRows =
-      rowsPerPage < totalCount
-        ? rowsPerPage - Math.min(rowsPerPage, totalCount - page * rowsPerPage)
+      rowsPerPage < filteredCount
+        ? rowsPerPage - Math.min(rowsPerPage, filteredCount - page * rowsPerPage)
         : 0;
     return (
       <div>
@@ -186,11 +196,11 @@ export class LightTable extends React.PureComponent {
               )}
             </TableBody>
           </Table>
-          {!summary && rows && totalCount > rowsPerPage && (
+          {!summary && rows && filteredCount > rowsPerPage && (
             <TablePagination
               rowsPerPageOptions={ROWS_PER_PAGE}
               component="div"
-              count={totalCount}
+              count={filteredCount}
               rowsPerPage={rowsPerPage}
               page={page}
               backIconButtonProps={{
@@ -201,6 +211,12 @@ export class LightTable extends React.PureComponent {
               }}
               onChangePage={this.handleChangePage}
               onChangeRowsPerPage={this.handleChangeRowsPerPage}
+              labelDisplayedRows={({ from, to, count }) => {
+                if (count === totalCount) {
+                  return `${from}-${to} of ${count}`;
+                }
+                return `${from}-${to} of ${count} filtered, ${totalCount} total`;
+              }}
             />
           )}
         </Paper>

--- a/src/components/table/SnapshotTable.jsx
+++ b/src/components/table/SnapshotTable.jsx
@@ -21,12 +21,20 @@ class SnapshotTable extends React.PureComponent {
     classes: PropTypes.object.isRequired,
     handleFilterSnapshots: PropTypes.func,
     snapshotCount: PropTypes.number,
+    filteredSnapshotCount: PropTypes.number,
     snapshots: PropTypes.array.isRequired,
     summary: PropTypes.bool,
   };
 
   render() {
-    const { classes, handleFilterSnapshots, snapshotCount, snapshots, summary } = this.props;
+    const {
+      classes,
+      handleFilterSnapshots,
+      snapshotCount,
+      filteredSnapshotCount,
+      snapshots,
+      summary,
+    } = this.props;
     // TODO add back modified_date column
     const columns = [
       {
@@ -62,6 +70,7 @@ class SnapshotTable extends React.PureComponent {
           rows={snapshots}
           summary={summary}
           totalCount={snapshotCount}
+          filteredCount={filteredSnapshotCount}
         />
       </div>
     );

--- a/src/reducers/dataset.js
+++ b/src/reducers/dataset.js
@@ -17,6 +17,7 @@ export default {
         immutable(state, {
           datasets: { $set: action.datasets.data.data.items },
           datasetsCount: { $set: action.datasets.data.data.total },
+          filteredDatasetsCount: { $set: action.datasets.data.data.filteredTotal },
         }),
       [ActionTypes.GET_DATASET_BY_ID]: (state) =>
         immutable(state, {

--- a/src/reducers/snapshot.js
+++ b/src/reducers/snapshot.js
@@ -44,6 +44,7 @@ export default {
         immutable(state, {
           snapshots: { $set: action.snapshots.data.data.items },
           snapshotCount: { $set: action.snapshots.data.data.total },
+          filteredSnapshotCount: { $set: action.snapshots.data.data.filteredTotal },
         }),
       [ActionTypes.CREATE_SNAPSHOT_JOB]: (state) =>
         immutable(state, {


### PR DESCRIPTION
By including the filteredTotal as well as the total count for enumerate endpoints, the UI can tell users how many total elements there are, as well as how many match their filter. It also allows us to fix a bug in the pagination where the totals didn't add up.

<img width="1183" alt="Screen Shot 2021-06-23 at 4 06 10 PM" src="https://user-images.githubusercontent.com/3210510/123307357-67952800-d4f0-11eb-82e7-0577fc171489.png">
<img width="1205" alt="Screen Shot 2021-06-23 at 4 05 57 PM" src="https://user-images.githubusercontent.com/3210510/123307361-67952800-d4f0-11eb-9f16-eb4b51e1af67.png">

<img width="1107" alt="Screen Shot 2021-06-23 at 4 06 44 PM" src="https://user-images.githubusercontent.com/3210510/123307353-6663fb00-d4f0-11eb-8b0e-21892f532c0d.png">
<img width="1102" alt="Screen Shot 2021-06-23 at 4 06 25 PM" src="https://user-images.githubusercontent.com/3210510/123307356-66fc9180-d4f0-11eb-935e-cef85b886e96.png">