### PR TITLE
DR-2693 Allow exporting to Azure

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "test": "npm run codegen && react-app-rewired test",
     "eject": "react-app-rewired eject",
     "ingest": "node --inspect tools/ingest ingest",
-    "codegen": "openapi-generator-cli generate -g typescript-axios -i ${TDR_OPEN_API_YAML_LOCATION:=https://data.terra.bio/data-repository-openapi.yaml} -o ./src/generated/tdr --skip-validate-spec",
+    "codegen": "openapi-generator-cli generate -g typescript-axios -i ${TDR_OPEN_API_YAML_LOCATION:=https://jade.datarepo-dev.broadinstitute.org/data-repository-openapi.yaml} -o ./src/generated/tdr --skip-validate-spec",
     "clean": "rm -fr build src/generated/*"
   },
   "husky": {

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -23,7 +23,11 @@ export const { createSnapshot } = createActions({
 });
 
 export const { exportSnapshot } = createActions({
-  [ActionTypes.EXPORT_SNAPSHOT]: (snapshotId, exportGsPaths) => ({ snapshotId, exportGsPaths }),
+  [ActionTypes.EXPORT_SNAPSHOT]: (snapshotId, exportGsPaths, validatePrimaryKeyUniqueness) => ({
+    snapshotId,
+    exportGsPaths,
+    validatePrimaryKeyUniqueness,
+  }),
   [ActionTypes.EXPORT_SNAPSHOT_START]: () => ({}),
   [ActionTypes.EXPORT_SNAPSHOT_JOB]: (exportResponse) => exportResponse,
   [ActionTypes.EXPORT_SNAPSHOT_SUCCESS]: (exportResponse) => exportResponse,

--- a/src/components/snapshot/overview/SnapshotExport.test.tsx
+++ b/src/components/snapshot/overview/SnapshotExport.test.tsx
@@ -7,10 +7,12 @@ import createMockStore from 'redux-mock-store';
 import history from '../../../modules/hist';
 import globalTheme from '../../../modules/theme';
 import SnapshotExport from './SnapshotExport';
+import { SnapshotModel } from '../../../generated/tdr';
 
-const snapshot = {
+const snapshot: SnapshotModel = {
   id: 'uuid',
   name: 'Snapshot',
+  cloudPlatform: 'gcp',
 };
 
 const configuration = {

--- a/src/components/snapshot/overview/SnapshotExport.tsx
+++ b/src/components/snapshot/overview/SnapshotExport.tsx
@@ -57,7 +57,9 @@ const formatExportUrl = (
   snapshot: SnapshotModel,
   manifest: string,
 ) =>
-  `${terraUrl}#import-data?url=${window}&snapshotId=${snapshot.id}&format=tdrexport&snapshotName=${snapshot.name}&tdrmanifest=${manifest}`;
+  `${terraUrl}#import-data?url=${window}&snapshotId=${snapshot.id}&format=tdrexport&snapshotName=${
+    snapshot.name
+  }&tdrmanifest=${encodeURIComponent(manifest)}`;
 
 function SnapshotExport(props: SnapshotExportProps) {
   const [exportGsPaths, setExportGsPaths] = React.useState(false);
@@ -82,7 +84,8 @@ function SnapshotExport(props: SnapshotExportProps) {
   };
 
   const exportToWorkspaceCopy = () => {
-    dispatch(exportSnapshot(of.id, exportGsPaths));
+    const validatePrimaryKeyUniqueness = of.cloudPlatform === 'gcp';
+    dispatch(exportSnapshot(of.id, exportGsPaths, validatePrimaryKeyUniqueness));
   };
 
   const resetExport = () => {
@@ -109,18 +112,20 @@ function SnapshotExport(props: SnapshotExportProps) {
       <Typography variant="body1" className={classes.section}>
         Export a copy of the snapshot metadata to an existing or new Terra workspace
       </Typography>
-      <FormGroup>
-        <FormControlLabel
-          data-cy="gs-paths-checkbox"
-          control={gsPathsCheckbox}
-          label="Convert DRS URLs to Google Cloud Storage Paths (gs://...)"
-        />
-        <FormHelperText>
-          <i>
-            <b>Note: </b> gs-paths can change over time
-          </i>
-        </FormHelperText>
-      </FormGroup>
+      {of.cloudPlatform === 'gcp' && (
+        <FormGroup>
+          <FormControlLabel
+            data-cy="gs-paths-checkbox"
+            control={gsPathsCheckbox}
+            label="Convert DRS URLs to Google Cloud Storage Paths (gs://...)"
+          />
+          <FormHelperText>
+            <i>
+              <b>Note: </b> gs-paths can change over time
+            </i>
+          </FormHelperText>
+        </FormGroup>
+      )}
       {!isProcessing && !isDone && (
         <TerraTooltip title={canExport ? tooltipMessage : tooltipError}>
           <span>

--- a/src/components/snapshot/overview/SnapshotExport.tsx
+++ b/src/components/snapshot/overview/SnapshotExport.tsx
@@ -121,7 +121,7 @@ function SnapshotExport(props: SnapshotExportProps) {
           />
           <FormHelperText>
             <i>
-              <b>Note: </b> gs-paths can change over time
+              <b>Note:</b> gs-paths can change over time
             </i>
           </FormHelperText>
         </FormGroup>

--- a/src/components/snapshot/overview/SnapshotOverviewPanel.tsx
+++ b/src/components/snapshot/overview/SnapshotOverviewPanel.tsx
@@ -63,7 +63,7 @@ function SnapshotOverviewPanel(props: SnapshotOverviewPanelProps) {
   const { classes, snapshot } = props;
   // @ts-ignore
   const sourceDataset = snapshot.source[0].dataset;
-  const linkToBq = snapshot.accessInformation?.bigQuery !== undefined;
+  const linkToBq = snapshot.cloudPlatform === 'gcp';
 
   const handleChange = (_event: React.SyntheticEvent, newValue: number) => {
     setValue(newValue);

--- a/src/sagas/repository.ts
+++ b/src/sagas/repository.ts
@@ -132,10 +132,10 @@ export function* exportSnapshot({ payload }: any): any {
     yield put({
       type: ActionTypes.EXPORT_SNAPSHOT_START,
     });
-    const { snapshotId, exportGsPaths } = payload;
+    const { snapshotId, exportGsPaths, validatePrimaryKeyUniqueness } = payload;
     const response = yield call(
       authGet,
-      `/api/repository/v1/snapshots/${snapshotId}/export?exportGsPaths=${exportGsPaths}`,
+      `/api/repository/v1/snapshots/${snapshotId}/export?exportGsPaths=${exportGsPaths}&validatePrimaryKeyUniqueness=${validatePrimaryKeyUniqueness}`,
     );
     const jobId = response.data.id;
     yield put({


### PR DESCRIPTION
This PR enables exporting Azure snapshots to Terra workspaces.  Specifically:
- Allow skipping Uniqueness validation for Azure snapshots (since it's not implemented)
- Hide the "resolve to gs:// paths" checkbox (since it doesn't make sense for Azure)
- Hides the export to sheets button (since it doesn't make sense for Azure)

Of note: this also uses the dev instance's swagger to generate the TDR client

Looks like this:
![image](https://user-images.githubusercontent.com/5633787/186752667-0aeb0a91-28f8-44b8-ab5b-491aefbbd93e.png)
