### PR TITLE
DR-2341 Update table stylings to more closely match Terra UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jade-data-repo-ui",
-  "version": "0.90.0",
+  "version": "0.93.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2963,12 +2963,6 @@
             "node-releases": "^1.1.66"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001159",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001159.tgz",
-          "integrity": "sha512-w9Ph56jOsS8RL20K9cLND3u/+5WASWdhC/PPrf+V3/HsM3uHOavWOR1Xzakbv4Puo/srmPHudkmCRWM7Aq+/UA==",
-          "dev": true
-        },
         "electron-to-chromium": {
           "version": "1.3.602",
           "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.602.tgz",
@@ -5510,9 +5504,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001123",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001123.tgz",
-      "integrity": "sha512-03dJDoa4YC4332jq0rqwiM+Hw6tA5RJtrnZKvOQy7ASoIUv8CinkcmGhYpCvCjedvkBQrrKnkcELxrUSW/XwNQ=="
+      "version": "1.0.30001298",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001298.tgz",
+      "integrity": "sha512-AcKqikjMLlvghZL/vfTHorlQsLDhGRalYf1+GmWCf5SCMziSGjRYQW/JEksj14NaYHIR6KIhrFAy0HV5C25UzQ=="
     },
     "capture-exit": {
       "version": "2.0.0",

--- a/src/components/table/DatasetTable.jsx
+++ b/src/components/table/DatasetTable.jsx
@@ -12,6 +12,8 @@ const styles = (theme) => ({
   },
 });
 
+const cloudPlatforms = {'gcp': 'Google Cloud Platform', 'azure': 'Microsoft Azure'}
+
 class DatasetTable extends React.PureComponent {
   static propTypes = {
     classes: PropTypes.object.isRequired,
@@ -70,7 +72,10 @@ class DatasetTable extends React.PureComponent {
       {
         label: 'Cloud Platform',
         property: 'platorm',
-        render: (row) => Array.from(new Set(row.storage.map((s) => s.cloudPlatform))).join(', '),
+        render: (row) =>
+          <div>
+            {Array.from(new Set(row.storage.map((s) => cloudPlatforms[s.cloudPlatform]))).map(c => <div>{c}</div>)}
+          </div>,
       },
     ];
     return (

--- a/src/components/table/DatasetTable.jsx
+++ b/src/components/table/DatasetTable.jsx
@@ -12,7 +12,7 @@ const styles = (theme) => ({
   },
 });
 
-const cloudPlatforms = {'gcp': 'Google Cloud Platform', 'azure': 'Microsoft Azure'}
+const cloudPlatforms = { gcp: 'Google Cloud Platform', azure: 'Microsoft Azure' };
 
 class DatasetTable extends React.PureComponent {
   static propTypes = {
@@ -72,10 +72,15 @@ class DatasetTable extends React.PureComponent {
       {
         label: 'Cloud Platform',
         property: 'platorm',
-        render: (row) =>
+        render: (row) => (
           <div>
-            {Array.from(new Set(row.storage.map((s) => cloudPlatforms[s.cloudPlatform]))).map(c => <div>{c}</div>)}
-          </div>,
+            {Array.from(new Set(row.storage.map((s) => cloudPlatforms[s.cloudPlatform]))).map(
+              (c) => (
+                <div>{c}</div>
+              ),
+            )}
+          </div>
+        ),
       },
     ];
     return (

--- a/src/components/table/LightTable.jsx
+++ b/src/components/table/LightTable.jsx
@@ -31,18 +31,18 @@ const styles = (theme) => ({
     borderRadius: `${theme.shape.borderRadius}px ${theme.shape.borderRadius}px 0 0`,
   },
   evenRow: {
-    backgroundColor: 'white',
+    backgroundColor: theme.palette.lightTable.callBackgroundLight,
   },
   oddRow: {
-    backgroundColor: 'rgba(233,236,239,0.4)',
+    backgroundColor: theme.palette.lightTable.cellBackgroundDark,
   },
   paginationButton: {
     borderRadius: `${theme.shape.borderRadius}px`,
     margin: '0px 2px',
     transition: null,
     padding: '0.25rem',
-    border: '1px solid #4d72aa',
-    color: '#4d72aa',
+    border: `1px solid ${theme.palette.lightTable.paginationBlue}`,
+    color: theme.palette.lightTable.paginationBlue,
   },
   search: {
     height: 45,

--- a/src/components/table/LightTable.jsx
+++ b/src/components/table/LightTable.jsx
@@ -11,11 +11,12 @@ import InputBase from '@material-ui/core/InputBase';
 import SearchIcon from '@material-ui/icons/Search';
 import { fade } from '@material-ui/core/styles/colorManipulator';
 
+import clsx from 'clsx';
 import LightTableHead from './LightTableHead';
 
 const styles = (theme) => ({
   root: {
-    border: '1px solid #e8eaeb',
+    border: `1px solid ${theme.palette.lightTable.borderColor}`,
     borderRadius: `${theme.shape.borderRadius}px ${theme.shape.borderRadius}px 0 0`,
     boxShadow: 'none',
     marginTop: theme.spacing(3),
@@ -30,10 +31,10 @@ const styles = (theme) => ({
   row: {
     borderRadius: `${theme.shape.borderRadius}px ${theme.shape.borderRadius}px 0 0`,
   },
-  evenRow: {
+  lightRow: {
     backgroundColor: theme.palette.lightTable.callBackgroundLight,
   },
-  oddRow: {
+  darkRow: {
     backgroundColor: theme.palette.lightTable.cellBackgroundDark,
   },
   paginationButton: {
@@ -186,18 +187,25 @@ export class LightTable extends React.PureComponent {
             />
             <TableBody>
               {rows && rows.length > 0 ? (
-                rows.map((row, index) => (
-                  <TableRow
-                    key={rowKey ? rowKey(row) : row.id}
-                    className={`${classes.row} ${index % 2 ? classes.oddRow : classes.evenRow}`}
-                  >
-                    {columns.map((col) => (
-                      <TableCell key={col.property} style={{ wordBreak: 'break-word' }}>
-                        {col.render ? col.render(row) : row[col.property]}
-                      </TableCell>
-                    ))}
-                  </TableRow>
-                ))
+                rows.map((row, index) => {
+                  const darkRow = index % 2 !== 0;
+                  return (
+                    <TableRow
+                      key={rowKey ? rowKey(row) : row.id}
+                      className={clsx({
+                        [classes.row]: true,
+                        [classes.darkRow]: darkRow,
+                        [classes.lightRow]: !darkRow,
+                      })}
+                    >
+                      {columns.map((col) => (
+                        <TableCell key={col.property} style={{ wordBreak: 'break-word' }}>
+                          {col.render ? col.render(row) : row[col.property]}
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                  );
+                })
               ) : (
                 <TableRow className={classes.row}>
                   <TableCell colSpan={columns.length}>

--- a/src/components/table/LightTable.jsx
+++ b/src/components/table/LightTable.jsx
@@ -15,7 +15,7 @@ import LightTableHead from './LightTableHead';
 
 const styles = (theme) => ({
   root: {
-    border: `1px solid ${theme.palette.primary.dark}`,
+    border: `1px solid #e8eaeb`,
     borderRadius: `${theme.shape.borderRadius}px ${theme.shape.borderRadius}px 0 0`,
     boxShadow: 'none',
     marginTop: theme.spacing(3),
@@ -29,6 +29,20 @@ const styles = (theme) => ({
   },
   row: {
     borderRadius: `${theme.shape.borderRadius}px ${theme.shape.borderRadius}px 0 0`,
+  },
+  evenRow: {
+    backgroundColor: 'white',
+  },
+  oddRow: {
+    backgroundColor : 'rgba(233,236,239,0.4)'
+  },
+  paginationButton:{
+    borderRadius: `${theme.shape.borderRadius}px`,
+    margin: '0px 2px',
+    transition: null,
+    padding: '0.25rem',
+    border: '1px solid #4d72aa',
+    color: '#4d72aa',
   },
   search: {
     height: 45,
@@ -172,8 +186,9 @@ export class LightTable extends React.PureComponent {
             />
             <TableBody>
               {rows && rows.length > 0 ? (
-                rows.map((row) => (
-                  <TableRow key={rowKey ? rowKey(row) : row.id} className={classes.row}>
+                rows.map((row, index) => (
+                  <TableRow key={rowKey ? rowKey(row) : row.id}
+                            className={`${classes.row} ${index % 2 ? classes.oddRow : classes.evenRow}`}>
                     {columns.map((col) => (
                       <TableCell key={col.property} style={{ wordBreak: 'break-word' }}>
                         {col.render ? col.render(row) : row[col.property]}
@@ -204,9 +219,17 @@ export class LightTable extends React.PureComponent {
               page={page}
               backIconButtonProps={{
                 'aria-label': 'Previous Page',
+                disableTouchRipple: true,
+                disableFocusRipple: true,
+                disableRipple: true,
+                className: classes.paginationButton,
               }}
               nextIconButtonProps={{
                 'aria-label': 'Next Page',
+                disableTouchRipple: true,
+                disableFocusRipple: true,
+                disableRipple: true,
+                className: classes.paginationButton,
               }}
               onChangePage={this.handleChangePage}
               onChangeRowsPerPage={this.handleChangeRowsPerPage}

--- a/src/components/table/LightTable.jsx
+++ b/src/components/table/LightTable.jsx
@@ -15,7 +15,7 @@ import LightTableHead from './LightTableHead';
 
 const styles = (theme) => ({
   root: {
-    border: `1px solid #e8eaeb`,
+    border: '1px solid #e8eaeb',
     borderRadius: `${theme.shape.borderRadius}px ${theme.shape.borderRadius}px 0 0`,
     boxShadow: 'none',
     marginTop: theme.spacing(3),
@@ -34,9 +34,9 @@ const styles = (theme) => ({
     backgroundColor: 'white',
   },
   oddRow: {
-    backgroundColor : 'rgba(233,236,239,0.4)'
+    backgroundColor: 'rgba(233,236,239,0.4)',
   },
-  paginationButton:{
+  paginationButton: {
     borderRadius: `${theme.shape.borderRadius}px`,
     margin: '0px 2px',
     transition: null,
@@ -187,8 +187,10 @@ export class LightTable extends React.PureComponent {
             <TableBody>
               {rows && rows.length > 0 ? (
                 rows.map((row, index) => (
-                  <TableRow key={rowKey ? rowKey(row) : row.id}
-                            className={`${classes.row} ${index % 2 ? classes.oddRow : classes.evenRow}`}>
+                  <TableRow
+                    key={rowKey ? rowKey(row) : row.id}
+                    className={`${classes.row} ${index % 2 ? classes.oddRow : classes.evenRow}`}
+                  >
                     {columns.map((col) => (
                       <TableCell key={col.property} style={{ wordBreak: 'break-word' }}>
                         {col.render ? col.render(row) : row[col.property]}

--- a/src/components/table/LightTableHead.jsx
+++ b/src/components/table/LightTableHead.jsx
@@ -21,7 +21,7 @@ const styles = (theme) => ({
     fontWeight: 600,
     letterSpacing: 0,
     lineHeight: '16px',
-    border: `1px solid ${theme.palette.lightTable.cellBorderColor}`,
+    border: `1px solid ${theme.palette.lightTable.borderColor}`,
   },
 });
 

--- a/src/components/table/LightTableHead.jsx
+++ b/src/components/table/LightTableHead.jsx
@@ -11,7 +11,7 @@ import { Sort } from '@material-ui/icons';
 const styles = (theme) => ({
   head: {
     color: theme.palette.primary.dark,
-    backgroundColor: 'rgba(233,236,239,0.4)',
+    backgroundColor: theme.palette.lightTable.cellBackgroundDark,
     fontFamily: theme.typography.fontFamily,
   },
   cell: {
@@ -21,7 +21,7 @@ const styles = (theme) => ({
     fontWeight: 600,
     letterSpacing: 0,
     lineHeight: '16px',
-    border: `1px solid #e8eaeb`,
+    border: `1px solid ${theme.palette.lightTable.cellBorderColor}`,
   },
 });
 

--- a/src/components/table/LightTableHead.jsx
+++ b/src/components/table/LightTableHead.jsx
@@ -6,17 +6,22 @@ import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 import Tooltip from '@material-ui/core/Tooltip';
 import TableSortLabel from '@material-ui/core/TableSortLabel';
+import {Sort} from "@material-ui/icons";
 
 const styles = (theme) => ({
   head: {
     color: theme.palette.primary.dark,
-    backgroundColor: theme.palette.primary.light,
+    backgroundColor: 'rgba(233,236,239,0.4)',
     fontFamily: theme.typography.fontFamily,
   },
   cell: {
     color: theme.palette.secondary.dark,
     minWidth: 200,
-    fontWeight: 500,
+    fontSize: '14px',
+    fontWeight: 600,
+    letterSpacing: 0,
+    lineHeight: '16px',
+    border: `1px solid #e8eaeb`
   },
 });
 
@@ -53,19 +58,23 @@ export class LightTableHead extends React.PureComponent {
                 {summary ? (
                   col.label
                 ) : (
-                  <Tooltip
-                    title="Sort"
-                    placement={col.numeric ? 'bottom-end' : 'bottom-start'}
-                    enterDelay={300}
-                  >
-                    <TableSortLabel
-                      active={orderBy === col.property}
-                      direction={orderDirection}
-                      onClick={this.createSortHandler(col.property)}
+                  <div>
+                    {col.label}
+                    <Tooltip
+                      title="Sort"
+                      placement={col.numeric ? 'bottom-end' : 'bottom-start'}
+                      enterDelay={300}
                     >
-                      {col.label}
-                    </TableSortLabel>
-                  </Tooltip>
+                      <TableSortLabel
+                        active={orderBy === col.property}
+                        direction={orderDirection}
+                        onClick={this.createSortHandler(col.property)}
+                        IconComponent={Sort}
+                        style={{float: 'right'}}
+                      >
+                      </TableSortLabel>
+                    </Tooltip>
+                  </div>
                 )}
               </TableCell>
             ),

--- a/src/components/table/LightTableHead.jsx
+++ b/src/components/table/LightTableHead.jsx
@@ -6,7 +6,7 @@ import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 import Tooltip from '@material-ui/core/Tooltip';
 import TableSortLabel from '@material-ui/core/TableSortLabel';
-import {Sort} from "@material-ui/icons";
+import Sort from '@material-ui/icons';
 
 const styles = (theme) => ({
   head: {
@@ -21,7 +21,7 @@ const styles = (theme) => ({
     fontWeight: 600,
     letterSpacing: 0,
     lineHeight: '16px',
-    border: `1px solid #e8eaeb`
+    border: `1px solid #e8eaeb`,
   },
 });
 
@@ -70,9 +70,8 @@ export class LightTableHead extends React.PureComponent {
                         direction={orderDirection}
                         onClick={this.createSortHandler(col.property)}
                         IconComponent={Sort}
-                        style={{float: 'right'}}
-                      >
-                      </TableSortLabel>
+                        style={{ float: 'right' }}
+                      />
                     </Tooltip>
                   </div>
                 )}

--- a/src/components/table/LightTableHead.jsx
+++ b/src/components/table/LightTableHead.jsx
@@ -6,7 +6,7 @@ import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 import Tooltip from '@material-ui/core/Tooltip';
 import TableSortLabel from '@material-ui/core/TableSortLabel';
-import Sort from '@material-ui/icons';
+import { Sort } from '@material-ui/icons';
 
 const styles = (theme) => ({
   head: {

--- a/src/modules/theme.js
+++ b/src/modules/theme.js
@@ -89,6 +89,12 @@ export default createMuiTheme({
       linkHover: LINK_HOVER,
       selection: '#99CCFF',
     },
+    lightTable: {
+      cellBackgroundDark: 'rgba(233,236,239,0.4)',
+      callBackgroundLight: 'white',
+      cellBorderColor: '#E8EAEB',
+      paginationBlue: '#4D72AA'
+    },
     primary: {
       main: '#81AB52',
       contrastText: '#FFFFFF',

--- a/src/modules/theme.js
+++ b/src/modules/theme.js
@@ -92,7 +92,7 @@ export default createMuiTheme({
     lightTable: {
       cellBackgroundDark: 'rgba(233,236,239,0.4)',
       callBackgroundLight: 'white',
-      cellBorderColor: '#E8EAEB',
+      borderColor: '#E8EAEB',
       paginationBlue: '#4D72AA',
     },
     primary: {

--- a/src/modules/theme.js
+++ b/src/modules/theme.js
@@ -93,7 +93,7 @@ export default createMuiTheme({
       cellBackgroundDark: 'rgba(233,236,239,0.4)',
       callBackgroundLight: 'white',
       cellBorderColor: '#E8EAEB',
-      paginationBlue: '#4D72AA'
+      paginationBlue: '#4D72AA',
     },
     primary: {
       main: '#81AB52',

--- a/src/modules/theme.js
+++ b/src/modules/theme.js
@@ -138,6 +138,11 @@ export default createMuiTheme({
         },
       },
     },
+    MuiTablePagination: {
+      actions: {
+        marginRight: '20px',
+      },
+    },
   },
   mixins: {
     jadeLink: {


### PR DESCRIPTION
Updated table stylings to be more in-line with Terra's based on [Lou's design](https://projects.invisionapp.com/share/KQ124BKIZGC6#/screens/461773905). I wasn't able to get all the way there, due to some limitations of MaterialUI, but its pretty close, save the pagination icons and layout. 

<img width="1669" alt="image" src="https://user-images.githubusercontent.com/3210510/149216398-62f9f172-d048-44ba-a97a-d862696f357d.png">
