### PR TITLE
[DR-2928] Collapse all resource role accordions by default

### DIFF
--- a/src/components/dataset/DatasetAccess.tsx
+++ b/src/components/dataset/DatasetAccess.tsx
@@ -70,7 +70,6 @@ function DatasetAccess(props: DatasetAccessProps) {
           typeOfUsers="Stewards"
           canManageUsers={canManageStewards}
           removeUser={removeUser(DatasetRoles.STEWARD)}
-          defaultOpen={true}
         />
       </Grid>
       <Grid item xs={12}>

--- a/src/components/snapshot/SnapshotAccess.tsx
+++ b/src/components/snapshot/SnapshotAccess.tsx
@@ -100,7 +100,6 @@ function SnapshotAccess(props: SnapshotAccessProps) {
           typeOfUsers="Stewards"
           canManageUsers={canManageUsers}
           removeUser={removeUser(SnapshotRoles.STEWARD)}
-          defaultOpen={true}
         />
       </Grid>
       <Grid item xs={12} data-cy="snapshot-readers">


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2928

Previously, dataset and snapshot steward accordions were expanded by default when clicking into the resource summary's roles and memberships tab.  Now, we close them all by default, since the stewards list can sometimes be quite long.

My [dev environment](https://jade-ok.datarepo-dev.broadinstitute.org/) has these changes deployed.  Here's a screen recording of the new behavior:

https://user-images.githubusercontent.com/79769153/220751417-be7f29ba-5021-4800-83d8-150d1897707d.mov

We considered also including a member count in the collapsed accordion headers -- i.e. 'Stewards (34)' -- but decided against it because such a count would only reflect direct members and could confuse our users.  Specifically, if a Firecloud group is a direct member of a resource's policy group, we won't be able to tell how many actual members it has.  We could revisit this in the future, though.