### PR TITLE
[DR-2743] Updates behaviors after nav bar refactor.

### DIFF
--- a/src/components/AppBreadcrumbs/AppBreadcrumbs.test.tsx
+++ b/src/components/AppBreadcrumbs/AppBreadcrumbs.test.tsx
@@ -21,13 +21,10 @@ describe('AppBreadcrumbs', () => {
     );
 
     cy.get('.MuiBreadcrumbs-ol > :nth-child(1) > a')
-      .should('contain.text', 'Dashboard')
-      .should('have.attr', 'href', '/');
-    cy.get('.MuiBreadcrumbs-ol > :nth-child(3) > a')
       .should('contain.text', 'Datasets')
       .should('have.attr', 'href', '/datasets');
 
-    cy.get('.MuiBreadcrumbs-ol > :nth-child(5) > a')
+    cy.get('.MuiBreadcrumbs-ol > :nth-child(3) > a')
       .should('contain.text', 'testDataset')
       .should('have.attr', 'href', '/datasets/foo-bar');
 
@@ -42,11 +39,11 @@ describe('AppBreadcrumbs', () => {
       </Router>,
     );
 
-    cy.get('.MuiBreadcrumbs-ol > :nth-child(5) > a')
+    cy.get('.MuiBreadcrumbs-ol > :nth-child(3) > a')
       .should('contain.text', 'testDataset')
       .should('have.attr', 'href', '/datasets/foo-bar');
 
-    cy.get('.MuiBreadcrumbs-ol > :nth-child(7) > a')
+    cy.get('.MuiBreadcrumbs-ol > :nth-child(5) > a')
       .should('contain.text', 'Data')
       .should('have.attr', 'href', '/datasets/foo-bar/data');
   });
@@ -67,13 +64,10 @@ describe('AppBreadcrumbs', () => {
       </Router>,
     );
     cy.get('.MuiBreadcrumbs-ol > :nth-child(1) > a')
-      .should('contain.text', 'Dashboard')
-      .should('have.attr', 'href', '/');
-    cy.get('.MuiBreadcrumbs-ol > :nth-child(3) > a')
       .should('contain.text', 'Snapshots')
       .should('have.attr', 'href', '/snapshots');
 
-    cy.get('.MuiBreadcrumbs-ol > :nth-child(5) > a')
+    cy.get('.MuiBreadcrumbs-ol > :nth-child(3) > a')
       .should('contain.text', 'testSnapshot')
       .should('have.attr', 'href', '/snapshots/foo-bar-snapshot');
   });
@@ -89,8 +83,8 @@ describe('AppBreadcrumbs', () => {
         </ThemeProvider>
       </Router>,
     );
-    cy.get('.MuiBreadcrumbs-ol > :nth-child(3) > a > span').should('have.css', 'cursor', 'pointer');
-    cy.get('.MuiBreadcrumbs-ol > :nth-child(5) > a > span ').should(
+    cy.get('.MuiBreadcrumbs-ol > :nth-child(1) > a > span').should('have.css', 'cursor', 'pointer');
+    cy.get('.MuiBreadcrumbs-ol > :nth-child(3) > a > span ').should(
       'have.css',
       'cursor',
       'default',
@@ -107,7 +101,7 @@ describe('AppBreadcrumbs', () => {
       </Router>,
     );
 
-    cy.get('.MuiBreadcrumbs-ol > :nth-child(5) > a > span').should('have.css', 'cursor', 'pointer');
-    cy.get('.MuiBreadcrumbs-ol > :nth-child(7) > a > span').should('have.css', 'cursor', 'default');
+    cy.get('.MuiBreadcrumbs-ol > :nth-child(3) > a > span').should('have.css', 'cursor', 'pointer');
+    cy.get('.MuiBreadcrumbs-ol > :nth-child(5) > a > span').should('have.css', 'cursor', 'default');
   });
 });

--- a/src/components/AppBreadcrumbs/AppBreadcrumbs.tsx
+++ b/src/components/AppBreadcrumbs/AppBreadcrumbs.tsx
@@ -17,7 +17,6 @@ function AppBreadcrumbs({ context, childBreadcrumbs }: AppBreadcrumbsProps) {
   const capitalize = (str: string): string => str.charAt(0).toUpperCase() + str.slice(1);
 
   const breadcrumbs: Breadcrumb[] = [
-    { text: 'Dashboard', to: '' },
     { text: `${capitalize(type)}s`, to: `${type}s` },
     { text: name, to: id },
     ...(childBreadcrumbs || []),
@@ -31,7 +30,8 @@ function AppBreadcrumbs({ context, childBreadcrumbs }: AppBreadcrumbsProps) {
         const { text, to } = breadcrumb;
         const disabled = i === breadcrumbs.length - 1;
         hierarchy.push(to);
-        const link = `${hierarchy.join('/')}`;
+        const link = `/${hierarchy.join('/')}`;
+        console.log(hierarchy, link);
         return (
           <BreadcrumbLink key={text.toLowerCase()} to={link} disabled={disabled}>
             {text}

--- a/src/components/AppBreadcrumbs/AppBreadcrumbs.tsx
+++ b/src/components/AppBreadcrumbs/AppBreadcrumbs.tsx
@@ -31,7 +31,6 @@ function AppBreadcrumbs({ context, childBreadcrumbs }: AppBreadcrumbsProps) {
         const disabled = i === breadcrumbs.length - 1;
         hierarchy.push(to);
         const link = `/${hierarchy.join('/')}`;
-        console.log(hierarchy, link);
         return (
           <BreadcrumbLink key={text.toLowerCase()} to={link} disabled={disabled}>
             {text}

--- a/src/routes/NotFound.tsx
+++ b/src/routes/NotFound.tsx
@@ -62,7 +62,7 @@ function NotFound(props: { classes: ClassNameMap }) {
           size="large"
           to="/"
         >
-          <span className={classes.buttonText}>Return to Dashboard</span>
+          <span className={classes.buttonText}>Return to Datasets</span>
         </Button>
       </Grid>
       <Grid item xs={6}>


### PR DESCRIPTION
After the [navbar refactor](https://broadworkbench.atlassian.net/browse/DR-2743) @nmalfroy noticed breadcrumbs needed to be updated.

This PR updates the:
- breadcrumbs to remove the "Dashboard" entry.
- NotFound route handler to display "Return to Datasets" since the Dashboard concept goes away.