### PR TITLE
DR-2433 Add checkbox to UI for enabling pre-resolve DRS urls on export

### DIFF
--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -23,7 +23,7 @@ export const { createSnapshot } = createActions({
 });
 
 export const { exportSnapshot } = createActions({
-  [ActionTypes.EXPORT_SNAPSHOT]: (snapshotId) => ({ snapshotId }),
+  [ActionTypes.EXPORT_SNAPSHOT]: (snapshotId, exportGsPaths) => ({ snapshotId, exportGsPaths }),
   [ActionTypes.EXPORT_SNAPSHOT_START]: () => ({}),
   [ActionTypes.EXPORT_SNAPSHOT_JOB]: (exportResponse) => exportResponse,
   [ActionTypes.EXPORT_SNAPSHOT_SUCCESS]: (exportResponse) => exportResponse,

--- a/src/components/DetailViewHeader.jsx
+++ b/src/components/DetailViewHeader.jsx
@@ -5,7 +5,18 @@ import moment from 'moment';
 import { withStyles } from '@material-ui/core/styles';
 import { exportSnapshot, resetSnapshotExport } from 'actions/index';
 import { connect } from 'react-redux';
-import { Card, Grid, Typography, Button, CircularProgress, Divider } from '@material-ui/core';
+import {
+  Card,
+  Grid,
+  Typography,
+  Button,
+  CircularProgress,
+  Divider,
+  Checkbox,
+  FormGroup,
+  FormControlLabel,
+  FormHelperText,
+} from '@material-ui/core';
 import { Launch } from '@material-ui/icons';
 import UserList from './UserList';
 import TerraTooltip from './common/TerraTooltip';
@@ -48,6 +59,13 @@ const styles = (theme) => ({
 });
 
 export class DetailViewHeader extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {
+      exportGsPaths: false,
+    };
+  }
+
   static propTypes = {
     addReader: PropTypes.func,
     addSteward: PropTypes.func,
@@ -69,12 +87,20 @@ export class DetailViewHeader extends React.PureComponent {
 
   exportToWorkspaceCopy = () => {
     const { dispatch, of } = this.props;
-    dispatch(exportSnapshot(of.id));
+    const { exportGsPaths } = this.state;
+    dispatch(exportSnapshot(of.id, exportGsPaths));
   };
 
   resetExport = () => {
     const { dispatch } = this.props;
     dispatch(resetSnapshotExport());
+  };
+
+  handleExportGsPathsChanged = () => {
+    const { exportGsPaths } = this.state;
+    this.setState({
+      exportGsPaths: !exportGsPaths,
+    });
   };
 
   render() {
@@ -95,6 +121,7 @@ export class DetailViewHeader extends React.PureComponent {
       userRoles,
       user,
     } = this.props;
+    const { exportGsPaths } = this.state;
     const loading = _.isNil(of) || _.isEmpty(of);
     const canManageUsers = userRoles.includes(SNAPSHOT_ROLES.STEWARD);
 
@@ -174,8 +201,21 @@ export class DetailViewHeader extends React.PureComponent {
             )}
             <Divider className={classes.separator} />
             <Typography variant="h6" className={classes.section}>
-              Export a copy of the snapshot metadata to an exisiting or new Terra workspace
+              Export a copy of the snapshot metadata to an existing or new Terra workspace
             </Typography>
+            <FormGroup>
+              <FormControlLabel
+                control={
+                  <Checkbox checked={exportGsPaths} onChange={this.handleExportGsPathsChanged} />
+                }
+                label="Convert DRS URLs to Google gs-paths"
+              />
+              <FormHelperText>
+                <i>
+                  <b>Note: </b> gs-paths can change over time
+                </i>
+              </FormHelperText>
+            </FormGroup>
             {!isProcessing && !isDone && (
               <TerraTooltip title="Exporting a snapshot to a workspace means that all members of your workspace will be able to have read only access to the tables and files in the snapshot">
                 <Button

--- a/src/components/DetailViewHeader.jsx
+++ b/src/components/DetailViewHeader.jsx
@@ -129,6 +129,11 @@ export class DetailViewHeader extends React.PureComponent {
     const consoleLink = linkToBq
       ? `${of.accessInformation.bigQuery.link}&authuser=${user?.email}`
       : '';
+    const gsPathsCheckbox = !isProcessing ? (
+      <Checkbox checked={exportGsPaths} onChange={this.handleExportGsPathsChanged} />
+    ) : (
+      <Checkbox checked={exportGsPaths} disabled />
+    );
 
     return (
       <Grid container wrap="nowrap" spacing={2}>
@@ -205,9 +210,7 @@ export class DetailViewHeader extends React.PureComponent {
             </Typography>
             <FormGroup>
               <FormControlLabel
-                control={
-                  <Checkbox checked={exportGsPaths} onChange={this.handleExportGsPathsChanged} />
-                }
+                control={gsPathsCheckbox}
                 label="Convert DRS URLs to Google gs-paths"
               />
               <FormHelperText>

--- a/src/components/DetailViewHeader.jsx
+++ b/src/components/DetailViewHeader.jsx
@@ -211,7 +211,7 @@ export class DetailViewHeader extends React.PureComponent {
             <FormGroup>
               <FormControlLabel
                 control={gsPathsCheckbox}
-                label="Convert DRS URLs to Google gs-paths"
+                label="Convert DRS URLs to Google Cloud Storage Paths (gs://...)"
               />
               <FormHelperText>
                 <i>

--- a/src/sagas/repository.js
+++ b/src/sagas/repository.js
@@ -108,8 +108,11 @@ export function* exportSnapshot({ payload }) {
     yield put({
       type: ActionTypes.EXPORT_SNAPSHOT_START,
     });
-    const snapshotId = payload.snapshotId;
-    const response = yield call(authGet, `/api/repository/v1/snapshots/${snapshotId}/export`);
+    const { snapshotId, exportGsPaths } = payload;
+    const response = yield call(
+      authGet,
+      `/api/repository/v1/snapshots/${snapshotId}/export?exportGsPaths=${exportGsPaths}`,
+    );
     const jobId = response.data.id;
     yield put({
       type: ActionTypes.EXPORT_SNAPSHOT_JOB,


### PR DESCRIPTION
Checkbox has been added to allow users to pre-resolve DRS URIs to gs paths on snapshot export. The UI now sends a `exportGsPaths` URL parameter in its snapshot export request. This can be changed to be part of a post body if needed, but I think a URL param makes sense.