### PR TITLE
[DR-2152] Add export snapshot link

### DIFF
--- a/cypress/integration/snapshotCreation.spec.js
+++ b/cypress/integration/snapshotCreation.spec.js
@@ -86,6 +86,13 @@ describe('test snapshot creation', () => {
 
     cy.get('[data-cy=snapshotName]').should('contain', 'mock_snapshot');
     cy.get('[data-cy=snapshotReaders]').should('contain', 'email@gmail.com');
+    cy.get('[data-cy=exportSnapshot]').within(() => {
+      cy.get('a').should(
+        'have.attr',
+        'href',
+        'https://bvdp-saturn-dev.appspot.com/#import-data?url=http://local.broadinstitute.org:3000&snapshotId=snapshotId&snapshotName=mock_snapshot&format=snapshot',
+      );
+    });
     cy.url().should('include', '/snapshots');
   });
 });

--- a/cypress/integration/snapshotCreation.spec.js
+++ b/cypress/integration/snapshotCreation.spec.js
@@ -86,13 +86,14 @@ describe('test snapshot creation', () => {
 
     cy.get('[data-cy=snapshotName]').should('contain', 'mock_snapshot');
     cy.get('[data-cy=snapshotReaders]').should('contain', 'email@gmail.com');
-    cy.get('[data-cy=exportSnapshot]').within(() => {
-      cy.get('a').should(
-        'have.attr',
-        'href',
-        'https://bvdp-saturn-dev.appspot.com/#import-data?url=http://local.broadinstitute.org:3000&snapshotId=snapshotId&snapshotName=mock_snapshot&format=snapshot',
-      );
+
+    const terraUrl = 'https://bvdp-saturn-dev.appspot.com';
+    cy.window().then((w) => {
+      const exportUrl = `${terraUrl}/#import-data?url=${w.location.origin}&snapshotId=snapshotId&snapshotName=mock_snapshot&format=snapshot`;
+      cy.get('[data-cy=exportSnapshot]').within(() => {
+        cy.get('a').should('have.attr', 'href', exportUrl);
+      });
+      cy.url().should('include', '/snapshots');
     });
-    cy.url().should('include', '/snapshots');
   });
 });

--- a/src/components/snapshot/SnapshotPopup.jsx
+++ b/src/components/snapshot/SnapshotPopup.jsx
@@ -13,7 +13,7 @@ import {
   Chip,
   CircularProgress,
 } from '@material-ui/core';
-import { CameraAlt, Edit, PeopleAlt, OpenInNew, Today } from '@material-ui/icons';
+import { CameraAlt, Edit, PeopleAlt, Today } from '@material-ui/icons';
 import clsx from 'clsx';
 import { openSnapshotDialog, getSnapshotById, getSnapshotPolicy } from 'actions/index';
 import { push } from 'modules/hist';
@@ -66,6 +66,7 @@ export class SnapshotPopup extends React.PureComponent {
     isOpen: PropTypes.bool,
     policies: PropTypes.arrayOf(PropTypes.object),
     snapshot: PropTypes.object,
+    terraUrl: PropTypes.string,
   };
 
   /**
@@ -89,7 +90,7 @@ export class SnapshotPopup extends React.PureComponent {
   };
 
   render() {
-    const { classes, filterData, isOpen, snapshot, policies } = this.props;
+    const { classes, filterData, isOpen, snapshot, policies, terraUrl } = this.props;
 
     const notReady = _.some([snapshot, policies, snapshot.source, snapshot.tables], _.isEmpty);
     if (notReady) {
@@ -196,9 +197,14 @@ export class SnapshotPopup extends React.PureComponent {
               <PeopleAlt className={classes.inline} />
               Share
             </Button>
-            <Button color="primary">
-              <OpenInNew className={classes.inline} />
-              Export
+            <Button color="primary" data-cy="exportSnapshot">
+              <a
+                target="_blank"
+                rel="noopener noreferrer"
+                href={`${terraUrl}/#import-data?url=${window.location.origin}&snapshotId=${snapshot.id}&snapshotName=${snapshot.name}&format=snapshot`}
+              >
+                Export
+              </a>
             </Button>
           </div>
         </DialogContent>
@@ -213,6 +219,7 @@ function mapStateToProps(state) {
     filterData: state.query.filterData,
     snapshot: state.snapshots.snapshot,
     policies: state.snapshots.snapshotPolicies,
+    terraUrl: state.configuration.terraUrl,
   };
 }
 


### PR DESCRIPTION
Add a link to the "export" button in the pop-up that appears after a successful snapshot create. This is the same link that is on the snapshot detail page.