### PR TITLE
DR-2739 Force group syncing for now when exporting snapshots to workspaces

### DIFF
--- a/src/components/snapshot/overview/SnapshotExport.tsx
+++ b/src/components/snapshot/overview/SnapshotExport.tsx
@@ -59,7 +59,7 @@ const formatExportUrl = (
 ) =>
   `${terraUrl}#import-data?url=${window}&snapshotId=${snapshot.id}&format=tdrexport&snapshotName=${
     snapshot.name
-  }&tdrmanifest=${encodeURIComponent(manifest)}`;
+  }&tdrmanifest=${encodeURIComponent(manifest)}&tdrSyncPermissions=true`;
 
 function SnapshotExport(props: SnapshotExportProps) {
   const [exportGsPaths, setExportGsPaths] = React.useState(false);


### PR DESCRIPTION
This will allow the AJ team introduce the new parameter on their end without changing the current behavior.  This should not cause any change in behavior