### PR TITLE
DR-2828 - Fix Total Row count for data tables

### DIFF
--- a/src/components/common/data/DataView.tsx
+++ b/src/components/common/data/DataView.tsx
@@ -198,7 +198,7 @@ function mapStateToProps(state: TdrState) {
     polling: state.query.polling,
     rows: state.query.rows,
     rowsPerPage: state.query.rowsPerPage,
-    totalRows: state.query.queryParams.totalRows,
+    totalRows: state.query.resultsCount,
     refreshCnt: state.query.refreshCnt,
   };
 }

--- a/src/components/dataset/data/DatasetDataView.tsx
+++ b/src/components/dataset/data/DatasetDataView.tsx
@@ -30,8 +30,6 @@ import {
   ResourceType,
 } from '../../../constants';
 
-const QUERY_LIMIT = 1000;
-
 type IProps = {
   dataset: DatasetModel;
   dispatch: Dispatch<Action>;
@@ -39,6 +37,7 @@ type IProps = {
   joinStatement: string;
   orderDirection: OrderDirectionOptions;
   orderProperty: string;
+  rowsPerPage: number;
   profile: BillingProfileModel;
   queryParams: QueryParams;
   snapshotRequest: SnapshotRequest;
@@ -52,6 +51,7 @@ function DatasetDataView({
   match,
   orderDirection,
   orderProperty,
+  rowsPerPage,
   profile,
   queryParams,
   snapshotRequest,
@@ -145,7 +145,7 @@ function DatasetDataView({
           SELECT ${DbColumns.ROW_ID},
             ${selectedTable?.columns?.map((column) => column.name).join(', ')} ${fromClause}
             ${orderProperty ? `ORDER BY ${orderProperty} ${orderDirection}` : ''}
-          LIMIT ${QUERY_LIMIT}`,
+          LIMIT ${rowsPerPage}`,
         ),
       );
       dispatch(
@@ -164,6 +164,7 @@ function DatasetDataView({
     joinStatement,
     orderDirection,
     orderProperty,
+    rowsPerPage,
     selected,
     selectedTable,
   ]);
@@ -216,6 +217,7 @@ function mapStateToProps(state: TdrState) {
     filterStatement: state.query.filterStatement,
     joinStatement: state.query.joinStatement,
     queryParams: state.query.queryParams,
+    rowsPerPage: state.query.rowsPerPage,
     orderDirection: state.query.orderDirection,
     orderProperty: state.query.orderProperty,
     profile: state.profiles.profile,

--- a/src/components/dataset/data/DatasetDataView.tsx
+++ b/src/components/dataset/data/DatasetDataView.tsx
@@ -37,7 +37,6 @@ type IProps = {
   joinStatement: string;
   orderDirection: OrderDirectionOptions;
   orderProperty: string;
-  rowsPerPage: number;
   profile: BillingProfileModel;
   queryParams: QueryParams;
   snapshotRequest: SnapshotRequest;
@@ -51,7 +50,6 @@ function DatasetDataView({
   match,
   orderDirection,
   orderProperty,
-  rowsPerPage,
   profile,
   queryParams,
   snapshotRequest,
@@ -144,8 +142,7 @@ function DatasetDataView({
           `#standardSQL
           SELECT ${DbColumns.ROW_ID},
             ${selectedTable?.columns?.map((column) => column.name).join(', ')} ${fromClause}
-            ${orderProperty ? `ORDER BY ${orderProperty} ${orderDirection}` : ''}
-          LIMIT ${rowsPerPage}`,
+            ${orderProperty ? `ORDER BY ${orderProperty} ${orderDirection}` : ''}`,
         ),
       );
       dispatch(
@@ -164,7 +161,6 @@ function DatasetDataView({
     joinStatement,
     orderDirection,
     orderProperty,
-    rowsPerPage,
     selected,
     selectedTable,
   ]);
@@ -217,7 +213,6 @@ function mapStateToProps(state: TdrState) {
     filterStatement: state.query.filterStatement,
     joinStatement: state.query.joinStatement,
     queryParams: state.query.queryParams,
-    rowsPerPage: state.query.rowsPerPage,
     orderDirection: state.query.orderDirection,
     orderProperty: state.query.orderProperty,
     profile: state.profiles.profile,

--- a/src/reducers/query.ts
+++ b/src/reducers/query.ts
@@ -128,7 +128,7 @@ export default {
           rows: { $set: rows },
           polling: { $set: false },
           delay: { $set: false },
-          resultsCount: { $set: rows.length },
+          resultsCount: { $set: parseInt(action.payload.totalRowCount, 10) },
         });
       },
       [ActionTypes.PAGE_QUERY]: (state) =>

--- a/src/sagas/repository.ts
+++ b/src/sagas/repository.ts
@@ -539,23 +539,6 @@ export function* removeDatasetPolicyMember({ payload }: any): any {
   }
 }
 
-export function* getDatasetTablePreview({ payload }: any): any {
-  const { dataset, tableName } = payload;
-  const datasetProject = dataset.dataProject;
-  const datasetBqSnapshotName = `datarepo_${dataset.name}`;
-  const url = `/bigquery/v2/projects/${datasetProject}/datasets/${datasetBqSnapshotName}/tables/${tableName}/data`;
-  try {
-    const response = yield call(authGet, `${url}?maxResults=100`, true);
-    yield put({
-      type: ActionTypes.GET_DATASET_TABLE_PREVIEW_SUCCESS,
-      preview: response,
-      tableName,
-    });
-  } catch (err) {
-    showNotification(err);
-  }
-}
-
 /**
  * Jobs.
  */
@@ -884,7 +867,6 @@ export default function* root() {
     takeLatest(ActionTypes.GET_DATASET_POLICY, getDatasetPolicy),
     takeLatest(ActionTypes.ADD_DATASET_POLICY_MEMBER, addDatasetPolicyMember),
     takeLatest(ActionTypes.REMOVE_DATASET_POLICY_MEMBER, removeDatasetPolicyMember),
-    takeLatest(ActionTypes.GET_DATASET_TABLE_PREVIEW, getDatasetTablePreview),
     takeLatest(ActionTypes.GET_JOBS, getJobs),
     takeLatest(ActionTypes.GET_JOB_RESULT, getJobResult),
     takeLatest(ActionTypes.RUN_QUERY, runQuery),


### PR DESCRIPTION
Changes deployed here: https://jade-sh.datarepo-dev.broadinstitute.org/

### The Bug
Total rows reported on the dataset data view was incorrectly capped at 1000. 

Example - total rows says 1000:
![image](https://user-images.githubusercontent.com/13254229/200676600-7074fc66-e016-4538-a25f-865c47fc6e8b.png)

However, we know that there are more than 1000 rows in this table.

**Why was this happening?**
Combo of two things:
- Total rows set by the count of rows returned for a given query.
- Incorrectly having a "limit 1000" clause where we should instead remove the limit

**This is fixed by a combo of two things:**
- Instead of setting total rows as a count of the rows returned by the query, get a count of rows that meet the filtering requirements
- Remove the "limit 1000" clause 
<img width="221" alt="image" src="https://user-images.githubusercontent.com/13254229/200676532-f53f98e3-cc04-4f7e-afe4-22385629b36b.png">
