### PR TITLE
[DR-2875] Fixed datatype npe in snapshot view

### DIFF
--- a/src/components/common/overview/SchemaPanel.tsx
+++ b/src/components/common/overview/SchemaPanel.tsx
@@ -143,7 +143,7 @@ const renderColumnName = (
   const isPk = _.includes(table.primaryKey || [], column.name);
   retVal.push(
     <span key="dt" className={classes.columnBox} title={column.datatype}>
-      {(column.datatype?.substring(0, 1) || 'N').toUpperCase()}
+      {column.datatype ? column.datatype.substring(0, 1).toUpperCase() : '?'}
       {column.array_of && <span className={classes.columnSubscript}>[ ]</span>}
     </span>,
   );

--- a/src/components/common/overview/SchemaPanel.tsx
+++ b/src/components/common/overview/SchemaPanel.tsx
@@ -143,7 +143,7 @@ const renderColumnName = (
   const isPk = _.includes(table.primaryKey || [], column.name);
   retVal.push(
     <span key="dt" className={classes.columnBox} title={column.datatype}>
-      {column.datatype.substring(0, 1).toUpperCase()}
+      {(column.datatype?.substring(0, 1) || 'N').toUpperCase()}
       {column.array_of && <span className={classes.columnSubscript}>[ ]</span>}
     </span>,
   );
@@ -162,7 +162,7 @@ const renderColumnName = (
   const tooltipText = (
     <div>
       <p>
-        Column <b>{column.name}</b> has datatype <b>{column.datatype}</b>
+        Column <b>{column.name}</b> has datatype <b>{column.datatype || '(none)'}</b>
       </p>
       <ul>
         {isPk && <li>It is a primary key</li>}


### PR DESCRIPTION
https://jade.datarepo-dev.broadinstitute.org/snapshots/f90f5d7f-c507-4e56-abfc-b965a66023fb

This snapshot page was failing on page load because there was an empty column datatype, and then we were substring'ing it without checking for null.