### PR TITLE
[DR-2804] Renders description as markdown.

### DIFF
--- a/src/components/dataset/data/sidebar/panels/InfoView.jsx
+++ b/src/components/dataset/data/sidebar/panels/InfoView.jsx
@@ -10,6 +10,7 @@ import Grid from '@mui/material/Grid';
 import { Close, ExpandMore, HelpOutline, Launch } from '@mui/icons-material';
 import IconButton from '@mui/material/IconButton';
 import TerraTooltip from 'components/common/TerraTooltip';
+import MarkdownContent from 'components/common/MarkdownContent';
 import { renderStorageResources } from '../../../../../libs/render-utils';
 import InfoViewDatasetAccess from './InfoViewDatasetAccess';
 
@@ -160,7 +161,10 @@ export class InfoView extends React.PureComponent {
             )}
             <Grid item xs={12}>
               <Typography variant="h6">About this dataset</Typography>
-              <Typography>{dataset.description}</Typography>
+              <MarkdownContent
+                markdownText={dataset.description}
+                emptyText="(No description available)"
+              />
             </Grid>
             <Grid item xs={6}>
               <Typography variant="h6">Storage</Typography>


### PR DESCRIPTION
BEFORE
![Screen Shot 2022-10-28 at 9 04 16 AM](https://user-images.githubusercontent.com/111771148/198609279-39285e91-a9e6-4c06-981e-5d2a4971af13.png)

AFTER
![Screen Shot 2022-10-28 at 9 16 19 AM](https://user-images.githubusercontent.com/111771148/198609348-38b89275-e277-4f65-9054-39150c21003c.png)

Swaps typography out and brings in the Markdown component to render the description.