### PR TITLE
DR-1843 Add Cloud Platform Column to datasets and snapshots

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jade-data-repo-ui",
-  "version": "0.76.0",
+  "version": "0.78.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/table/DatasetTable.jsx
+++ b/src/components/table/DatasetTable.jsx
@@ -71,6 +71,11 @@ class DatasetTable extends React.PureComponent {
         property: 'storage.array',
         render: (row) => Array.from(new Set(row.storage.map((s) => s.region))).join(', '),
       },
+      {
+        label: 'Cloud Platform',
+        property: 'storage.array',
+        render: (row) => Array.from(new Set(row.storage.map((s) => s.cloudPlatform))).join(', '),
+      },
     ];
     return (
       <LightTable

--- a/src/components/table/SnapshotTable.jsx
+++ b/src/components/table/SnapshotTable.jsx
@@ -60,6 +60,11 @@ class SnapshotTable extends React.PureComponent {
         property: 'storage',
         render: (row) => Array.from(new Set(row.storage.map((s) => s.region))).join(', '),
       },
+      {
+        label: 'Cloud Platform',
+        property: 'storage.array',
+        render: (row) => Array.from(new Set(row.storage.map((s) => s.cloudPlatform))).join(', '),
+      },
     ];
     return (
       <div>


### PR DESCRIPTION
Added Cloud Platform column in tables for datasets and snapshots.
![Screen Shot 2021-09-09 at 1 40 56 PM](https://user-images.githubusercontent.com/3210510/132735959-09a3929c-ff0a-42f3-b6a6-d028612babfe.png)
