### PR TITLE
DR-2956 - Turn off auto rebase for dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+  # Disable automatic rebasing to avoid tests kicking off all at once
+  rebase-strategy: "disabled"
   open-pull-requests-limit: 10
   ignore:
   # newer versions of prettier seem to format the code in a way that is incompatible with eslint (DR-2953)


### PR DESCRIPTION
Right now, when one dependabot PR changes, they all kick off tests. When 10 are kicked off at once, tests never complete.