### PR TITLE
DR-3223: Fix Snapshot Create on paste with return carriage

### DIFF
--- a/cypress/integration/queryBuilder.spec.js
+++ b/cypress/integration/queryBuilder.spec.js
@@ -133,7 +133,7 @@ testPlatforms.forEach((testPlatform) => {
             .its('snapshots')
             .its('snapshotRequest')
             .its('filterStatement')
-            .should('contain', 'ancestry_specific_meta_analysis.ancestry IN ("EU")');
+            .should('contain', "ancestry_specific_meta_analysis.ancestry IN ('EU')");
         });
       });
 

--- a/src/components/dataset/data/sidebar/filter/FreetextFilter.jsx
+++ b/src/components/dataset/data/sidebar/filter/FreetextFilter.jsx
@@ -66,7 +66,7 @@ export class FreetextFilter extends React.PureComponent {
     const { handleChange, filterMap } = this.props;
     event.preventDefault();
     const text = event.clipboardData.getData('text');
-    const selections = text.split(/[ ,\n]+/);
+    const selections = text.split(/[ ,\r\n]+/);
     const nonEmpty = selections.filter((s) => s !== '');
     const updatedValueArray = _.get(filterMap, 'value', []).concat(nonEmpty);
     handleChange(updatedValueArray);

--- a/src/components/dataset/data/sidebar/panels/FilterPanel.jsx
+++ b/src/components/dataset/data/sidebar/panels/FilterPanel.jsx
@@ -159,7 +159,7 @@ export class FilterPanel extends React.PureComponent {
     event.preventDefault();
     const { searchStrings } = this.state;
     const text = event.clipboardData.getData('text');
-    const selections = text.split(/[ ,\n]+/);
+    const selections = text.split(/[ ,\r\n]+/);
     const nonEmpty = selections.filter((s) => s !== '');
     const updatedValueArray = searchStrings.concat(nonEmpty);
     this.setState({ searchStrings: updatedValueArray });

--- a/src/modules/filter.ts
+++ b/src/modules/filter.ts
@@ -88,7 +88,7 @@ export const buildSnapshotFilterStatement = (filterMap: any, dataset: DatasetMod
             if (isRange) {
               statementClauses.push(`${property} BETWEEN ${keyValue[0]} AND ${keyValue[1]}`);
             } else if (_.isString(keyValue[0])) {
-              const selections = keyValue.map((selection) => `"${selection}"`).join(',');
+              const selections = keyValue.map((selection) => `'${selection}'`).join(',');
               statementClauses.push(`${property} ${notClause} IN (${selections})`);
             } else {
               statementClauses.push(
@@ -104,7 +104,7 @@ export const buildSnapshotFilterStatement = (filterMap: any, dataset: DatasetMod
                 if (checkboxValue === 'null') {
                   checkboxClauses.push(`${property} IS NULL`);
                 } else {
-                  checkboxValues.push(`"${checkboxValue}"`);
+                  checkboxValues.push(`'${checkboxValue}'`);
                 }
               });
               if (checkboxValues.length > 0) {

--- a/src/modules/filter.ts
+++ b/src/modules/filter.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { DatasetModel } from 'generated/tdr';
 
-export const buildfilterStatement = (filterMap: any) => {
+export const buildfilterStatement = (filterMap: any, dataset: DatasetModel | undefined) => {
   if (!_.isEmpty(filterMap)) {
     const tableClauses: any = [];
 
@@ -12,74 +12,8 @@ export const buildfilterStatement = (filterMap: any) => {
         const statementClauses: any = [];
 
         _.keys(filters).forEach((key) => {
-          // Note: original code qualitfied this with the dataset name
-          const property = `${key}`;
-          const keyValue = filters[key].value;
-          const isRange = filters[key].type === 'range';
-          const notClause = filters[key].exclude ? 'NOT' : '';
-
-          if (_.isArray(keyValue)) {
-            if (isRange) {
-              statementClauses.push(`${property} BETWEEN ${keyValue[0]} AND ${keyValue[1]}`);
-            } else if (_.isString(keyValue[0])) {
-              const selections = keyValue.map((selection) => `'${selection}'`).join(',');
-              statementClauses.push(`${property} ${notClause} IN (${selections})`);
-            } else {
-              statementClauses.push(
-                `${property} = '${keyValue[0]}' OR ${property} = '${keyValue[1]}'`,
-              );
-            }
-          } else if (_.isObject(keyValue)) {
-            const checkboxes = _.keys(keyValue);
-            if (checkboxes.length > 0) {
-              const checkboxValues: any = [];
-              const checkboxClauses = [];
-              checkboxes.forEach((checkboxValue) => {
-                if (checkboxValue === 'null') {
-                  checkboxClauses.push(`${property} IS NULL`);
-                } else {
-                  checkboxValues.push(`'${checkboxValue}'`);
-                }
-              });
-              if (checkboxValues.length > 0) {
-                checkboxClauses.push(`${property} IN (${checkboxValues.join(',')})`);
-              }
-              statementClauses.push(`(${checkboxClauses.join(' OR ')})`);
-            }
-          } else {
-            const values = keyValue.split(',').map((val: any) => `${key}='${val}'`);
-            statementClauses.push(values.join(' OR '));
-          }
-        });
-
-        if (!_.isEmpty(statementClauses)) {
-          tableClauses.push(statementClauses.join(' AND '));
-        }
-      }
-    });
-
-    if (!_.isEmpty(tableClauses)) {
-      return `WHERE ${tableClauses.join(' AND ')}`;
-    }
-  }
-  return '';
-};
-
-// TODO - this is largely the same as buildfilterStatement
-// Will refactor with DR-3025 because will need to add logic for azure filtering/snapshot create
-export const buildSnapshotFilterStatement = (filterMap: any, dataset: DatasetModel) => {
-  if (!_.isEmpty(filterMap)) {
-    const tableClauses: any = [];
-
-    _.keys(filterMap).forEach((table) => {
-      const filters = filterMap[table];
-
-      if (!_.isEmpty(filters)) {
-        const statementClauses: any = [];
-
-        _.keys(filters).forEach((key) => {
-          const datasetName = !dataset ? '' : `${dataset.name}.`;
-          const property = `${datasetName}${table}.${key}`;
+          const datasetName = !dataset ? '' : `${dataset.name}.${table}.`;
+          const property = `${datasetName}${key}`;
           const keyValue = filters[key].value;
           const isRange = filters[key].type === 'range';
           const notClause = filters[key].exclude ? 'NOT' : '';

--- a/src/reducers/query.ts
+++ b/src/reducers/query.ts
@@ -299,7 +299,7 @@ export default {
         });
       },
       [ActionTypes.APPLY_FILTERS]: (state, action: any) => {
-        const filterStatement = buildfilterStatement(action.payload.filters);
+        const filterStatement = buildfilterStatement(action.payload.filters, undefined);
         const _columns = state.columns.map((c: TableColumnType) => ({
           ...c,
           filterHasUpdated: true,

--- a/src/reducers/snapshot.ts
+++ b/src/reducers/snapshot.ts
@@ -1,6 +1,6 @@
 import { handleActions } from 'redux-actions';
 import immutable from 'immutability-helper';
-import { buildSnapshotFilterStatement } from 'modules/filter';
+import { buildfilterStatement } from 'modules/filter';
 import { buildSnapshotJoinStatement } from 'modules/snapshotByQuery';
 import { LOCATION_CHANGE } from 'connected-react-router';
 
@@ -280,7 +280,7 @@ export default {
       [ActionTypes.APPLY_FILTERS]: (state, action: any) => {
         const { filters, dataset } = action.payload;
 
-        const filterStatement = buildSnapshotFilterStatement(filters, dataset);
+        const filterStatement = buildfilterStatement(filters, dataset);
 
         return immutable(state, {
           snapshotRequest: { filterStatement: { $set: filterStatement } },


### PR DESCRIPTION
The changes: Switch to single quotes to match other filtering commands (And combine these functions since they're now the same); Add return carriage handling to paste into filter operation.

**The Problem**

A user ran into an issue creating a snapshot in the UI. The query for the snapshot create looked like the following example. This causes a "BigQueryException Syntax error - Unclosed string literal" error on snapshot create.


```sql
 SELECT <dataset>.<table>.datarepo_row_id FROM  <dataset>.<table> WHERE  <dataset>.<table>.<column> 
 IN (\"sample1\r\", \"sample2\r\", \"sample3\r\", \"sample1\r\")
```

I still haven't quite figured out how the escaped return carriage "\r" ended up in the query. 

With the the included code changes, we should instead get something that looks like the following example. 

```sql
SELECT <dataset>.<table>.datarepo_row_id FROM  <dataset>.<table>  WHERE  <dataset>.<table>.<column> 
IN ('sample1', 'sample2', 'sample3', 'sample4')
```

Example snapshot create by query with changes:
```sql
SELECT V2F_GWAS_Summary_Statistics.variant.datarepo_row_id FROM V2F_GWAS_Summary_Statistics.variant
WHERE V2F_GWAS_Summary_Statistics.variant.id  IN ('1:98233405:A:G','1:155630619:A:C')
```

### Testing

Changes have been deployed to my dev env: https://jade-sh.datarepo-dev.broadinstitute.org/datasets/5ed80a11-9c2e-402c-a583-fe4c85ead4b4 



