### PR TITLE
[DR-2677] Conditionally disable export snapshot button

### DIFF
--- a/src/components/snapshot/overview/SnapshotExport.test.tsx
+++ b/src/components/snapshot/overview/SnapshotExport.test.tsx
@@ -31,6 +31,7 @@ describe('SnapshotExport', () => {
         exportIsProcessing: false,
         exportIsDone: false,
         exportResponse: {},
+        userRoles: ['steward'],
       },
       configuration,
     };
@@ -46,12 +47,36 @@ describe('SnapshotExport', () => {
     );
     cy.get('[data-cy="export-snapshot-button"]').should('contain.text', 'Export snapshot');
   });
+  it('Test has export button disabled', () => {
+    const initialState = {
+      snapshots: {
+        snapshot,
+        exportIsProcessing: false,
+        exportIsDone: false,
+        exportResponse: {},
+        userRoles: ['reader'],
+      },
+      configuration,
+    };
+    const store = mockStore(initialState);
+    mount(
+      <Router history={history}>
+        <Provider store={store}>
+          <ThemeProvider theme={globalTheme}>
+            <SnapshotExport of={snapshot} />
+          </ThemeProvider>
+        </Provider>
+      </Router>,
+    );
+    cy.get('[data-cy="export-snapshot-button"]').should('be.disabled');
+  });
   it('Test preparing snapshot', () => {
     const preparingSnapshotState = {
       snapshots: {
         exportIsProcessing: true,
         exportIsDone: false,
         exportResponse: {},
+        userRoles: ['steward'],
       },
       configuration,
     };
@@ -79,6 +104,7 @@ describe('SnapshotExport', () => {
             },
           },
         },
+        userRoles: ['steward'],
       },
       configuration,
     };


### PR DESCRIPTION
Only enable exporting snapshots to a workspace if the user is a Steward. Otherwise, disable and make the tooltip display an error message:

<img width="830" alt="Screen Shot 2022-08-03 at 12 58 30 PM" src="https://user-images.githubusercontent.com/6414394/182667230-c422eb0c-9410-46ee-8fe9-1df82e77c79b.png">


For testing, I created two snapshots in my personal environment. The team has read-access to one and steward-access to the other: https://jade-se.datarepo-dev.broadinstitute.org/snapshots