### PR TITLE
[DR-2736] Snapshot readers can export snapshots to Terra

### DIFF
--- a/src/components/snapshot/overview/SnapshotExport.test.tsx
+++ b/src/components/snapshot/overview/SnapshotExport.test.tsx
@@ -26,7 +26,7 @@ describe('SnapshotExport', () => {
   beforeEach(() => {
     mockStore = createMockStore([]);
   });
-  it('Test has export button', () => {
+  it('Test steward can export with permission sync', () => {
     const initialState = {
       snapshots: {
         snapshot,
@@ -48,8 +48,11 @@ describe('SnapshotExport', () => {
       </Router>,
     );
     cy.get('[data-cy="export-snapshot-button"]').should('contain.text', 'Export snapshot');
+    cy.get('[data-cy="tdr-sync-permissions-checkbox"] input')
+      .should('not.be.disabled')
+      .and('be.checked');
   });
-  it('Test has export button disabled', () => {
+  it('Test reader can export without permission sync', () => {
     const initialState = {
       snapshots: {
         snapshot,
@@ -70,7 +73,10 @@ describe('SnapshotExport', () => {
         </Provider>
       </Router>,
     );
-    cy.get('[data-cy="export-snapshot-button"]').should('be.disabled');
+    cy.get('[data-cy="export-snapshot-button"]').should('contain.text', 'Export snapshot');
+    cy.get('[data-cy="tdr-sync-permissions-checkbox"] input')
+      .should('be.disabled')
+      .and('not.be.checked');
   });
   it('Test preparing snapshot', () => {
     const preparingSnapshotState = {
@@ -123,7 +129,10 @@ describe('SnapshotExport', () => {
     cy.get('[data-cy="snapshot-export-ready-button"]')
       .should('contain.text', 'Snapshot ready - continue')
       .within(() => {
-        cy.get('a').should('have.attr', 'href').and('include', configuration.configObject.terraUrl);
+        cy.get('a')
+          .should('have.attr', 'href')
+          .and('include', configuration.configObject.terraUrl)
+          .and('include', 'tdrSyncPermissions=true');
       });
   });
 });

--- a/src/components/snapshot/overview/SnapshotExport.tsx
+++ b/src/components/snapshot/overview/SnapshotExport.tsx
@@ -135,9 +135,7 @@ function SnapshotExport(props: SnapshotExportProps) {
           label="Add workspace policy groups to snapshot readers"
         />
         <FormHelperText>
-          <i>
-            This will grant workspace members read access to the snapshot's tables and files
-          </i>
+          <i>This will grant workspace members read access to the snapshot's tables and files</i>
         </FormHelperText>
       </FormGroup>
       {!isProcessing && !isDone && (

--- a/src/components/snapshot/overview/SnapshotExport.tsx
+++ b/src/components/snapshot/overview/SnapshotExport.tsx
@@ -11,7 +11,6 @@ import {
   Typography,
 } from '@mui/material';
 import { CustomTheme } from '@mui/material/styles';
-import TerraTooltip from '../../common/TerraTooltip';
 import { exportSnapshot, resetSnapshotExport } from '../../../actions';
 import { TdrState } from '../../../reducers';
 import { AppDispatch } from '../../../store';
@@ -56,13 +55,13 @@ const formatExportUrl = (
   window: string,
   snapshot: SnapshotModel,
   manifest: string,
+  tdrSyncPermissions: boolean,
 ) =>
   `${terraUrl}#import-data?url=${window}&snapshotId=${snapshot.id}&format=tdrexport&snapshotName=${
     snapshot.name
-  }&tdrmanifest=${encodeURIComponent(manifest)}&tdrSyncPermissions=true`;
+  }&tdrmanifest=${encodeURIComponent(manifest)}&tdrSyncPermissions=${tdrSyncPermissions}`;
 
 function SnapshotExport(props: SnapshotExportProps) {
-  const [exportGsPaths, setExportGsPaths] = React.useState(false);
   const {
     classes,
     dispatch,
@@ -73,14 +72,17 @@ function SnapshotExport(props: SnapshotExportProps) {
     terraUrl,
     userRoles,
   } = props;
-  const exportResponseManifest =
-    exportResponse &&
-    exportResponse.format &&
-    exportResponse.format.parquet &&
-    exportResponse.format.parquet.manifest;
+  const exportResponseManifest = exportResponse?.format?.parquet?.manifest;
 
+  const [exportGsPaths, setExportGsPaths] = React.useState(false);
   const handleExportGsPathsChanged = () => {
     setExportGsPaths(!exportGsPaths);
+  };
+
+  const canSyncPermissions = userRoles.includes(SnapshotRoles.STEWARD);
+  const [tdrSyncPermissions, setTdrSyncPermissions] = React.useState(canSyncPermissions);
+  const handleTdrSyncPermissionsChanged = () => {
+    setTdrSyncPermissions(!tdrSyncPermissions);
   };
 
   const exportToWorkspaceCopy = () => {
@@ -92,31 +94,25 @@ function SnapshotExport(props: SnapshotExportProps) {
     dispatch(resetSnapshotExport());
   };
 
-  const gsPathsCheckbox = !isProcessing ? (
-    <Checkbox checked={exportGsPaths} onChange={handleExportGsPathsChanged} />
-  ) : (
-    <Checkbox checked={exportGsPaths} disabled />
-  );
-
-  const canExport = userRoles.includes(SnapshotRoles.STEWARD);
-  const tooltipMessage =
-    'Exporting a snapshot to a workspace means that all members of your workspace ' +
-    'will be able to have read only access to the tables and files in the snapshot';
-  const tooltipError = 'You must be a steward of this snapshot in order to export to Terra';
-
   return (
     <div>
       <Typography variant="h6" className={classes.section}>
         Export to Terra
       </Typography>
       <Typography variant="body1" className={classes.section}>
-        Export a copy of the snapshot metadata to an existing or new Terra workspace
+        Export a copy of the snapshot metadata to a new or existing Terra workspace
       </Typography>
       {of.cloudPlatform === 'gcp' && (
         <FormGroup>
           <FormControlLabel
             data-cy="gs-paths-checkbox"
-            control={gsPathsCheckbox}
+            control={
+              <Checkbox
+                checked={exportGsPaths}
+                onChange={handleExportGsPathsChanged}
+                disabled={isProcessing}
+              />
+            }
             label="Convert DRS URLs to Google Cloud Storage Paths (gs://...)"
           />
           <FormHelperText>
@@ -126,21 +122,34 @@ function SnapshotExport(props: SnapshotExportProps) {
           </FormHelperText>
         </FormGroup>
       )}
+      <FormGroup>
+        <FormControlLabel
+          data-cy="tdr-sync-permissions-checkbox"
+          control={
+            <Checkbox
+              checked={tdrSyncPermissions}
+              onChange={handleTdrSyncPermissionsChanged}
+              disabled={!canSyncPermissions || isProcessing}
+            />
+          }
+          label="Add workspace policy groups to snapshot readers"
+        />
+        <FormHelperText>
+          <i>
+            This will grant workspace members read access to the snapshot's tables and files
+          </i>
+        </FormHelperText>
+      </FormGroup>
       {!isProcessing && !isDone && (
-        <TerraTooltip title={canExport ? tooltipMessage : tooltipError}>
-          <span>
-            <Button
-              data-cy="export-snapshot-button"
-              onClick={exportToWorkspaceCopy}
-              className={classes.exportButton}
-              variant="outlined"
-              color="primary"
-              disabled={!canExport}
-            >
-              Export snapshot
-            </Button>
-          </span>
-        </TerraTooltip>
+        <Button
+          data-cy="export-snapshot-button"
+          onClick={exportToWorkspaceCopy}
+          className={classes.exportButton}
+          variant="outlined"
+          color="primary"
+        >
+          Export snapshot
+        </Button>
       )}
       {isProcessing && !isDone && (
         <Button
@@ -164,7 +173,13 @@ function SnapshotExport(props: SnapshotExportProps) {
           <a
             target="_blank"
             rel="noopener noreferrer"
-            href={formatExportUrl(terraUrl, window.location.origin, of, exportResponseManifest)}
+            href={formatExportUrl(
+              terraUrl,
+              window.location.origin,
+              of,
+              exportResponseManifest,
+              tdrSyncPermissions,
+            )}
           >
             Snapshot ready - continue
           </a>

--- a/src/components/snapshot/overview/SnapshotWorkspace.test.tsx
+++ b/src/components/snapshot/overview/SnapshotWorkspace.test.tsx
@@ -112,7 +112,7 @@ describe('Snapshot workspace accordion - with workspace entries', () => {
   it('Displays accordion and workspaces', () => {
     cy.get('[data-cy="snapshot-workspace-accordion"]').should(
       'contain.text',
-      'Workspaces with this snapshot',
+      'Snapshot Reader Workspaces',
     );
     cy.get('[data-cy="snapshot-workspace-list"]').children().should('have.length', 4);
     cy.get('[data-cy="snapshot-workspace-list"]').find('li').should('have.length', 2);
@@ -141,7 +141,7 @@ describe('Snapshot workspace accordion - without workspace entries', () => {
   it('Displays accordion and lists no workspaces', () => {
     cy.get('[data-cy="snapshot-workspace-accordion"]').should(
       'contain.text',
-      'Workspaces with this snapshot',
+      'Snapshot Reader Workspaces',
     );
     cy.get('.MuiAccordionDetails-root > .MuiTypography-root').should(
       'contain.text',

--- a/src/components/snapshot/overview/SnapshotWorkspace.tsx
+++ b/src/components/snapshot/overview/SnapshotWorkspace.tsx
@@ -64,7 +64,7 @@ function SnapshotWorkspace(props: SnapshotWorkspaceProps) {
         id="panel1a-header"
       >
         <Typography className={classes.snapshotAccordionTitle}>
-          Workspaces with this snapshot
+          Snapshot Reader Workspaces
         </Typography>
       </AccordionSummary>
       <AccordionDetails>


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2736

Previously in the TDR UI:
- All snapshot exports also synced destination workspace policy groups as snapshot readers.
- Thus, only snapshot stewards were allowed to initiate snapshot exports from the UI.  This is because snapshot readers do not hold the needed snapshot action to modify its readers, so could not complete the full export workflow.

Behavior now:
- Snapshot stewards can choose whether or not to sync workspace policy groups as snapshot readers during an export to Terra.  By default, this is enabled to remain consistent with existing behaviors.
- Snapshot readers can export snapshots to Terra, but can't sync the workspace policy groups as snapshot readers.
- If a snapshot export is performed without policy group syncing, the workspace members will not have full access to the snapshot's files as they would if they were full snapshot readers.

Export as a snapshot steward:

https://user-images.githubusercontent.com/79769153/223541054-f1a978b0-e7b0-4cd5-b1d3-c2210a42b8b7.mov

Export as a snapshot reader:

https://user-images.githubusercontent.com/79769153/223541156-489c3b4e-771a-4281-9c47-91b88ca3e827.mov

My [dev environment](https://jade-ok.datarepo-dev.broadinstitute.org/snapshots) is up to date with these changes.