### PR TITLE
DR-2681 Sort data columns when previewing snapshots

### DIFF
--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -177,7 +177,15 @@ export const { runQuery } = createActions({
 });
 
 export const { previewData } = createActions({
-  [ActionTypes.PREVIEW_DATA]: (resourceType, resourceId, table, columns, totalRowCount, orderDirection, orderProperty) => ({
+  [ActionTypes.PREVIEW_DATA]: (
+    resourceType,
+    resourceId,
+    table,
+    columns,
+    totalRowCount,
+    orderDirection,
+    orderProperty,
+  ) => ({
     resourceType,
     resourceId,
     table,

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -177,12 +177,14 @@ export const { runQuery } = createActions({
 });
 
 export const { previewData } = createActions({
-  [ActionTypes.PREVIEW_DATA]: (resourceType, resourceId, table, columns, totalRowCount) => ({
+  [ActionTypes.PREVIEW_DATA]: (resourceType, resourceId, table, columns, totalRowCount, orderDirection, orderProperty) => ({
     resourceType,
     resourceId,
     table,
     columns,
     totalRowCount,
+    orderDirection,
+    orderProperty,
   }),
   [ActionTypes.PREVIEW_DATA_SUCCESS]: (queryResults, columns) => ({
     queryResults,

--- a/src/components/common/data/DataView.tsx
+++ b/src/components/common/data/DataView.tsx
@@ -48,6 +48,7 @@ type DataViewProps = {
   filterStatement: string;
   handleChangeTable: () => void;
   handleDrawerWidth: () => void;
+  handleEnumeration: () => void;
   pageBQQuery: () => void;
   panels: Array<object>;
   polling: boolean;
@@ -70,6 +71,7 @@ function DataView({
   filterStatement,
   handleChangeTable,
   handleDrawerWidth,
+  handleEnumeration,
   pageBQQuery,
   panels,
   polling,
@@ -133,6 +135,7 @@ function DataView({
             <LightTable
               columns={columns}
               filteredCount={totalRows}
+              handleEnumeration={handleEnumeration}
               loading={polling}
               noRowsMessage={
                 isDatasetFiltered ? 'No rows match your filter' : 'No rows exist in the table'
@@ -141,6 +144,7 @@ function DataView({
               rowKey={rowKey}
               rows={rows}
               searchString={filterStatement}
+              tableName={selectedTable}
               totalCount={totalRows} // TODO - DR-2663 - instead should display total rows regardless of filtering
             />
           </div>

--- a/src/components/table/LightTable.tsx
+++ b/src/components/table/LightTable.tsx
@@ -103,6 +103,7 @@ type LightTableProps = {
   rows: Array<TableRowType>;
   rowsPerPage: number;
   searchString: string;
+  tableName?: string;
   totalCount: number;
 };
 
@@ -123,6 +124,7 @@ function LightTable({
   rows,
   rowsPerPage,
   searchString,
+  tableName,
   totalCount,
 }: LightTableProps) {
   const [seeMore, setSeeMore] = useState({ open: false, title: '', contents: [''] });
@@ -225,6 +227,7 @@ function LightTable({
     return value;
   };
 
+  // Not pulling including handleEnumeration in effect list since we don't want a change in the function to trigger a fetch
   useEffect(() => {
     if (handleEnumeration) {
       handleEnumeration(
@@ -235,7 +238,8 @@ function LightTable({
         searchString,
       );
     }
-  }, [searchString, page, rowsPerPage, handleEnumeration, orderProperty, orderDirection]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchString, page, rowsPerPage, orderProperty, orderDirection, tableName]);
 
   return (
     <div>

--- a/src/components/table/LightTable.tsx
+++ b/src/components/table/LightTable.tsx
@@ -174,7 +174,7 @@ function LightTable({
 
   const handleRepeatedValues = (values: Array<string>, columnName: string) => {
     const allValues = [];
-    const cleanValues = values.map((v) => (_.isNull(v) ? handleNullValue() : v));
+    const cleanValues = values.map((v) => (_.isNil(v) ? handleNullValue() : `${v}`));
     const start = <span key="start">[</span>;
     const end = <span key="end">]</span>;
     for (let i = 0; i < cleanValues.length; i++) {
@@ -219,12 +219,12 @@ function LightTable({
         return handleRepeatedValues(value, column.name);
       }
       const singleValue = value[0];
-      return _.isNull(singleValue) ? handleNullValue() : singleValue;
+      return _.isNil(singleValue) ? handleNullValue() : `${singleValue}`;
     }
-    if (_.isNull(value)) {
+    if (_.isNil(value)) {
       return handleNullValue();
     }
-    return value;
+    return `${value}`;
   };
 
   // Not pulling including handleEnumeration in effect list since we don't want a change in the function to trigger a fetch

--- a/src/components/table/LightTable.tsx
+++ b/src/components/table/LightTable.tsx
@@ -27,7 +27,7 @@ import LoadingSpinner from '../common/LoadingSpinner';
 import { AppDispatch } from '../../store';
 import { TableColumnType, TableRowType, OrderDirectionOptions } from '../../reducers/query';
 import { TdrState } from '../../reducers';
-import { TABLE_DEFAULT_ROWS_PER_PAGE_OPTIONS } from '../../constants';
+import { TABLE_DEFAULT_ROWS_PER_PAGE_OPTIONS, TABLE_DEFAULT_SORT_ORDER } from '../../constants';
 
 const styles = (theme: CustomTheme) => ({
   root: {
@@ -130,9 +130,9 @@ function LightTable({
   const [seeMore, setSeeMore] = useState({ open: false, title: '', contents: [''] });
 
   const handleRequestSort = (_event: any, sort: string) => {
-    let newOrder = 'desc';
-    if (orderProperty === sort && orderDirection === 'desc') {
-      newOrder = 'asc';
+    let newOrder = TABLE_DEFAULT_SORT_ORDER;
+    if (orderProperty === sort && orderDirection === 'asc') {
+      newOrder = 'desc';
     }
     dispatch(applySort(sort, newOrder));
   };

--- a/src/components/table/LightTableHead.tsx
+++ b/src/components/table/LightTableHead.tsx
@@ -9,6 +9,7 @@ import { ClassNameMap, withStyles } from '@mui/styles';
 import TerraTooltip from '../common/TerraTooltip';
 import { TableColumnType, OrderDirectionOptions } from '../../reducers/query';
 import { TdrState } from '../../reducers';
+import { TABLE_DEFAULT_SORT_ORDER } from '../../constants';
 
 const styles = (theme: CustomTheme) => ({
   head: {
@@ -68,7 +69,7 @@ function LightTableHead({
                   <TerraTooltip title="Sort" placement="bottom-end" enterDelay={300}>
                     <TableSortLabel
                       active={orderProperty === col.name}
-                      direction={orderDirection}
+                      direction={sortDir || TABLE_DEFAULT_SORT_ORDER}
                       onClick={createSortHandler(col.name)}
                       IconComponent={Sort}
                     >

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -185,3 +185,4 @@ export enum ResourceType {
 /** Shared Defaults */
 export const TABLE_DEFAULT_ROWS_PER_PAGE = 100;
 export const TABLE_DEFAULT_ROWS_PER_PAGE_OPTIONS = [25, 100, 250];
+export const TABLE_DEFAULT_SORT_ORDER = 'asc';

--- a/src/reducers/query.ts
+++ b/src/reducers/query.ts
@@ -107,7 +107,7 @@ export default {
           name: column.name,
           dataType: column.datatype,
           arrayOf: column.array_of,
-          allowSort: false,
+          allowSort: !column.array_of,
         }));
         const queryParams = {
           totalRows: parseInt(action.payload.totalRowCount, 10),
@@ -151,11 +151,13 @@ export default {
         immutable(state, {
           delay: { $set: true },
         }),
-      [ActionTypes.PREVIEW_DATA]: (state) =>
+      [ActionTypes.PREVIEW_DATA]: (state, action: any) =>
         immutable(state, {
           error: { $set: false },
           queryParams: { $set: defaultQueryParams },
           polling: { $set: true },
+          orderProperty: { $set: action.payload.orderProperty },
+          orderDirection: { $set: action.payload.orderDirection },
         }),
       [ActionTypes.PREVIEW_DATA_FAILURE]: (state, action: any) =>
         immutable(state, {

--- a/src/reducers/query.ts
+++ b/src/reducers/query.ts
@@ -191,6 +191,7 @@ export default {
       },
       [ActionTypes.APPLY_SORT]: (state, action: any) =>
         immutable(state, {
+          page: { $set: 0 },
           orderProperty: { $set: action.payload.property },
           orderDirection: { $set: action.payload.direction },
         }),

--- a/src/sagas/repository.ts
+++ b/src/sagas/repository.ts
@@ -540,7 +540,9 @@ export function* previewData({ payload }: any): any {
   const queryState = yield select(getQuery);
   const offset = queryState.page * queryState.rowsPerPage;
   const limit = queryState.rowsPerPage;
-  const query = `/api/repository/v1/${payload.resourceType}s/${payload.resourceId}/data/${payload.table}?offset=${offset}&limit=${limit}`;
+  const sort = queryState.orderProperty === undefined ? '' : `&sort=${queryState.orderProperty}` ;
+  const sortDirection = queryState.orderDirection === undefined ? '' : `&direction=${queryState.orderDirection}` ;
+  const query = `/api/repository/v1/${payload.resourceType}s/${payload.resourceId}/data/${payload.table}?offset=${offset}&limit=${limit}${sort}${sortDirection}`;
   try {
     const response = yield call(authGet, query);
     yield put({

--- a/src/sagas/repository.ts
+++ b/src/sagas/repository.ts
@@ -540,8 +540,9 @@ export function* previewData({ payload }: any): any {
   const queryState = yield select(getQuery);
   const offset = queryState.page * queryState.rowsPerPage;
   const limit = queryState.rowsPerPage;
-  const sort = queryState.orderProperty === undefined ? '' : `&sort=${queryState.orderProperty}` ;
-  const sortDirection = queryState.orderDirection === undefined ? '' : `&direction=${queryState.orderDirection}` ;
+  const sort = queryState.orderProperty === undefined ? '' : `&sort=${queryState.orderProperty}`;
+  const sortDirection =
+    queryState.orderDirection === undefined ? '' : `&direction=${queryState.orderDirection}`;
   const query = `/api/repository/v1/${payload.resourceType}s/${payload.resourceId}/data/${payload.table}?offset=${offset}&limit=${limit}${sort}${sortDirection}`;
   try {
     const response = yield call(authGet, query);


### PR DESCRIPTION
This PR does enables sorting on columns in the snapshot preview (this already works with dataset preview)

I changed how the fetch gets triggered to make it so that data is fetched when ordering changes.

I also did a drive-by change to make sure that booleans render correctly in the UI

You can see this in action at:
https://jade-nm.datarepo-dev.broadinstitute.org/snapshots/9cbb702c-51f8-4396-85e0-9ad2b43aedb7/data