### PR TITLE
DR-2816: Bump up checkbox threshold

### DIFF
--- a/src/components/dataset/data/sidebar/filter/CategoryWrapper.jsx
+++ b/src/components/dataset/data/sidebar/filter/CategoryWrapper.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import FreetextFilter from './FreetextFilter';
 import CategoryFilterGroup from './CategoryFilterGroup';
 
-const CHECKBOX_THRESHOLD = 10;
+const CHECKBOX_THRESHOLD = 30;
 
 export class CategoryWrapper extends React.PureComponent {
   constructor(props) {


### PR DESCRIPTION
**Note:** Changes deployed to my dev env: https://jade-sh.datarepo-dev.broadinstitute.org/datasets/c5248002-05d6-469e-bf31-38f1792198f3/data

### Background
There are two modes for filtering string values on snapshot create in the UI.  Currently, when there are more than 10 distinct values for a column, we switch from a "checkbox" over to a "dropdown list". 

1. Checkboxes
![image](https://user-images.githubusercontent.com/13254229/199587965-129a34d6-eef7-4e0a-80ef-17153188619a.png)

2. Dropdown list
![image](https://user-images.githubusercontent.com/13254229/199587744-c1357b3d-1e70-47ef-a2f5-8ade7306d4ca.png)

### The Change/User Request
The user experience is not the best for the dropdown list. So, they want to see the checkbox option more often. We can do this by increasing the threshold for which we switch over the dropdown list. Bumping this up to 30 seems like a reasonable change.
