### PR TITLE
[DR-2890] Update deprecated Github Actions set-output commands

### DIFF
--- a/.github/workflows/helmtagbump.yaml
+++ b/.github/workflows/helmtagbump.yaml
@@ -106,7 +106,7 @@ jobs:
           ((a[2]++))
           printf "increase default ui version: ${a[2]}\n\n"
           new_version="${a[0]}.${a[1]}.${a[2]}"
-          echo "::set-output name=new_version::$new_version"
+          echo "new_version=${new_version}" >> $GITHUB_OUTPUT
       - name: "bump ui chart Version"
         uses: docker://mikefarah/yq:3
         with:


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2890

The `save-state` and `set-output` commands are going to be deprecated in Github Actions. This PR updates the syntax for `set-output` (`save-state` is not used anywhere). Here is more context about this change: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/