### PR TITLE
Remove e2e cypress recording

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -110,7 +110,7 @@ jobs:
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
         run: |
-          npx cypress run --record
+          npx cypress run
       - name: 'Clean state lock from used Namespace on API deploy'
         if: always()
         uses: broadinstitute/datarepo-actions/actions/main@0.59.0


### PR DESCRIPTION
Testing out if removing the recording functionality from the e2e tests speeds things up. Our tests currently take 30 minutes on github runners, but much much less time locally. The recording functionality is one of the main differences, and the recordings from github runners are not really of much use anyways. 