### PR TITLE
DR-2419 Specify dataset columns in order rather than selecting all

### DIFF
--- a/src/components/dataset/query/QueryView.jsx
+++ b/src/components/dataset/query/QueryView.jsx
@@ -120,7 +120,7 @@ export class QueryView extends React.PureComponent {
         runQuery(
           dataset.dataProject,
           `#standardSQL
-          SELECT ${selected}.* ${fromClause}
+          SELECT ${this.getSelectColumns()} ${fromClause}
           ${orderBy}
           LIMIT ${QUERY_LIMIT}`,
           PAGE_SIZE,
@@ -134,6 +134,14 @@ export class QueryView extends React.PureComponent {
         ),
       );
     }
+  }
+
+  getSelectColumns() {
+    const { dataset } = this.props;
+    const { selected } = this.state;
+    const { tables } = dataset.schema;
+    const selectedTable = tables.find((table) => table.name === selected);
+    return `datarepo_row_id, ${selectedTable.columns.map((column) => column.name).join(', ')}`;
   }
 
   hasDataset() {


### PR DESCRIPTION
The UI portion of https://broadworkbench.atlassian.net/browse/DR-2419 making sure that the UI displays dataset columns in the order they were returned by the API.