### PR TITLE
[DR-2838] added null ptr protection

### DIFF
--- a/src/components/table/JournalEntryTable.tsx
+++ b/src/components/table/JournalEntryTable.tsx
@@ -91,8 +91,8 @@ const JournalEntryTable = withStyles(styles)(
           const details = [];
           if (row.entryType === JournalEntryModelEntryTypeEnum.Create) {
             note = description;
-          } else if (_.get(parsedReq, 0) === 'bio.terra.model.IngestRequestModel') {
-            const strategy = _.get(parsedReq, [1, 'updateStrategy'], '');
+          } else if (parsedReq?.[0] === 'bio.terra.model.IngestRequestModel') {
+            const strategy = parsedReq?.[1]?.updateStrategy || '';
             const casedStrategy = `${strategy[0].toUpperCase()}${strategy.substring(1)}`;
             details.push(`${casedStrategy} with ${parsedReq[1].path}`);
           } else if (description && description !== note) {

--- a/src/components/table/JournalEntryTable.tsx
+++ b/src/components/table/JournalEntryTable.tsx
@@ -82,7 +82,6 @@ const JournalEntryTable = withStyles(styles)(
         render: (row: any) => {
           const request = _.get(row, ['mutation', 'request.json'], '{}');
           const parsedReq = JSON.parse(request);
-          console.log('parsedReq', parsedReq);
 
           let { note } = row;
 

--- a/src/components/table/JournalEntryTable.tsx
+++ b/src/components/table/JournalEntryTable.tsx
@@ -82,6 +82,7 @@ const JournalEntryTable = withStyles(styles)(
         render: (row: any) => {
           const request = _.get(row, ['mutation', 'request.json'], '{}');
           const parsedReq = JSON.parse(request);
+          console.log('parsedReq', parsedReq);
 
           let { note } = row;
 
@@ -91,8 +92,8 @@ const JournalEntryTable = withStyles(styles)(
           const details = [];
           if (row.entryType === JournalEntryModelEntryTypeEnum.Create) {
             note = description;
-          } else if (parsedReq[0] === 'bio.terra.model.IngestRequestModel') {
-            const strategy = parsedReq[1].updateStrategy;
+          } else if (_.get(parsedReq, 0) === 'bio.terra.model.IngestRequestModel') {
+            const strategy = _.get(parsedReq, [1, 'updateStrategy'], '');
             const casedStrategy = `${strategy[0].toUpperCase()}${strategy.substring(1)}`;
             details.push(`${casedStrategy} with ${parsedReq[1].path}`);
           } else if (description && description !== note) {


### PR DESCRIPTION
Fixed null ptr exception on dev:

https://jade.datarepo-dev.broadinstitute.org/snapshots/e2151834-13cd-4156-9ea2-168a1b7abf60

On this page, the Activity tab will break. To render the description, we would pull out the `request.json` key-value in the JournalEntryTableModel's "mutation" field, then parse out this json string, and grab values. Some of these values did not exist.

However, after this PR, it wont!