### PR TITLE
DR-2902, DR-2889 - Upgrade Github actions due to Node 12 Deprecation

### DIFF
--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -92,13 +92,18 @@ jobs:
           actions_subcommand: 'deploytagupdate'
           helm_env_prefix: dev
           helm_imagetag_update: ui
-      - name: Trigger action to update helm tag
-        uses: broadinstitute/workflow-dispatch@v1
-        with:
-          workflow: Update integration ui helm image tag
-          token: ${{ secrets.BROADBOT_TOKEN }}
+    helm_tag_bump:
+      needs: update_image
+      uses: ./.github/workflows/helmtagbump.yaml
+      secrets: inherit
+    action_notify:
+      runs-on: ubuntu-latest
+      # if: always()
+      needs:
+        - update_image
+        - helm_tag_bump
+      steps:
       - name: Slack job status
-        if: always()
         uses: broadinstitute/action-slack@v2
         with:
           status: ${{ job.status }}

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -106,7 +106,7 @@ jobs:
     - name: Slack job status
       uses: broadinstitute/action-slack@v3.15.0
       with:
-        status: ${{ job.status }}
+        status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
         author_name: Integration Test
       env:
         GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -31,19 +31,19 @@ jobs:
     if: "!contains( github.event.sender.login, 'broadbot')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: develop
           token: ${{ secrets.BROADBOT_TOKEN }}
       - name: 'Checkout datarepo-helm-definitions repo'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'broadinstitute/datarepo-helm-definitions'
           token: ${{ secrets.BROADBOT_TOKEN }}
           path: datarepo-helm-definitions
       - name: 'Bump the tag to a new version'
-        uses: broadinstitute/datarepo-actions/actions/main@0.65.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.66.0
         with:
           actions_subcommand: 'bumper'
           role_id: ${{ secrets.ROLE_ID }}
@@ -52,7 +52,7 @@ jobs:
           version_variable_name: version
           GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
       - name: 'Get gcp credentials'
-        uses: broadinstitute/datarepo-actions/actions/main@0.65.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.66.0
         with:
           actions_subcommand: 'skip'
           role_id: ${{ secrets.ROLE_ID }}
@@ -87,7 +87,7 @@ jobs:
           gcr.io/${{ env.gcr_google_project }}/jade-data-repo-ui:"${GCR_TAG}" \
           gcr.io/${{ env.gcr_google_project }}/jade-data-repo-ui:"${{ steps.uiprevioustag.outputs.tag }}" --quiet
       - name: 'Check and edit Helm definition for dev'
-        uses: broadinstitute/datarepo-actions/actions/main@0.65.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.66.0
         with:
           actions_subcommand: 'deploytagupdate'
           helm_env_prefix: dev

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -43,7 +43,7 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN }}
           path: datarepo-helm-definitions
       - name: 'Bump the tag to a new version'
-        uses: broadinstitute/datarepo-actions/actions/main@0.66.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
         with:
           actions_subcommand: 'bumper'
           role_id: ${{ secrets.ROLE_ID }}
@@ -52,7 +52,7 @@ jobs:
           version_variable_name: version
           GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
       - name: 'Get gcp credentials'
-        uses: broadinstitute/datarepo-actions/actions/main@0.66.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
         with:
           actions_subcommand: 'skip'
           role_id: ${{ secrets.ROLE_ID }}
@@ -87,7 +87,7 @@ jobs:
           gcr.io/${{ env.gcr_google_project }}/jade-data-repo-ui:"${GCR_TAG}" \
           gcr.io/${{ env.gcr_google_project }}/jade-data-repo-ui:"${{ steps.uiprevioustag.outputs.tag }}" --quiet
       - name: 'Check and edit Helm definition for dev'
-        uses: broadinstitute/datarepo-actions/actions/main@0.66.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
         with:
           actions_subcommand: 'deploytagupdate'
           helm_env_prefix: dev

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -98,13 +98,13 @@ jobs:
     secrets: inherit
   action_notify:
     runs-on: ubuntu-latest
-    # if: always() TODO - uncomment before merging
+    if: always()
     needs:
       - update_image
       - helm_tag_bump
     steps:
     - name: Slack job status
-      uses: broadinstitute/action-slack@v2
+      uses: broadinstitute/action-slack@v3.15.0
       with:
         status: ${{ job.status }}
         author_name: Integration Test

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -92,22 +92,22 @@ jobs:
           actions_subcommand: 'deploytagupdate'
           helm_env_prefix: dev
           helm_imagetag_update: ui
-    helm_tag_bump:
-      needs: update_image
-      uses: ./.github/workflows/helmtagbump.yaml
-      secrets: inherit
-    action_notify:
-      runs-on: ubuntu-latest
-      # if: always()
-      needs:
-        - update_image
-        - helm_tag_bump
-      steps:
-      - name: Slack job status
-        uses: broadinstitute/action-slack@v2
-        with:
-          status: ${{ job.status }}
-          author_name: Integration Test
-        env:
-          GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  helm_tag_bump:
+    needs: update_image
+    uses: ./.github/workflows/helmtagbump.yaml
+    secrets: inherit
+  action_notify:
+    runs-on: ubuntu-latest
+    # if: always() TODO - uncomment before merging
+    needs:
+      - update_image
+      - helm_tag_bump
+    steps:
+    - name: Slack job status
+      uses: broadinstitute/action-slack@v2
+      with:
+        status: ${{ job.status }}
+        author_name: Integration Test
+      env:
+        GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/helmtagbump.yaml
+++ b/.github/workflows/helmtagbump.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: develop
@@ -17,7 +17,7 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - name: 'Checkout datarepo-helm-definitions repo'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'broadinstitute/datarepo-helm-definitions'
           token: ${{ secrets.BROADBOT_TOKEN}}
@@ -47,7 +47,7 @@ jobs:
         with:
           args: yq w -i datarepo-helm-definitions/integration/integration-6/datarepo-ui.yaml image.tag ${{ steps.uiprevioustag.outputs.tag }}"
       - name: "[datarepo-helm-definitions] Merge chart version update"
-        uses: broadinstitute/datarepo-actions/actions/merger@0.65.0
+        uses: broadinstitute/datarepo-actions/actions/merger@0.66.0
         env:
           COMMIT_MESSAGE: "Datarepo ui tag version update: ${{ steps.uiprevioustag.outputs.tag }}"
           GITHUB_REPO: datarepo-helm-definitions
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: develop
@@ -77,7 +77,7 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - name: 'Checkout datarepo-helm repo'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'broadinstitute/datarepo-helm'
           token: ${{ secrets.BROADBOT_TOKEN }}
@@ -104,7 +104,7 @@ jobs:
         with:
           args: yq w -i datarepo-helm/charts/datarepo-ui/Chart.yaml version ${{ steps.new_version.outputs.new_version }}"
       - name: "[datarepo-helm] Merge chart version update"
-        uses: broadinstitute/datarepo-actions/actions/merger@0.65.0
+        uses: broadinstitute/datarepo-actions/actions/merger@0.66.0
         env:
           COMMIT_MESSAGE: "Datarepo ui tag version update: ${{ steps.uiprevioustag.outputs.tag }}"
           GITHUB_REPO: datarepo-helm

--- a/.github/workflows/helmtagbump.yaml
+++ b/.github/workflows/helmtagbump.yaml
@@ -1,7 +1,15 @@
 name: Update integration ui helm image tag
 on:
-  workflow_dispatch: {}
-  workflow_call: {}
+  workflow_dispatch:
+    inputs:
+      notify-slack:
+        default: true
+        type: boolean
+  workflow_call:
+    inputs:
+      notify-slack:
+        default: false
+        type: boolean
 jobs:
 # new integration image updater
   integration_helm_tag_update:
@@ -54,6 +62,15 @@ jobs:
           GITHUB_REPO: datarepo-helm-definitions
           SWITCH_DIRECTORIES: true
           MERGE_BRANCH: master
+      - name: Slack job status
+        if: ${{ inputs.notify-slack && always() }}
+        uses: broadinstitute/action-slack@v2
+        with:
+          status: ${{ job.status }}
+          author_name: ui_helm_bumper
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   ui_helm_default_chart_tag:
     runs-on: ubuntu-20.04
     steps:
@@ -101,3 +118,12 @@ jobs:
           GITHUB_REPO: datarepo-helm
           SWITCH_DIRECTORIES: true
           MERGE_BRANCH: master
+      - name: Slack job status
+        if: ${{ inputs.notify-slack && always() }}
+        uses: broadinstitute/action-slack@v2
+        with:
+          status: ${{ job.status }}
+          author_name: ui_helm_bumper
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/helmtagbump.yaml
+++ b/.github/workflows/helmtagbump.yaml
@@ -1,6 +1,7 @@
 name: Update integration ui helm image tag
 on:
   workflow_dispatch: {}
+  workflow_call: {}
 jobs:
 # new integration image updater
   integration_helm_tag_update:
@@ -53,16 +54,6 @@ jobs:
           GITHUB_REPO: datarepo-helm-definitions
           SWITCH_DIRECTORIES: true
           MERGE_BRANCH: master
-      - name: Slack job status
-        if: always()
-        uses: broadinstitute/action-slack@v2
-        with:
-          status: ${{ job.status }}
-          author_name: ui_helm_bumper
-          only_mention_fail: smark,myessail
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   ui_helm_default_chart_tag:
     runs-on: ubuntu-20.04
     steps:
@@ -110,13 +101,3 @@ jobs:
           GITHUB_REPO: datarepo-helm
           SWITCH_DIRECTORIES: true
           MERGE_BRANCH: master
-      - name: Slack job status
-        if: always()
-        uses: broadinstitute/action-slack@v2
-        with:
-          status: ${{ job.status }}
-          author_name: ui_helm_bumper
-          only_mention_fail: smark,myessail
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/helmtagbump.yaml
+++ b/.github/workflows/helmtagbump.yaml
@@ -14,9 +14,9 @@ jobs:
           ref: develop
       - name: 'Get Previous tag'
         id: uiprevioustag
-        uses: "broadinstitute/github-action-get-previous-tag@master"
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          TAG=$(git for-each-ref --sort=-creatordate --count 1 --format="%(refname:short)" "refs/tags/")
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
       - name: 'Checkout datarepo-helm-definitions repo'
         uses: actions/checkout@v3
         with:
@@ -64,9 +64,9 @@ jobs:
           ref: develop
       - name: 'Get Previous tag'
         id: uiprevioustag
-        uses: "broadinstitute/github-action-get-previous-tag@master"
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          TAG=$(git for-each-ref --sort=-creatordate --count 1 --format="%(refname:short)" "refs/tags/")
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
       - name: 'Checkout datarepo-helm repo'
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/helmtagbump.yaml
+++ b/.github/workflows/helmtagbump.yaml
@@ -47,7 +47,7 @@ jobs:
         with:
           args: yq w -i datarepo-helm-definitions/integration/integration-6/datarepo-ui.yaml image.tag ${{ steps.uiprevioustag.outputs.tag }}"
       - name: "[datarepo-helm-definitions] Merge chart version update"
-        uses: broadinstitute/datarepo-actions/actions/merger@0.66.0
+        uses: broadinstitute/datarepo-actions/actions/merger@0.67.0
         env:
           COMMIT_MESSAGE: "Datarepo ui tag version update: ${{ steps.uiprevioustag.outputs.tag }}"
           GITHUB_REPO: datarepo-helm-definitions
@@ -104,7 +104,7 @@ jobs:
         with:
           args: yq w -i datarepo-helm/charts/datarepo-ui/Chart.yaml version ${{ steps.new_version.outputs.new_version }}"
       - name: "[datarepo-helm] Merge chart version update"
-        uses: broadinstitute/datarepo-actions/actions/merger@0.66.0
+        uses: broadinstitute/datarepo-actions/actions/merger@0.67.0
         env:
           COMMIT_MESSAGE: "Datarepo ui tag version update: ${{ steps.uiprevioustag.outputs.tag }}"
           GITHUB_REPO: datarepo-helm

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
     timeout-minutes: 180
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [14.x]
     if: "!contains( github.event.pull_request.labels.*.name, 'skip-ci')"
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - name: npm ci

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
     timeout-minutes: 180
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
     if: "!contains( github.event.pull_request.labels.*.name, 'skip-ci')"
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - name: 'Whitelist Runner IP'

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -33,20 +33,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
       - name: 'Whitelist Runner IP'
-        uses: broadinstitute/datarepo-actions/actions/main@0.65.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.66.0
         with:
           actions_subcommand: 'gcp_whitelist'
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
       - name: 'Check for an available namespace to deploy API to and set state lock'
         id: namespace
-        uses: broadinstitute/datarepo-actions/actions/main@0.65.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.66.0
         with:
           actions_subcommand: 'k8_checknamespace'
           # Note: Integration-4 is also set up for UI testing, except that the datasets
@@ -88,7 +88,7 @@ jobs:
         run: |
           echo "Pushed docker image gcr.io/broad-jade-dev/jade-data-repo-ui:${GCR_TAG}"
       - name: 'Deploy to cluster with Helm'
-        uses: broadinstitute/datarepo-actions/actions/main@0.65.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.66.0
         with:
           actions_subcommand: 'helmdeploy'
           helm_create_secret_manager_secret_version: '0.0.6'
@@ -98,7 +98,7 @@ jobs:
           helm_oidc_proxy_chart_version: 0.0.39
           helm_imagetag_update: 'ui'
       - name: "Wait for deployment to come back online"
-        uses: broadinstitute/datarepo-actions/actions/wait-for-deployment@0.65.0
+        uses: broadinstitute/datarepo-actions/actions/wait-for-deployment@0.66.0
         env:
           DEPLOYMENT_TYPE: 'ui'
       - name: set cypresss env
@@ -116,11 +116,11 @@ jobs:
           npx cypress run --record
       - name: 'Clean state lock from used Namespace on API deploy'
         if: always()
-        uses: broadinstitute/datarepo-actions/actions/main@0.65.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.66.0
         with:
           actions_subcommand: 'k8_checknamespace_clean'
       - name: 'Clean whitelisted Runner IP'
         if: always()
-        uses: broadinstitute/datarepo-actions/actions/main@0.65.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.66.0
         with:
           actions_subcommand: 'gcp_whitelist_clean'

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -39,14 +39,14 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: 'Whitelist Runner IP'
-        uses: broadinstitute/datarepo-actions/actions/main@0.66.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
         with:
           actions_subcommand: 'gcp_whitelist'
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
       - name: 'Check for an available namespace to deploy API to and set state lock'
         id: namespace
-        uses: broadinstitute/datarepo-actions/actions/main@0.66.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
         with:
           actions_subcommand: 'k8_checknamespace'
           # Note: Integration-4 is also set up for UI testing, except that the datasets
@@ -88,7 +88,7 @@ jobs:
         run: |
           echo "Pushed docker image gcr.io/broad-jade-dev/jade-data-repo-ui:${GCR_TAG}"
       - name: 'Deploy to cluster with Helm'
-        uses: broadinstitute/datarepo-actions/actions/main@0.66.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
         with:
           actions_subcommand: 'helmdeploy'
           helm_create_secret_manager_secret_version: '0.0.6'
@@ -98,7 +98,7 @@ jobs:
           helm_oidc_proxy_chart_version: 0.0.39
           helm_imagetag_update: 'ui'
       - name: "Wait for deployment to come back online"
-        uses: broadinstitute/datarepo-actions/actions/wait-for-deployment@0.66.0
+        uses: broadinstitute/datarepo-actions/actions/wait-for-deployment@0.67.0
         env:
           DEPLOYMENT_TYPE: 'ui'
       - name: set cypresss env
@@ -116,11 +116,11 @@ jobs:
           npx cypress run --record
       - name: 'Clean state lock from used Namespace on API deploy'
         if: always()
-        uses: broadinstitute/datarepo-actions/actions/main@0.66.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
         with:
           actions_subcommand: 'k8_checknamespace_clean'
       - name: 'Clean whitelisted Runner IP'
         if: always()
-        uses: broadinstitute/datarepo-actions/actions/main@0.66.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
         with:
           actions_subcommand: 'gcp_whitelist_clean'

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Run codegen
         run: npm run codegen
       - name: Cypress Run Component Tests
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v5
         env:
           DISABLE_ESLINT_PLUGIN: true
         with:

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - name: npm ci

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -7,5 +7,5 @@ jobs:
     name: DSP AppSec Trivy check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: broadinstitute/dsp-appsec-trivy-action@v1


### PR DESCRIPTION
See https://github.com/DataBiosphere/jade-data-repo/pull/1404 PR description for more details about the changes.

### Testing
Successful runs against this branch:
- trivy (see latest run on PR)
- e2e (see latest run on PR)
- lint (see latest run on PR)
- unit (see latest run on PR)
- [update dev ui image](https://github.com/DataBiosphere/jade-data-repo-ui/actions/runs/4120022083)