### PR TITLE
[DR-2568] Test fixing java install error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,7 @@ FROM node:14.0-buster
 
 # Install java to run codegen
 RUN apt-get update && \
-    apt-get install -y software-properties-common && \
-    apt-get update && \
-    apt-get install -y openjdk-11-jdk
+    apt-get install -y software-properties-common openjdk-11-jre
 
 RUN set -x \
   && git clone https://github.com/DataBiosphere/jade-data-repo-ui \
@@ -14,7 +12,7 @@ RUN set -x \
   && npm run build --production
 
 # Uninstall java
-RUN apt purge -y openjdk-11-jdk
+RUN apt purge -y openjdk-11-jre
 
 FROM us.gcr.io/broad-dsp-gcr-public/base/nginx:stable-alpine
 COPY --from=0 /jade-data-repo-ui/build /usr/share/nginx/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
-FROM node:14
+FROM node:14.0-buster
 
 # Install java to run codegen
 RUN apt-get update && \
     apt-get install -y software-properties-common && \
-    add-apt-repository ppa:openjdk-r/ppa && \
     apt-get update && \
-    apt-get install -y default-jre
+    apt-get install -y openjdk-11-jdk
 
 RUN set -x \
   && git clone https://github.com/DataBiosphere/jade-data-repo-ui \
@@ -15,7 +14,7 @@ RUN set -x \
   && npm run build --production
 
 # Uninstall java
-RUN apt purge -y default-jre
+RUN apt purge -y openjdk-11-jdk
 
 FROM us.gcr.io/broad-dsp-gcr-public/base/nginx:stable-alpine
 COPY --from=0 /jade-data-repo-ui/build /usr/share/nginx/html

--- a/Dockerfile.direct
+++ b/Dockerfile.direct
@@ -2,9 +2,7 @@ FROM node:14.0-buster
 
 # Install java to run codegen
 RUN apt-get update && \
-    apt-get install -y software-properties-common && \
-    apt-get update && \
-    apt-get install -y openjdk-11-jdk
+    apt-get install -y software-properties-common openjdk-11-jre
 
 COPY . /
 
@@ -12,7 +10,7 @@ RUN npm ci && \
   npm run build --production
 
 # Uninstall java
-RUN apt purge -y default-jre
+RUN apt purge -y openjdk-11-jre
 
 FROM nginxinc/nginx-unprivileged:stable-alpine
 COPY --from=0 /build /usr/share/nginx/html

--- a/Dockerfile.direct
+++ b/Dockerfile.direct
@@ -1,11 +1,10 @@
-FROM node:14
+FROM node:14.0-buster
 
 # Install java to run codegen
 RUN apt-get update && \
     apt-get install -y software-properties-common && \
-    add-apt-repository ppa:openjdk-r/ppa && \
     apt-get update && \
-    apt-get install -y default-jre
+    apt-get install -y openjdk-11-jdk
 
 COPY . /
 


### PR DESCRIPTION
Installing OpenJDK 11 fails because it is looking for an Ubuntu distribution ("kinetic") that does not exist in https://launchpad.net/~openjdk-r/+archive/ubuntu/ppa.

This changes the base image from one that uses Debian 9 to Debian 10 (which includes OpenJDK 11 as the default Java version) so that installing from the ppa is no longer necessary.