### PR TITLE
DR-3178 - Add note that *Azure* snapshot import into Terra is not yet fully supported 

### DIFF
--- a/src/components/snapshot/overview/SnapshotExport.test.tsx
+++ b/src/components/snapshot/overview/SnapshotExport.test.tsx
@@ -15,6 +15,12 @@ const snapshot: SnapshotModel = {
   cloudPlatform: 'gcp',
 };
 
+const azureSnapshot: SnapshotModel = {
+  id: 'uuid',
+  name: 'AzureSnapshot',
+  cloudPlatform: 'azure',
+};
+
 const configuration = {
   configObject: {
     terraUrl: 'https://bvdp-saturn-dev.appspot.com/',
@@ -134,5 +140,47 @@ describe('SnapshotExport', () => {
           .and('include', configuration.configObject.terraUrl)
           .and('include', 'tdrSyncPermissions=true');
       });
+  });
+  it('Test note for Azure snapshot', () => {
+    const initialAzureState = {
+      snapshots: {
+        exportIsProcessing: false,
+        exportIsDone: false,
+        userRoles: ['steward'],
+      },
+      configuration,
+    };
+    const store = mockStore(initialAzureState);
+    mount(
+      <Router history={history}>
+        <Provider store={store}>
+          <ThemeProvider theme={globalTheme}>
+            <SnapshotExport of={azureSnapshot} />
+          </ThemeProvider>
+        </Provider>
+      </Router>,
+    );
+    cy.get('[data-cy="azure-warning-note"]').should('contain.text', 'not yet fully supported');
+  });
+  it('No test note for Gcp snapshot', () => {
+    const initialGcpState = {
+      snapshots: {
+        exportIsProcessing: false,
+        exportIsDone: false,
+        userRoles: ['steward'],
+      },
+      configuration,
+    };
+    const store = mockStore(initialGcpState);
+    mount(
+      <Router history={history}>
+        <Provider store={store}>
+          <ThemeProvider theme={globalTheme}>
+            <SnapshotExport of={snapshot} />
+          </ThemeProvider>
+        </Provider>
+      </Router>,
+    );
+    cy.get('[data-cy="azure-warning-note"]').should('not.exist');
   });
 });

--- a/src/components/snapshot/overview/SnapshotExport.tsx
+++ b/src/components/snapshot/overview/SnapshotExport.tsx
@@ -14,7 +14,7 @@ import { CustomTheme } from '@mui/material/styles';
 import { exportSnapshot, resetSnapshotExport } from '../../../actions';
 import { TdrState } from '../../../reducers';
 import { AppDispatch } from '../../../store';
-import { SnapshotExportResponseModel, SnapshotModel } from '../../../generated/tdr';
+import { CloudPlatform, SnapshotExportResponseModel, SnapshotModel } from '../../../generated/tdr';
 import { SnapshotRoles } from '../../../constants';
 
 const styles = (theme: CustomTheme) =>
@@ -86,7 +86,7 @@ function SnapshotExport(props: SnapshotExportProps) {
   };
 
   const exportToWorkspaceCopy = () => {
-    const validatePrimaryKeyUniqueness = of.cloudPlatform === 'gcp';
+    const validatePrimaryKeyUniqueness = of.cloudPlatform === CloudPlatform.Gcp;
     dispatch(exportSnapshot(of.id, exportGsPaths, validatePrimaryKeyUniqueness));
   };
 
@@ -99,10 +99,15 @@ function SnapshotExport(props: SnapshotExportProps) {
       <Typography variant="h6" className={classes.section}>
         Export to Terra
       </Typography>
+      {of.cloudPlatform === CloudPlatform.Azure && (
+        <Typography variant="h6" className={classes.section} data-cy="azure-warning-note">
+          Note: Azure snapshot import into Terra is not yet fully supported.
+        </Typography>
+      )}
       <Typography variant="body1" className={classes.section}>
         Export a copy of the snapshot metadata to a new or existing Terra workspace
       </Typography>
-      {of.cloudPlatform === 'gcp' && (
+      {of.cloudPlatform === CloudPlatform.Gcp && (
         <FormGroup>
           <FormControlLabel
             data-cy="gs-paths-checkbox"


### PR DESCRIPTION
Right now, when an **Azure** snapshot is exported into Terra, only the table names imported into the Terra workspace. This change adds a note just to help alleviate some potential confusion around this partially implemented functionality. Once this feature is implemented in Terra, we should revert this change. 
![image](https://github.com/DataBiosphere/jade-data-repo-ui/assets/13254229/402390b9-4774-4f2c-b08a-5116473b625a)
