### PR TITLE
[DR-2969] Display DUOS group's last synced time

### DIFF
--- a/src/components/EditableFieldView.tsx
+++ b/src/components/EditableFieldView.tsx
@@ -50,8 +50,6 @@ const styles = (theme: CustomTheme) =>
     },
   } as const);
 
-const UNSET_FIELD_TEXT = '(Empty)';
-
 interface EditableFieldViewProps extends WithStyles<typeof styles> {
   canEdit: boolean;
   isPendingSave: boolean;
@@ -159,7 +157,7 @@ function EditableFieldView({
       </div>
       {!canEdit && (
         <span className={classes.markdownPreview}>
-          <TextContent text={updatedFieldValue} emptyText={UNSET_FIELD_TEXT} markdown={true} />
+          <TextContent text={updatedFieldValue} markdown={true} />
         </span>
       )}
       {canEdit && (
@@ -167,11 +165,7 @@ function EditableFieldView({
           <div className={classes.textInputDiv}>
             {!isEditing && (
               <span className={classes.markdownPreview}>
-                <TextContent
-                  text={updatedFieldValue}
-                  emptyText={UNSET_FIELD_TEXT}
-                  markdown={true}
-                />
+                <TextContent text={updatedFieldValue} markdown={true} />
               </span>
             )}
             {isEditing && (

--- a/src/components/common/TextContent.tsx
+++ b/src/components/common/TextContent.tsx
@@ -71,7 +71,11 @@ function TextContent({
           {text}
         </ReactMarkdown>
       )}
-      {!text && <span className={classes.nullValue}>{emptyText}</span>}
+      {!text && (
+        <span data-cy="react-markdown-empty-text" className={classes.nullValue}>
+          {emptyText}
+        </span>
+      )}
     </>
   );
 }

--- a/src/components/snapshot/overview/SnapshotOverviewPanel.tsx
+++ b/src/components/snapshot/overview/SnapshotOverviewPanel.tsx
@@ -111,20 +111,30 @@ function SnapshotOverviewPanel(props: SnapshotOverviewPanelProps) {
               useMarkdown={true}
             />
           </Grid>
-          <Grid item xs={12}>
-            <Grid item xs={4}>
-              <EditableFieldView
-                fieldValue={snapshot.duosFirecloudGroup?.duosId}
-                fieldName="DUOS ID"
-                canEdit={isSteward}
-                isPendingSave={pendingSave.duosDataset}
-                updateFieldValueFn={(text: string | undefined) =>
-                  dispatch(updateDuosDataset(snapshot.id, text))
-                }
-                useMarkdown={false}
-                infoButtonText={duosInfoButtonText}
-              />
-            </Grid>
+          <Grid item xs={4}>
+            <EditableFieldView
+              fieldValue={snapshot.duosFirecloudGroup?.duosId}
+              fieldName="DUOS ID"
+              canEdit={isSteward}
+              isPendingSave={pendingSave.duosDataset}
+              updateFieldValueFn={(text: string | undefined) =>
+                dispatch(updateDuosDataset(snapshot.id, text))
+              }
+              useMarkdown={false}
+              infoButtonText={duosInfoButtonText}
+            />
+          </Grid>
+          <Grid item xs={8}>
+            {snapshot.duosFirecloudGroup && (
+              <Grid item xs={4}>
+                <Typography variant="h6">DUOS Users Last Synced:</Typography>
+                <Typography data-cy="snapshot-duos-last-synced">
+                  {snapshot.duosFirecloudGroup.lastSynced
+                    ? moment(snapshot.duosFirecloudGroup.lastSynced).fromNow()
+                    : 'Never'}
+                </Typography>
+              </Grid>
+            )}
           </Grid>
           <Grid item xs={4}>
             <Typography variant="h6">Root dataset:</Typography>


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2969

If a snapshot is linked to a DUOS dataset, we now display the DUOS Firecloud's last synced time in the snapshot summary panel.

We have some work coming down the pike to reorganize snapshot summary information in a more logical way within our UI, but for now this surfaces helpful information about the freshness of DUOS Firecloud groups.

Note: we're using the moment library to parse the timestamp value, ex. "an hour ago".  It might be a bit confusing to the user to see a moment on a tab that hasn't been refreshed in awhile, since a snapshot in the UI doesn't get updated periodically in the background (only on refresh or as part of action handling).  But this is consistent with our other moment usages, so I think it's okay.

**Demonstration**

My [developer environment](https://jade-ok.datarepo-dev.broadinstitute.org/snapshots/efb89ba7-8c64-4a7e-ae7a-31faea93d115) is up to date with these changes.

https://user-images.githubusercontent.com/79769153/235708277-de3b59d9-2d77-4d74-b972-1bb47938a892.mov