### PR TITLE
Bump node from 12.x to 14.x

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
     timeout-minutes: 180
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
     if: "!contains( github.event.pull_request.labels.*.name, 'skip-ci')"
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -27,7 +27,7 @@ jobs:
     timeout-minutes: 180
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
     if: "!contains( github.event.pull_request.labels.*.name, 'skip-ci')"
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Our dockerfile already uses node 14, and some of our dependencies are deprecating node 12. This bumps the actions to use node 14 as well.