### PR TITLE
[DR-2137] Check billing profile access when creating snapshots

### DIFF
--- a/cypress/integration/queryBuilder.spec.js
+++ b/cypress/integration/queryBuilder.spec.js
@@ -4,6 +4,7 @@ describe('test query builder', () => {
 
     cy.route('GET', 'api/repository/v1/datasets/**').as('getDataset');
     cy.route('GET', 'api/repository/v1/datasets/**/policies').as('getDatasetPolicies');
+    cy.route('GET', 'api/resources/v1/profiles/**').as('getBillingProfileById');
 
     cy.visit('/login/e2e');
     cy.get('#tokenInput').type(Cypress.env('GOOGLE_TOKEN'), {
@@ -17,7 +18,7 @@ describe('test query builder', () => {
     cy.contains('Date created').click();
     cy.contains(/V2F_GWAS_Summary_Stats|V2F_GWAS_Summary_Statistics/g).should('be.visible');
     cy.contains(/V2F_GWAS_Summary_Stats|V2F_GWAS_Summary_Statistics/g).click();
-    cy.wait(['@getDataset', '@getDatasetPolicies']);
+    cy.wait(['@getDataset', '@getDatasetPolicies', '@getBillingProfileById']);
   });
 
   it('does render', () => {});
@@ -30,7 +31,7 @@ describe('test query builder', () => {
 
     it('does show array values', () => {
       // Click the header to make sure we don't sort or trigger an error
-      cy.get(`[data-cy=columnheader-consequence_terms]`).click();
+      cy.get('[data-cy=columnheader-consequence_terms]').click();
 
       for (let i = 0; i < 100; i++) {
         cy.get(`[data-cy=cellvalue-consequence_terms-${i}]`).should(

--- a/cypress/integration/snapshotCreation.spec.js
+++ b/cypress/integration/snapshotCreation.spec.js
@@ -98,14 +98,14 @@ describe('test snapshot creation is disabled', () => {
     cy.route('GET', 'api/repository/v1/datasets/**').as('getDataset');
     cy.route('GET', 'api/repository/v1/datasets/**/policies').as('getDatasetPolicies');
     cy.route({
-          method: 'GET',
-          url: '/api/resources/v1/profiles/**',
-          status: 401,
-          response: {
-            message: 'unauthorized',
-            errorDetail: []
-          },
-        });
+      method: 'GET',
+      url: '/api/resources/v1/profiles/**',
+      status: 401,
+      response: {
+        message: 'unauthorized',
+        errorDetail: [],
+      },
+    });
 
     cy.visit('/login/e2e');
     cy.get('#tokenInput').type(Cypress.env('GOOGLE_TOKEN'), {

--- a/cypress/integration/snapshotCreation.spec.js
+++ b/cypress/integration/snapshotCreation.spec.js
@@ -4,7 +4,7 @@ describe('test snapshot creation', () => {
 
     cy.route('GET', 'api/repository/v1/datasets/**').as('getDataset');
     cy.route('GET', 'api/repository/v1/datasets/**/policies').as('getDatasetPolicies');
-    cy.route('GET', 'api/resources/v1/profiles/**').as('getBillingProfileById');
+    cy.route({ method: 'GET', url: 'api/resources/v1/profiles/**' }).as('getBillingProfileById');
     cy.route({
       method: 'POST',
       url: '/api/repository/v1/snapshots',
@@ -101,10 +101,6 @@ describe('test snapshot creation is disabled', () => {
       method: 'GET',
       url: '/api/resources/v1/profiles/**',
       status: 401,
-      response: {
-        message: 'unauthorized',
-        errorDetail: [],
-      },
     });
 
     cy.visit('/login/e2e');

--- a/cypress/integration/snapshotCreation.spec.js
+++ b/cypress/integration/snapshotCreation.spec.js
@@ -4,6 +4,7 @@ describe('test snapshot creation', () => {
 
     cy.route('GET', 'api/repository/v1/datasets/**').as('getDataset');
     cy.route('GET', 'api/repository/v1/datasets/**/policies').as('getDatasetPolicies');
+    cy.route('GET', 'api/resources/v1/profiles/**').as('getBillingProfileById');
     cy.route({
       method: 'POST',
       url: '/api/repository/v1/snapshots',
@@ -72,7 +73,7 @@ describe('test snapshot creation', () => {
     cy.contains('Date created').click();
     cy.contains(/V2F_GWAS_Summary_Stats|V2F_GWAS_Summary_Statistics/g).should('be.visible');
     cy.contains(/V2F_GWAS_Summary_Stats|V2F_GWAS_Summary_Statistics/g).click();
-    cy.wait(['@getDataset', '@getDatasetPolicies']);
+    cy.wait(['@getDataset', '@getDatasetPolicies', '@getBillingProfileById']);
   });
 
   it('opens modal', () => {
@@ -87,5 +88,41 @@ describe('test snapshot creation', () => {
     cy.get('[data-cy=snapshotName]').should('contain', 'mock_snapshot');
     cy.get('[data-cy=snapshotReaders]').should('contain', 'email@gmail.com');
     cy.url().should('include', '/snapshots');
+  });
+});
+
+describe('test snapshot creation is disabled', () => {
+  beforeEach(() => {
+    cy.server();
+
+    cy.route('GET', 'api/repository/v1/datasets/**').as('getDataset');
+    cy.route('GET', 'api/repository/v1/datasets/**/policies').as('getDatasetPolicies');
+    cy.route({
+          method: 'GET',
+          url: '/api/resources/v1/profiles/**',
+          status: 401,
+          response: {
+            message: 'unauthorized',
+            errorDetail: []
+          },
+        });
+
+    cy.visit('/login/e2e');
+    cy.get('#tokenInput').type(Cypress.env('GOOGLE_TOKEN'), {
+      log: false,
+      delay: 0,
+    });
+    cy.get('#e2eLoginButton').click();
+
+    cy.contains('See all Datasets').click();
+    cy.contains('Date created').click();
+    cy.contains(/V2F_GWAS_Summary_Stats|V2F_GWAS_Summary_Statistics/g).should('be.visible');
+    cy.contains(/V2F_GWAS_Summary_Stats|V2F_GWAS_Summary_Statistics/g).click();
+    cy.wait(['@getDataset', '@getDatasetPolicies']);
+  });
+
+  it('opens modal', () => {
+    cy.get('div.MuiButtonBase-root:nth-child(2) > svg:nth-child(1)').click();
+    cy.get('[data-cy=createSnapshot]').should('be.disabled');
   });
 });

--- a/cypress/integration/snapshotCreation.spec.js
+++ b/cypress/integration/snapshotCreation.spec.js
@@ -101,6 +101,9 @@ describe('test snapshot creation is disabled', () => {
       method: 'GET',
       url: '/api/resources/v1/profiles/**',
       status: 401,
+      response: {
+        message: "unauthorized"
+      }
     });
 
     cy.visit('/login/e2e');

--- a/cypress/integration/snapshotCreation.spec.js
+++ b/cypress/integration/snapshotCreation.spec.js
@@ -102,8 +102,8 @@ describe('test snapshot creation is disabled', () => {
       url: '/api/resources/v1/profiles/**',
       status: 401,
       response: {
-        message: "unauthorized"
-      }
+        message: 'unauthorized',
+      },
     });
 
     cy.visit('/login/e2e');

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -9,8 +9,8 @@ import { createActions } from 'redux-actions';
 import { ActionTypes } from 'constants/index';
 
 export const { getBillingProfileById } = createActions({
-   [ActionTypes.GET_BILLING_PROFILE_BY_ID]: (profile) => profile,
-   [ActionTypes.GET_BILLING_PROFILE_BY_ID_SUCCESS]: (profile) => profile,
+  [ActionTypes.GET_BILLING_PROFILE_BY_ID]: (profile) => profile,
+  [ActionTypes.GET_BILLING_PROFILE_BY_ID_SUCCESS]: (profile) => profile,
 });
 
 export const { createSnapshot } = createActions({

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -8,6 +8,11 @@ import { createActions } from 'redux-actions';
 
 import { ActionTypes } from 'constants/index';
 
+export const {getBillingProfileById} = createActions({
+   [ActionTypes.GET_BILLING_PROFILE_BY_ID]: (profile) => profile,
+   [ActionTypes.GET_BILLING_PROFILE_BY_ID_SUCCESS]: (profile) => profile,
+});
+
 export const { createSnapshot } = createActions({
   [ActionTypes.CREATE_SNAPSHOT]: () => ({}),
   [ActionTypes.CREATE_SNAPSHOT_JOB]: (snapshot) => snapshot,

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -8,7 +8,7 @@ import { createActions } from 'redux-actions';
 
 import { ActionTypes } from 'constants/index';
 
-export const {getBillingProfileById} = createActions({
+export const { getBillingProfileById } = createActions({
    [ActionTypes.GET_BILLING_PROFILE_BY_ID]: (profile) => profile,
    [ActionTypes.GET_BILLING_PROFILE_BY_ID_SUCCESS]: (profile) => profile,
 });

--- a/src/components/dataset/query/QueryView.jsx
+++ b/src/components/dataset/query/QueryView.jsx
@@ -65,6 +65,7 @@ export class QueryView extends React.PureComponent {
     orderBy: PropTypes.string,
     queryResults: PropTypes.object,
     profile: PropTypes.object,
+    table: PropTypes.object,
   };
 
   componentDidMount() {
@@ -141,7 +142,7 @@ export class QueryView extends React.PureComponent {
   };
 
   getPanels = () => {
-    const { table, dataset, profile } = this.props;
+    const { table, dataset } = this.props;
     const { canLink } = this.state;
     const panels = [
       {

--- a/src/components/dataset/query/QueryView.jsx
+++ b/src/components/dataset/query/QueryView.jsx
@@ -85,16 +85,7 @@ export class QueryView extends React.PureComponent {
     const { dataset, dispatch, filterStatement, joinStatement, orderBy, profile } = this.props;
     const { selected, canLink } = this.state;
 
-    if (
-      this.hasDataset() &&
-      dataset.defaultProfileId &&
-      canLink === false &&
-      Object.keys(prevProps.profile).length === 0
-    ) {
-      dispatch(getBillingProfileById(dataset.defaultProfileId));
-    }
-
-    if (profile.id && canLink === false) {
+    if (profile.id) {
       this.setState({ canLink: true });
     }
 

--- a/src/components/dataset/query/QueryView.jsx
+++ b/src/components/dataset/query/QueryView.jsx
@@ -84,7 +84,6 @@ export class QueryView extends React.PureComponent {
     if (datasetPolicies == null || dataset.id !== datasetId) {
       dispatch(getDatasetPolicy(datasetId));
     }
-
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -142,33 +141,33 @@ export class QueryView extends React.PureComponent {
   };
 
   getPanels = () => {
-  const { table, dataset, profile } = this.props;
-  const { canLink } = this.state;
-  const panels = [
-    {
-      icon: Info,
-      width: 800,
-      component: InfoView,
-      table,
-      dataset,
-    },
-    {
-      icon: FilterList,
-      width: 400,
-      component: QueryViewSidebar,
-      table,
-      dataset,
-    }]
+    const { table, dataset, profile } = this.props;
+    const { canLink } = this.state;
+    const panels = [
+      {
+        icon: Info,
+        width: 800,
+        component: InfoView,
+        table,
+        dataset,
+      },
+      {
+        icon: FilterList,
+        width: 400,
+        component: QueryViewSidebar,
+        table,
+        dataset,
+      },
+    ];
     if (canLink) {
-      panels.push(
-       {
-         icon: People,
-         width: 600,
-         component: ShareSnapshot,
-         table,
-         dataset,
-        });
-    };
+      panels.push({
+        icon: People,
+        width: 600,
+        component: ShareSnapshot,
+        table,
+        dataset,
+      });
+    }
     return panels;
   };
 
@@ -227,7 +226,7 @@ function mapStateToProps(state) {
     queryResults: state.query.queryResults,
     orderBy: state.query.orderBy,
     profile: state.profiles.profile,
-    canLink: state.canLink
+    canLink: state.canLink,
   };
 }
 

--- a/src/components/dataset/query/QueryView.jsx
+++ b/src/components/dataset/query/QueryView.jsx
@@ -10,7 +10,6 @@ import {
   getDatasetById,
   getDatasetPolicy,
   countResults,
-  getBillingProfileById,
 } from 'actions/index';
 import { Typography } from '@material-ui/core';
 import { FilterList, Info, People } from '@material-ui/icons';
@@ -83,7 +82,7 @@ export class QueryView extends React.PureComponent {
 
   componentDidUpdate(prevProps, prevState) {
     const { dataset, dispatch, filterStatement, joinStatement, orderBy, profile } = this.props;
-    const { selected, canLink } = this.state;
+    const { selected } = this.state;
 
     if (profile.id) {
       this.setState({ canLink: true });

--- a/src/components/dataset/query/QueryView.jsx
+++ b/src/components/dataset/query/QueryView.jsx
@@ -224,7 +224,6 @@ function mapStateToProps(state) {
     queryResults: state.query.queryResults,
     orderBy: state.query.orderBy,
     profile: state.profiles.profile,
-    canLink: state.canLink,
   };
 }
 

--- a/src/components/dataset/query/QueryView.jsx
+++ b/src/components/dataset/query/QueryView.jsx
@@ -69,27 +69,34 @@ export class QueryView extends React.PureComponent {
   };
 
   componentDidMount() {
-    const { dispatch, match, dataset, datasetPolicies, profile } = this.props;
+    const { dispatch, match, dataset, datasetPolicies } = this.props;
     const datasetId = match.params.uuid;
 
     if (dataset == null || dataset.id !== datasetId) {
       dispatch(getDatasetById(datasetId));
     }
 
-    if (dataset != null && dataset.defaultProfileId) {
-      dispatch(getBillingProfileById(dataset.defaultProfileId));
-      if (profile) {
-        this.setState({ canLink: true });
-      }
-    }
     if (datasetPolicies == null || dataset.id !== datasetId) {
       dispatch(getDatasetPolicy(datasetId));
     }
   }
 
   componentDidUpdate(prevProps, prevState) {
-    const { dataset, dispatch, filterStatement, joinStatement, orderBy } = this.props;
-    const { selected } = this.state;
+    const { dataset, dispatch, filterStatement, joinStatement, orderBy, profile } = this.props;
+    const { selected, canLink } = this.state;
+
+    if (
+      this.hasDataset() &&
+      dataset.defaultProfileId &&
+      canLink === false &&
+      Object.keys(prevProps.profile).length === 0
+    ) {
+      dispatch(getBillingProfileById(dataset.defaultProfileId));
+    }
+
+    if (profile.id && canLink === false) {
+      this.setState({ canLink: true });
+    }
 
     if (
       this.hasDataset() &&

--- a/src/components/dataset/query/sidebar/QueryViewSidebar.jsx
+++ b/src/components/dataset/query/sidebar/QueryViewSidebar.jsx
@@ -16,6 +16,7 @@ export class QueryViewSidebar extends React.PureComponent {
     selected: PropTypes.string,
     switchPanels: PropTypes.func,
     table: PropTypes.object,
+    canLink: PropTypes.bool,
   };
 
   handleCreateSnapshot = (isSavingSnapshot) => {
@@ -23,13 +24,14 @@ export class QueryViewSidebar extends React.PureComponent {
   };
 
   render() {
-    const { open, table, selected, switchPanels } = this.props;
+    const { open, table, selected, switchPanels, canLink } = this.props;
     const { isSavingSnapshot } = this.state;
 
     return (
       <div>
         {!isSavingSnapshot ? (
           <FilterPanel
+            canLink={canLink}
             open={open}
             table={table}
             selected={selected}

--- a/src/components/dataset/query/sidebar/SidebarDrawer.jsx
+++ b/src/components/dataset/query/sidebar/SidebarDrawer.jsx
@@ -54,12 +54,13 @@ export class SidebarDrawer extends React.PureComponent {
   }
 
   static propTypes = {
+    canLink: PropTypes.bool,
     classes: PropTypes.object,
     handleDrawerWidth: PropTypes.func,
     panels: PropTypes.array,
     selected: PropTypes.string,
-    width: PropTypes.number,
     table: PropTypes.object,
+    width: PropTypes.number,
   };
 
   handleOpenPanel = (InputPanelComponent) => {
@@ -77,7 +78,7 @@ export class SidebarDrawer extends React.PureComponent {
   };
 
   render() {
-    const { panels, classes, table, selected } = this.props;
+    const { panels, classes, table, selected, canLink } = this.props;
     const { PanelComponent } = this.state;
     const open = PanelComponent !== null;
     return (
@@ -99,6 +100,7 @@ export class SidebarDrawer extends React.PureComponent {
         >
           {PanelComponent != null && (
             <PanelComponent
+              canLink={canLink}
               open={open}
               table={table}
               selected={selected}

--- a/src/components/dataset/query/sidebar/panels/FilterPanel.jsx
+++ b/src/components/dataset/query/sidebar/panels/FilterPanel.jsx
@@ -172,7 +172,7 @@ export class FilterPanel extends React.PureComponent {
     const { searchString, openFilter } = this.state;
     const filteredColumns = table.columns.filter((column) => column.name.includes(searchString));
     const billingErrorMessage =
-      'You cannot create a snapshot because you do not have access to the dataset billing profile.';
+      'You cannot create a snapshot because you do not have access to the dataset\'s billing profile.';
 
     return (
       <div className={classes.root}>

--- a/src/components/dataset/query/sidebar/panels/FilterPanel.jsx
+++ b/src/components/dataset/query/sidebar/panels/FilterPanel.jsx
@@ -31,7 +31,6 @@ const styles = (theme) => ({
   },
   snapshotBtnCntnr: {
     textAlign: 'end',
-    paddingTop: theme.spacing(1),
   },
   panelContent: {
     padding: `0px ${theme.spacing(2)}px`,
@@ -66,6 +65,13 @@ const styles = (theme) => ({
   tooltip: {
     pointerEvents: 'auto !important',
     color: 'red',
+  },
+  button: {
+    backgroundColor: theme.palette.common.link,
+    color: theme.palette.common.white,
+    '&:hover': {
+      backgroundColor: theme.palette.common.link,
+    },
   },
 });
 
@@ -233,7 +239,7 @@ export class FilterPanel extends React.PureComponent {
             className={clsx({
               [classes.hide]: !open,
               [classes.tooltip]: _.isEmpty(dataset.schema.assets),
-            })}
+            }, classes.button)}
             onClick={() => handleCreateSnapshot(true)}
             data-cy="createSnapshot"
           >

--- a/src/components/dataset/query/sidebar/panels/FilterPanel.jsx
+++ b/src/components/dataset/query/sidebar/panels/FilterPanel.jsx
@@ -11,7 +11,6 @@ import QueryViewSidebarItem from '../QueryViewSidebarItem';
 import QuerySidebarPanel from '../QuerySidebarPanel';
 import { applyFilters } from '../../../../../actions';
 
-
 const styles = (theme) => ({
   root: {
     margin: theme.spacing(1),
@@ -168,11 +167,12 @@ export class FilterPanel extends React.PureComponent {
       joinStatement,
       selected,
       handleCreateSnapshot,
-      canLink
+      canLink,
     } = this.props;
     const { searchString, openFilter } = this.state;
     const filteredColumns = table.columns.filter((column) => column.name.includes(searchString));
-    const billingErrorMessage = "You cannot create a snapshot because you do not have access to the dataset billing profile.";
+    const billingErrorMessage =
+      'You cannot create a snapshot because you do not have access to the dataset billing profile.';
 
     return (
       <div className={classes.root}>
@@ -231,22 +231,25 @@ export class FilterPanel extends React.PureComponent {
         </div>
         <div className={clsx(classes.rowTwo, classes.snapshotBtnCntnr)}>
           <Tooltip
-            title={canLink? "": billingErrorMessage}>
-          <span>
-          <Button
-            variant="contained"
-            disabled={_.isEmpty(dataset.schema.assets) || !canLink}
-            className={clsx({
-              [classes.hide]: !open,
-              [classes.tooltip]: _.isEmpty(dataset.schema.assets),
-            }, classes.button)}
-            onClick={() => handleCreateSnapshot(true)}
-            data-cy="createSnapshot"
-          >
-            Create Snapshot
-          </Button>
-          </span>
-        </Tooltip>
+title={canLink ? '' : billingErrorMessage}>
+            <span>
+              <Button
+                variant="contained"
+                disabled={_.isEmpty(dataset.schema.assets) || !canLink}
+                className={clsx(
+                  {
+                    [classes.hide]: !open,
+                    [classes.tooltip]: _.isEmpty(dataset.schema.assets),
+                  },
+                  classes.button,
+                )}
+                onClick={() => handleCreateSnapshot(true)}
+                data-cy="createSnapshot"
+              >
+                Create Snapshot
+              </Button>
+            </span>
+          </Tooltip>
         </div>
       </div>
     );

--- a/src/components/dataset/query/sidebar/panels/FilterPanel.jsx
+++ b/src/components/dataset/query/sidebar/panels/FilterPanel.jsx
@@ -85,6 +85,7 @@ export class FilterPanel extends React.PureComponent {
   }
 
   static propTypes = {
+    canLink: PropTypes.bool,
     classes: PropTypes.object,
     dataset: PropTypes.object,
     dispatch: PropTypes.func.isRequired,
@@ -96,7 +97,6 @@ export class FilterPanel extends React.PureComponent {
     selected: PropTypes.string,
     table: PropTypes.object,
     token: PropTypes.string,
-    canLink: PropTypes.bool,
   };
 
   UNSAFE_componentWillReceiveProps(nextProps) {
@@ -230,8 +230,7 @@ export class FilterPanel extends React.PureComponent {
             ))}
         </div>
         <div className={clsx(classes.rowTwo, classes.snapshotBtnCntnr)}>
-          <Tooltip
-title={canLink ? '' : billingErrorMessage}>
+          <Tooltip title={canLink ? '' : billingErrorMessage}>
             <span>
               <Button
                 variant="contained"

--- a/src/components/dataset/query/sidebar/panels/FilterPanel.jsx
+++ b/src/components/dataset/query/sidebar/panels/FilterPanel.jsx
@@ -172,7 +172,7 @@ export class FilterPanel extends React.PureComponent {
     const { searchString, openFilter } = this.state;
     const filteredColumns = table.columns.filter((column) => column.name.includes(searchString));
     const billingErrorMessage =
-      'You cannot create a snapshot because you do not have access to the dataset\'s billing profile.';
+      "You cannot create a snapshot because you do not have access to the dataset's billing profile.";
 
     return (
       <div className={classes.root}>

--- a/src/components/dataset/query/sidebar/panels/FilterPanel.jsx
+++ b/src/components/dataset/query/sidebar/panels/FilterPanel.jsx
@@ -4,11 +4,14 @@ import clsx from 'clsx';
 import { connect } from 'react-redux';
 import { withStyles } from '@material-ui/core/styles';
 import PropTypes from 'prop-types';
+import Tooltip from '@material-ui/core/Tooltip';
 import { Box, Typography, Button, Grid, InputBase, ListItem, Collapse } from '@material-ui/core';
 import { ExpandMore, ExpandLess, Search } from '@material-ui/icons';
 import QueryViewSidebarItem from '../QueryViewSidebarItem';
 import QuerySidebarPanel from '../QuerySidebarPanel';
 import { applyFilters } from '../../../../../actions';
+import { getBillingProfileById } from 'actions/index';
+
 
 const styles = (theme) => ({
   root: {
@@ -74,6 +77,7 @@ export class FilterPanel extends React.PureComponent {
       filterMap: {},
       searchString: '',
       openFilter: {},
+      canLink: true
     };
   }
 
@@ -89,7 +93,18 @@ export class FilterPanel extends React.PureComponent {
     selected: PropTypes.string,
     table: PropTypes.object,
     token: PropTypes.string,
+    profile: PropTypes.object
   };
+
+  componentDidMount() {
+    const { dispatch, dataset, profile } = this.props;
+    dispatch(getBillingProfileById(dataset.defaultBillingProfile));
+    if (!profile) {
+      this.setState({ canLink: false });
+    } else {
+      handleCreateSnapshot(true)
+    }
+  }
 
   UNSAFE_componentWillReceiveProps(nextProps) {
     const { filterMap } = this.state;
@@ -160,8 +175,9 @@ export class FilterPanel extends React.PureComponent {
       selected,
       handleCreateSnapshot,
     } = this.props;
-    const { searchString, openFilter } = this.state;
+    const { searchString, openFilter, canLink } = this.state;
     const filteredColumns = table.columns.filter((column) => column.name.includes(searchString));
+    const billingErrorMessage = "You cannot create a snapshot because you do not have access to the dataset billing profile.";
 
     return (
       <div className={classes.root}>
@@ -219,9 +235,12 @@ export class FilterPanel extends React.PureComponent {
             ))}
         </div>
         <div className={clsx(classes.rowTwo, classes.snapshotBtnCntnr)}>
+          <Tooltip
+            title={canLink? "": billingErrorMessage}>
+          <span>
           <Button
             variant="contained"
-            disabled={_.isEmpty(dataset.schema.assets)}
+            disabled={_.isEmpty(dataset.schema.assets) || !canLink}
             className={clsx({
               [classes.hide]: !open,
               [classes.tooltip]: _.isEmpty(dataset.schema.assets),
@@ -231,6 +250,8 @@ export class FilterPanel extends React.PureComponent {
           >
             Create Snapshot
           </Button>
+          </span>
+        </Tooltip>
         </div>
       </div>
     );

--- a/src/components/dataset/query/sidebar/panels/FilterPanel.jsx
+++ b/src/components/dataset/query/sidebar/panels/FilterPanel.jsx
@@ -10,7 +10,6 @@ import { ExpandMore, ExpandLess, Search } from '@material-ui/icons';
 import QueryViewSidebarItem from '../QueryViewSidebarItem';
 import QuerySidebarPanel from '../QuerySidebarPanel';
 import { applyFilters } from '../../../../../actions';
-import { getBillingProfileById } from 'actions/index';
 
 
 const styles = (theme) => ({
@@ -77,7 +76,6 @@ export class FilterPanel extends React.PureComponent {
       filterMap: {},
       searchString: '',
       openFilter: {},
-      canLink: true
     };
   }
 
@@ -93,18 +91,8 @@ export class FilterPanel extends React.PureComponent {
     selected: PropTypes.string,
     table: PropTypes.object,
     token: PropTypes.string,
-    profile: PropTypes.object
+    canLink: PropTypes.bool,
   };
-
-  componentDidMount() {
-    const { dispatch, dataset, profile } = this.props;
-    dispatch(getBillingProfileById(dataset.defaultBillingProfile));
-    if (!profile) {
-      this.setState({ canLink: false });
-    } else {
-      handleCreateSnapshot(true)
-    }
-  }
 
   UNSAFE_componentWillReceiveProps(nextProps) {
     const { filterMap } = this.state;
@@ -174,8 +162,9 @@ export class FilterPanel extends React.PureComponent {
       joinStatement,
       selected,
       handleCreateSnapshot,
+      canLink
     } = this.props;
-    const { searchString, openFilter, canLink } = this.state;
+    const { searchString, openFilter } = this.state;
     const filteredColumns = table.columns.filter((column) => column.name.includes(searchString));
     const billingErrorMessage = "You cannot create a snapshot because you do not have access to the dataset billing profile.";
 

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -45,6 +45,8 @@ export const ActionTypes = keyMirror({
   ADD_CUSTODIAN_TO_DATASET_SUCCESS: undefined,
   REMOVE_CUSTODIAN_FROM_DATASET: undefined,
   REMOVE_CUSTODIAN_FROM_DATASET_SUCCESS: undefined,
+  GET_BILLING_PROFILE_BY_ID: undefined,
+  GET_BILLING_PROFILE_BY_ID_SUCCESS: undefined,
   GET_JOB_RESULT: undefined,
   GET_JOB_RESULT_SUCCESS: undefined,
   GET_JOB_RESULT_FAILURE: undefined,

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -15,5 +15,5 @@ export default {
   ...configuration,
   ...query,
   ...status,
-  ...profile
+  ...profile,
 };

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -5,6 +5,7 @@ import job from './job';
 import configuration from './configuration';
 import query from './query';
 import status from './status';
+import profile from './profile';
 
 export default {
   ...user,
@@ -14,4 +15,5 @@ export default {
   ...configuration,
   ...query,
   ...status,
+  ...profile
 };

--- a/src/reducers/profile.js
+++ b/src/reducers/profile.js
@@ -1,0 +1,26 @@
+import { handleActions } from 'redux-actions';
+import immutable from 'immutability-helper';
+
+import { ActionTypes } from 'constants/index';
+
+export const profileState = {
+  profiles: [],
+  profile: {},
+};
+
+export default {
+  profiles: handleActions(
+    {
+      [ActionTypes.GET_BILLING_PROFILE_BY_ID]: (state) =>
+        immutable(state, {
+          profile: {},
+        }),
+      [ActionTypes.GET_BILLING_PROFILE_BY_ID_SUCCESS]: (state, action) =>
+        immutable(state, {
+          profile: { $set: action.profile.data.data },
+        }),
+      [ActionTypes.USER_LOGOUT]: () => profileState,
+    },
+    profileState,
+  ),
+};

--- a/src/sagas/repository.js
+++ b/src/sagas/repository.js
@@ -348,14 +348,6 @@ export function* getDatasetTablePreview({ payload }) {
 /**
  * billing profile
  */
-export function* watchRequests() {
-  const requestChan = yield actionChannel(ActionTypes.GET_DATASET_BY_ID_SUCCESS);
-  while (true) {
-    const {dataset} = yield take(requestChan);
-    yield call(getBillingProfileById, dataset.data.data.defaultProfileId);
-  }
-}
-
 export function* getBillingProfileById(profileId) {
   try {
     const response = yield call(authGet, `/api/resources/v1/profiles/${profileId}`);
@@ -368,6 +360,14 @@ export function* getBillingProfileById(profileId) {
       type: ActionTypes.EXCEPTION,
       profile: null,
     });
+  }
+}
+
+export function* watchRequests() {
+  const requestChan = yield actionChannel(ActionTypes.GET_DATASET_BY_ID_SUCCESS);
+  while (true) {
+    const { dataset } = yield take(requestChan);
+    yield call(getBillingProfileById, dataset.data.data.defaultProfileId);
   }
 }
 

--- a/src/sagas/repository.js
+++ b/src/sagas/repository.js
@@ -363,7 +363,7 @@ export function* getBillingProfileById(profileId) {
   }
 }
 
-export function* watchRequests() {
+export function* watchGetDatasetByIdSuccess() {
   const requestChan = yield actionChannel(ActionTypes.GET_DATASET_BY_ID_SUCCESS);
   while (true) {
     const { dataset } = yield take(requestChan);
@@ -502,6 +502,6 @@ export default function* root() {
     takeLatest(ActionTypes.COUNT_RESULTS, countResults),
     takeLatest(ActionTypes.GET_FEATURES, getFeatures),
     takeLatest(ActionTypes.GET_BILLING_PROFILE_BY_ID, getBillingProfileById),
-    fork(watchRequests),
+    fork(watchGetDatasetByIdSuccess),
   ]);
 }

--- a/src/sagas/repository.js
+++ b/src/sagas/repository.js
@@ -346,6 +346,24 @@ export function* getDatasetTablePreview({ payload }) {
 }
 
 /**
+ * billing profile
+ */
+export function* getBillingProfileById({ payload }) {
+  const profileId = payload;
+  try {
+    const response = yield call(authGet, `/api/repository/v1/profiles/${profileId}`);
+    yield put({
+      type: ActionTypes.GET_BILLING_PROFILE_BY_ID_SUCCESS,
+      profile: { data: response },
+    });
+  } catch (err) {
+    yield put({
+      type: ActionTypes.EXCEPTION
+    });
+  }
+}
+
+/**
  * bigquery
  */
 
@@ -475,5 +493,6 @@ export default function* root() {
     takeLatest(ActionTypes.PAGE_QUERY, pageQuery),
     takeLatest(ActionTypes.COUNT_RESULTS, countResults),
     takeLatest(ActionTypes.GET_FEATURES, getFeatures),
+    takeLatest(ActionTypes.GET_BILLING_PROFILE_BY_ID, getBillingProfileById)
   ]);
 }

--- a/src/sagas/repository.js
+++ b/src/sagas/repository.js
@@ -359,6 +359,7 @@ export function* getBillingProfileById({ payload }) {
   } catch (err) {
     yield put({
       type: ActionTypes.EXCEPTION,
+      profile: null,
     });
   }
 }

--- a/src/sagas/repository.js
+++ b/src/sagas/repository.js
@@ -351,14 +351,14 @@ export function* getDatasetTablePreview({ payload }) {
 export function* getBillingProfileById({ payload }) {
   const profileId = payload;
   try {
-    const response = yield call(authGet, `/api/repository/v1/profiles/${profileId}`);
+    const response = yield call(authGet, `/api/resources/v1/profiles/${profileId}`);
     yield put({
       type: ActionTypes.GET_BILLING_PROFILE_BY_ID_SUCCESS,
       profile: { data: response },
     });
   } catch (err) {
     yield put({
-      type: ActionTypes.EXCEPTION
+      type: ActionTypes.EXCEPTION,
     });
   }
 }
@@ -493,6 +493,6 @@ export default function* root() {
     takeLatest(ActionTypes.PAGE_QUERY, pageQuery),
     takeLatest(ActionTypes.COUNT_RESULTS, countResults),
     takeLatest(ActionTypes.GET_FEATURES, getFeatures),
-    takeLatest(ActionTypes.GET_BILLING_PROFILE_BY_ID, getBillingProfileById)
+    takeLatest(ActionTypes.GET_BILLING_PROFILE_BY_ID, getBillingProfileById),
   ]);
 }


### PR DESCRIPTION
**Changes:**
1. "Create snapshot" is disabled and the "share" panel is not displayed if the logged in user does not have GET access to the billing profile:
<img width="453" alt="Screen Shot 2021-10-07 at 6 09 39 PM" src="https://user-images.githubusercontent.com/6414394/136582491-ecb337d3-5b8d-4b98-9fdd-9f1cfe7936d4.png">

 
2. "Create snapshot" button is blue when activated
<img width="455" alt="Screen Shot 2021-10-07 at 6 07 30 PM" src="https://user-images.githubusercontent.com/6414394/136582322-1ab4466a-808d-4507-af76-c5e75c443ddd.png">
 