### PR TITLE
DR-3100: Cherry-pick dev image to prod/public gcr on merge to dev

### DIFF
--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -23,6 +23,8 @@ env:
 
 jobs:
   update_image:
+    outputs:
+      ui_image_tag: ${{ steps.bumperstep.outputs.tag }}
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -43,6 +45,7 @@ jobs:
           path: datarepo-helm-definitions
       - name: 'Bump the tag to a new version'
         uses: broadinstitute/datarepo-actions/actions/main@0.67.0
+        id: bumperstep
         with:
           actions_subcommand: 'bumper'
           role_id: ${{ secrets.ROLE_ID }}
@@ -95,12 +98,21 @@ jobs:
     needs: update_image
     uses: ./.github/workflows/helmtagbump.yaml
     secrets: inherit
+  cherry_pick_image_to_production_gcr:
+    needs: update_image
+    uses: DataBiosphere/jade-data-repo/.github/workflows/cherry-pick-image.yaml@1.536.0
+    secrets: inherit
+    with:
+      gcr_tag: ${{ needs.update_image.outputs.ui_image_tag }}
+      source_gcr_url: 'gcr.io/broad-jade-dev/jade-data-repo-ui'
+      target_gcr_url: 'gcr.io/datarepo-public-gcr/jade-data-repo-ui'
   action_notify:
     runs-on: ubuntu-latest
     if: always()
     needs:
       - update_image
       - helm_tag_bump
+      - cherry_pick_image_to_production_gcr
     steps:
     - name: Slack job status
       uses: broadinstitute/action-slack@v3.15.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,3 +22,10 @@ jobs:
         run: npm ci
       - name: Run ESLint
         run: npm run lint
+  cherry_pick_image_to_production_gcr:
+    uses: DataBiosphere/jade-data-repo/.github/workflows/cherry-pick-image.yaml@1.536.0
+    secrets: inherit
+    with:
+      gcr_tag: '0bcb377'
+      source_gcr_url: 'gcr.io/broad-jade-dev/jade-data-repo-ui'
+      target_gcr_url: 'gcr.io/datarepo-public-gcr/jade-data-repo-ui'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,10 +22,3 @@ jobs:
         run: npm ci
       - name: Run ESLint
         run: npm run lint
-  cherry_pick_image_to_production_gcr:
-    uses: DataBiosphere/jade-data-repo/.github/workflows/cherry-pick-image.yaml@1.536.0
-    secrets: inherit
-    with:
-      gcr_tag: '0bcb377'
-      source_gcr_url: 'gcr.io/broad-jade-dev/jade-data-repo-ui'
-      target_gcr_url: 'gcr.io/datarepo-public-gcr/jade-data-repo-ui'


### PR DESCRIPTION
Part of work to move away from two GCRs - https://github.com/DataBiosphere/jade-data-repo/pull/1521
### The Changes
- Output tag during bump action
- Call jade-data-repo's cherry-pick action
- Wait to send slack notification until cherry-pick completes

### Testing
- Testing out running the cherry-pick action by copying the job code over to the lint action and giving it an image tag of an existing tag (rather than a version tag). This successfully ran!
<img width="1396" alt="image" src="https://github.com/DataBiosphere/jade-data-repo-ui/assets/13254229/025926cc-d442-4087-b5e5-4e1db9cdc87c">
<img width="767" alt="image" src="https://github.com/DataBiosphere/jade-data-repo-ui/assets/13254229/fea0c9d7-af79-4261-a18a-b83ac66e0f46">

### Remaining points of failure
- For the UI, I'm having to pull the tag version from the bumper action. From looking at the output from previous runs, I'm pretty sure this is the tag I want, but I could be wrong
- As true with the API, I don't want to run the full dev-image-update action off my PR because versions could get out of wack. But, I think I've tested almost all of the individual components. 