### PR TITLE
DR-2457 Fix BigQuery CORS errors

### DIFF
--- a/Dockerfile.direct
+++ b/Dockerfile.direct
@@ -1,8 +1,8 @@
 FROM node:14
 COPY . /
-RUN set -x \
-  && npm ci \
-  && npm run build --production
+
+RUN npm ci
+RUN npm run build --production
 
 FROM nginxinc/nginx-unprivileged:stable-alpine
 COPY --from=0 /build /usr/share/nginx/html

--- a/cypress/integration/errors.spec.js
+++ b/cypress/integration/errors.spec.js
@@ -28,8 +28,6 @@ describe('test error handling', () => {
       },
     }).as('getQueryResults');
 
-    cy.get('a > .MuiButtonBase-root').click();
-
     cy.wait(['@getDataset', '@getDatasetPolicies', '@getQueryResults']);
     cy.contains('Error 401: This is the reason for the error').should('be.visible');
   });
@@ -45,8 +43,6 @@ describe('test error handling', () => {
       },
     }).as('getQueryResults');
 
-    cy.get('a > .MuiButtonBase-root').click();
-
     cy.wait(['@getDataset', '@getDatasetPolicies', '@getQueryResults']);
     cy.contains('Error 401: Was not able to query').should('be.visible');
   });
@@ -60,8 +56,6 @@ describe('test error handling', () => {
         message: 'Was not able to query',
       },
     }).as('getQueryResults');
-
-    cy.get('a > .MuiButtonBase-root').click();
 
     cy.wait(['@getDataset', '@getDatasetPolicies', '@getQueryResults']);
     cy.contains('Error 401: Was not able to query').should('be.visible');
@@ -80,8 +74,6 @@ describe('test error handling', () => {
       status: 200,
       response: { jobComplete: false, jobReference: { jobId: 'jobId' } },
     }).as('getQueryJobResults');
-
-    cy.get('a > .MuiButtonBase-root').click();
 
     cy.wait(['@getDataset', '@getDatasetPolicies', '@getQueryResults', '@getQueryJobResults']);
     cy.contains(

--- a/cypress/integration/errors.spec.js
+++ b/cypress/integration/errors.spec.js
@@ -20,13 +20,16 @@ describe('test error handling', () => {
   it('displays error toasts with error detail', () => {
     cy.route({
       method: 'POST',
-      url: 'https://bigquery.googleapis.com/bigquery/v2/projects/**/queries',
+      url: 'bigquery/v2/projects/**/queries',
       status: 401,
       response: {
         message: 'Was not able to query',
         errorDetail: ['This is the reason for the error'],
       },
     }).as('getQueryResults');
+
+    cy.get('a > .MuiButtonBase-root').click();
+
     cy.wait(['@getDataset', '@getDatasetPolicies', '@getQueryResults']);
     cy.contains('Error 401: This is the reason for the error').should('be.visible');
   });
@@ -34,13 +37,16 @@ describe('test error handling', () => {
   it('displays error toasts with empty error detail', () => {
     cy.route({
       method: 'POST',
-      url: 'https://bigquery.googleapis.com/bigquery/v2/projects/**/queries',
+      url: 'bigquery/v2/projects/**/queries',
       status: 401,
       response: {
         message: 'Was not able to query',
         errorDetail: [],
       },
     }).as('getQueryResults');
+
+    cy.get('a > .MuiButtonBase-root').click();
+
     cy.wait(['@getDataset', '@getDatasetPolicies', '@getQueryResults']);
     cy.contains('Error 401: Was not able to query').should('be.visible');
   });
@@ -48,12 +54,15 @@ describe('test error handling', () => {
   it('displays error toasts with no error detail', () => {
     cy.route({
       method: 'POST',
-      url: 'https://bigquery.googleapis.com/bigquery/v2/projects/**/queries',
+      url: 'bigquery/v2/projects/**/queries',
       status: 401,
       response: {
         message: 'Was not able to query',
       },
     }).as('getQueryResults');
+
+    cy.get('a > .MuiButtonBase-root').click();
+
     cy.wait(['@getDataset', '@getDatasetPolicies', '@getQueryResults']);
     cy.contains('Error 401: Was not able to query').should('be.visible');
   });
@@ -61,16 +70,19 @@ describe('test error handling', () => {
   it('displays loading message', () => {
     cy.route({
       method: 'POST',
-      url: 'https://bigquery.googleapis.com/bigquery/v2/projects/*/queries',
+      url: 'bigquery/v2/projects/*/queries',
       status: 200,
       response: { jobComplete: false, jobReference: { jobId: 'jobId' } },
     }).as('getQueryResults');
     cy.route({
       method: 'GET',
-      url: 'https://bigquery.googleapis.com/bigquery/v2/projects/*/queries/jobId',
+      url: 'bigquery/v2/projects/*/queries/jobId',
       status: 200,
       response: { jobComplete: false, jobReference: { jobId: 'jobId' } },
     }).as('getQueryJobResults');
+
+    cy.get('a > .MuiButtonBase-root').click();
+
     cy.wait(['@getDataset', '@getDatasetPolicies', '@getQueryResults', '@getQueryJobResults']);
     cy.contains(
       'For large datasets, it can take a few minutes to fetch results from BigQuery. Thank you for your patience.',

--- a/src/modules/bigquery.js
+++ b/src/modules/bigquery.js
@@ -136,7 +136,7 @@ export default class BigQuery {
   buildOrderBy = (property, direction) => (property ? `ORDER BY ${property} ${direction}` : '');
 
   getColumnMinMax = (columnName, dataset, tableName, token) => {
-    const url = `https://bigquery.googleapis.com/bigquery/v2/projects/${dataset.dataProject}/queries`;
+    const url = `/bigquery/v2/projects/${dataset.dataProject}/queries`;
     const query = `SELECT MIN(${columnName}) AS min, MAX(${columnName}) AS max FROM \`${dataset.dataProject}.datarepo_${dataset.name}.${tableName}\``;
 
     return axios
@@ -157,7 +157,7 @@ export default class BigQuery {
   };
 
   getColumnDistinct = (columnName, dataset, tableName, token, filterStatement, joinStatement) => {
-    const url = `https://bigquery.googleapis.com/bigquery/v2/projects/${dataset.dataProject}/queries`;
+    const url = `/bigquery/v2/projects/${dataset.dataProject}/queries`;
     const query = `SELECT ${tableName}.${columnName}, COUNT(*) FROM \`${dataset.dataProject}.datarepo_${dataset.name}.${tableName}\` AS ${tableName} ${joinStatement} ${filterStatement} GROUP BY ${tableName}.${columnName}`;
     return axios
       .post(
@@ -185,7 +185,7 @@ export default class BigQuery {
     filterStatement,
     joinStatement,
   ) => {
-    const url = `https://bigquery.googleapis.com/bigquery/v2/projects/${dataset.dataProject}/queries`;
+    const url = `/bigquery/v2/projects/${dataset.dataProject}/queries`;
     const filterOrEmpty = _.isEmpty(filterStatement)
       ? `WHERE ${columnName} LIKE '%${currText}%'`
       : `${filterStatement} AND ${columnName} LIKE '%${currText}%'`;

--- a/src/sagas/repository.js
+++ b/src/sagas/repository.js
@@ -439,8 +439,7 @@ export function* getDatasetTablePreview({ payload }) {
   const { dataset, tableName } = payload;
   const datasetProject = dataset.dataProject;
   const datasetBqSnapshotName = `datarepo_${dataset.name}`;
-  const bqApi = 'https://www.googleapis.com/bigquery/v2';
-  const url = `${bqApi}/projects/${datasetProject}/datasets/${datasetBqSnapshotName}/tables/${tableName}/data`;
+  const url = `/bigquery/v2/projects/${datasetProject}/datasets/${datasetBqSnapshotName}/tables/${tableName}/data`;
   try {
     const response = yield call(authGet, `${url}?maxResults=100`);
     yield put({
@@ -485,7 +484,7 @@ export function* watchGetDatasetByIdSuccess() {
 
 function* pollQuery(projectId, jobId) {
   try {
-    const url = `https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/queries/${jobId}`;
+    const url = `/bigquery/v2/projects/${projectId}/queries/${jobId}`;
     const response = yield call(authGet, url);
     const { jobComplete } = response.data;
     if (jobComplete) {
@@ -504,7 +503,7 @@ function* pollQuery(projectId, jobId) {
 
 export function* runQuery({ payload }) {
   try {
-    const url = `https://bigquery.googleapis.com/bigquery/v2/projects/${payload.projectId}/queries`;
+    const url = `/bigquery/v2/projects/${payload.projectId}/queries`;
     const body = {
       query: payload.query,
       maxResults: payload.maxResults,
@@ -531,7 +530,7 @@ export function* runQuery({ payload }) {
 
 export function* pageQuery({ payload }) {
   try {
-    const url = `https://bigquery.googleapis.com/bigquery/v2/projects/${payload.projectId}/queries/${payload.jobId}`;
+    const url = `/bigquery/v2/projects/${payload.projectId}/queries/${payload.jobId}`;
     const params = {
       maxResults: payload.pageSize,
       pageToken: payload.pageToken,
@@ -550,7 +549,7 @@ export function* pageQuery({ payload }) {
 
 export function* countResults({ payload }) {
   try {
-    const url = `https://bigquery.googleapis.com/bigquery/v2/projects/${payload.projectId}/queries`;
+    const url = `/bigquery/v2/projects/${payload.projectId}/queries`;
     const body = {
       query: payload.query,
     };

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -1,6 +1,7 @@
 const { createProxyMiddleware } = require('http-proxy-middleware');
 
 const proxyUrl = process.env.PROXY_URL || 'http://localhost:8080';
+const bigQueryApi = 'https://bigquery.googleapis.com';
 
 module.exports = (app) => {
   app.use(
@@ -21,6 +22,13 @@ module.exports = (app) => {
     '/status',
     createProxyMiddleware({
       target: proxyUrl,
+      changeOrigin: true,
+    }),
+  );
+  app.use(
+    '/bigquery',
+    createProxyMiddleware({
+      target: bigQueryApi,
       changeOrigin: true,
     }),
   );


### PR DESCRIPTION
By routing requests through the UI layer, we can avoid the `OPTIONS` XHR pre-flight requests for CORS. It appears that BigQuery has stopped supporting this `OPTIONS` request. This PR will need to wait until the apache proxy has been updated to route these requests.