### PR TITLE
[DR-3194] Remove unnecessary dependabot pinnings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,3 @@ updates:
   - dependency-name: "prettier"
   # newer versions of material ui (MUI) cause our styling to not respect theming or straight up break the UI (DR-2952)
   - dependency-name: "@mui/*"
-  # the upgrade is a major breaking change that significant requires test refactoring (DR-2954)
-  - dependency-name: "cypress"
-    update-types: ["version-update:semver-major"]
-  # new versions prevents unit tests from running (DR-2954)
-  - dependency-name: "@cypress/react"


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/DR-3194

`@cypress/react` was removed and `cypress` was upgraded to v12 when migrating to vite.