### PR TITLE
DR-2803: Fix filtering on null values during snapshot create

### DIFF
--- a/cypress/integration/queryBuilder.spec.js
+++ b/cypress/integration/queryBuilder.spec.js
@@ -132,6 +132,44 @@ describe('test query builder', () => {
     });
   });
 
+  describe('filtering on null checkbox value', () => {
+    it('filters on null', () => {
+      // Switch to variant table
+      cy.get('[data-cy=selectTable]').click();
+      cy.get('[data-cy=menuItem-variant]').click();
+
+      // selects the filter button in the sidebar
+      cy.get('div.MuiButtonBase-root:nth-child(2) > svg:nth-child(1)').click();
+      // first, let's filter down to a reasonble number of entries
+      // type variant ids into filter box
+      cy.get('[data-cy=filterItem]').contains('id').click();
+      cy.get('#autocomplete-id').type('1:65196986:A:G\n1:231395857:A:G\n');
+      cy.get('[data-cy="filter-id-button"]').click();
+      
+      // select the "reference" field
+      cy.get('[data-cy=filterItem]').contains('reference').click();
+
+      // select the "null" checkbox
+      cy.get('[data-cy=categoryFilterCheckbox-null]').click();
+      
+      // Apply filtering
+      cy.get('[data-cy="filter-reference-button"]').click();
+
+      // null row should be visible, but non-null row should be hidden
+      cy.get('[data-cy=tableBody]').should('contain', '1:65196986:A:G');
+      cy.get('[data-cy=tableBody]').should('not.contain', '1:231395857:A:G');
+
+      // Go back and select other checkbox for reference field: "A"
+      cy.get('[data-cy=categoryFilterCheckbox-A]').click();
+      // apply new filtering
+      cy.get('[data-cy="filter-reference-button"]').click();
+
+      // now both the null row and the row associated with "A" should be visible
+      cy.get('[data-cy=tableBody]').should('contain', '1:65196986:A:G');
+      cy.get('[data-cy=tableBody]').should('contain', '1:231395857:A:G');
+    })
+  })
+
   describe('test share panel', () => {
     beforeEach(() => {
       // selects the share button in the sidebar

--- a/cypress/integration/queryBuilder.spec.js
+++ b/cypress/integration/queryBuilder.spec.js
@@ -145,13 +145,13 @@ describe('test query builder', () => {
       cy.get('[data-cy=filterItem]').contains('id').click();
       cy.get('#autocomplete-id').type('1:65196986:A:G\n1:231395857:A:G\n');
       cy.get('[data-cy="filter-id-button"]').click();
-      
+
       // select the "reference" field
       cy.get('[data-cy=filterItem]').contains('reference').click();
 
       // select the "null" checkbox
       cy.get('[data-cy=categoryFilterCheckbox-null]').click();
-      
+
       // Apply filtering
       cy.get('[data-cy="filter-reference-button"]').click();
 
@@ -167,8 +167,8 @@ describe('test query builder', () => {
       // now both the null row and the row associated with "A" should be visible
       cy.get('[data-cy=tableBody]').should('contain', '1:65196986:A:G');
       cy.get('[data-cy=tableBody]').should('contain', '1:231395857:A:G');
-    })
-  })
+    });
+  });
 
   describe('test share panel', () => {
     beforeEach(() => {

--- a/src/modules/bigquery.js
+++ b/src/modules/bigquery.js
@@ -96,15 +96,8 @@ export default class BigQuery {
               if (isRange) {
                 statementClauses.push(`${property} BETWEEN ${keyValue[0]} AND ${keyValue[1]}`);
               } else if (_.isString(keyValue[0])) {
-                const selections = [];
-                keyValue.forEach((selection) => {
-                  if (selection === 'null') {
-                    statementClauses.push(`${property} IS ${notClause} NULL`);
-                  } else {
-                    selections.push(`"${selection}"`);
-                  }
-                  statementClauses.push(`${property} ${notClause} IN (${selections.join(',')})`);
-                });
+                const selections = keyValue.map((selection) => `"${selection}"`).join(',');
+                statementClauses.push(`${property} ${notClause} IN (${selections})`);
               } else {
                 statementClauses.push(
                   `${property} = '${keyValue[0]}' OR ${property} = '${keyValue[1]}'`,
@@ -114,16 +107,18 @@ export default class BigQuery {
               const checkboxes = _.keys(keyValue);
               if (checkboxes.length > 0) {
                 const checkboxValues = [];
+                const checkboxClauses = [];
                 checkboxes.forEach((checkboxValue) => {
                   if (checkboxValue === 'null') {
-                    statementClauses.push(`${property} IS ${notClause} NULL`);
+                    checkboxClauses.push(`${property} IS ${notClause} NULL`);
                   } else {
                     checkboxValues.push(`"${checkboxValue}"`);
                   }
                 });
                 if (checkboxValues.length > 0) {
-                  statementClauses.push(`${property} IN (${checkboxValues.join(',')})`);
+                  checkboxClauses.push(`${property} IN (${checkboxValues.join(',')})`);
                 }
+                statementClauses.push(checkboxClauses.join(' OR '));
               }
             } else {
               const values = keyValue.split(',').map((val) => `${key}='${val}'`);

--- a/src/modules/bigquery.js
+++ b/src/modules/bigquery.js
@@ -118,7 +118,7 @@ export default class BigQuery {
                 if (checkboxValues.length > 0) {
                   checkboxClauses.push(`${property} IN (${checkboxValues.join(',')})`);
                 }
-                statementClauses.push(checkboxClauses.join(' OR '));
+                statementClauses.push(`(${checkboxClauses.join(' OR ')})`);
               }
             } else {
               const values = keyValue.split(',').map((val) => `${key}='${val}'`);

--- a/src/modules/bigquery.js
+++ b/src/modules/bigquery.js
@@ -96,8 +96,15 @@ export default class BigQuery {
               if (isRange) {
                 statementClauses.push(`${property} BETWEEN ${keyValue[0]} AND ${keyValue[1]}`);
               } else if (_.isString(keyValue[0])) {
-                const selections = keyValue.map((selection) => `"${selection}"`).join(',');
-                statementClauses.push(`${property} ${notClause} IN (${selections})`);
+                const selections = [];
+                keyValue.forEach((selection) => {
+                  if (selection === 'null') {
+                    statementClauses.push(`${property} IS ${notClause} NULL`);
+                  } else {
+                    selections.push(`"${selection}"`);
+                  }
+                  statementClauses.push(`${property} ${notClause} IN (${selections.join(',')})`);
+                });
               } else {
                 statementClauses.push(
                   `${property} = '${keyValue[0]}' OR ${property} = '${keyValue[1]}'`,
@@ -106,10 +113,17 @@ export default class BigQuery {
             } else if (_.isObject(keyValue)) {
               const checkboxes = _.keys(keyValue);
               if (checkboxes.length > 0) {
-                const checkboxValues = checkboxes
-                  .map((checkboxValue) => `"${checkboxValue}"`)
-                  .join(',');
-                statementClauses.push(`${property} IN (${checkboxValues})`);
+                const checkboxValues = [];
+                checkboxes.forEach((checkboxValue) => {
+                  if (checkboxValue === 'null') {
+                    statementClauses.push(`${property} IS ${notClause} NULL`);
+                  } else {
+                    checkboxValues.push(`"${checkboxValue}"`);
+                  }
+                });
+                if (checkboxValues.length > 0) {
+                  statementClauses.push(`${property} IN (${checkboxValues.join(',')})`);
+                }
               }
             } else {
               const values = keyValue.split(',').map((val) => `${key}='${val}'`);

--- a/src/modules/bigquery.js
+++ b/src/modules/bigquery.js
@@ -110,7 +110,7 @@ export default class BigQuery {
                 const checkboxClauses = [];
                 checkboxes.forEach((checkboxValue) => {
                   if (checkboxValue === 'null') {
-                    checkboxClauses.push(`${property} IS ${notClause} NULL`);
+                    checkboxClauses.push(`${property} IS NULL`);
                   } else {
                     checkboxValues.push(`"${checkboxValue}"`);
                   }

--- a/tools/ui_integration/files/V2F_GWAS_Summary_Statistics/variant.json
+++ b/tools/ui_integration/files/V2F_GWAS_Summary_Statistics/variant.json
@@ -998,3 +998,4 @@
 {"id":"1:185833681:A:G","alt":"G","chromosome":"1","position":"185833681","reference":"A"}
 {"id":"1:231395857:A:G","alt":"G","chromosome":"1","position":"231395857","reference":"A"}
 {"id":"1:65196986:A:G","alt":"G","chromosome":"1","position":"65196986","reference":"A"}
+{"id":"1:65196986:A:G","alt":"G","chromosome":"1","position":"65196986"}


### PR DESCRIPTION
The bug: The query builder was attempting to check for the string "null", so no results are found. 
```
# BROKEN - return 0 rows
SELECT * FROM `<table>` WHERE <column> IN ("null")
 LIMIT 100

#WORKS - returns 100 rows
SELECT * FROM `<table>` WHERE  <column> IS NULL
 LIMIT 100
```

Before the change --

https://user-images.githubusercontent.com/13254229/198398751-4a2b33ea-96d8-47fc-bd51-05bc64fc77cd.mov

With code changes -- 

https://user-images.githubusercontent.com/13254229/198399413-819f6312-d0d8-4a32-b26f-a8e515b821db.mov


