### PR TITLE
[DDO-3250] Don't update datarepo-helm-definitions's dev anymore

### DIFF
--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -79,9 +79,13 @@ jobs:
           gcloud auth configure-docker --quiet
           docker push gcr.io/${{ env.gcr_google_project }}/jade-data-repo-ui:${GCR_TAG}
           gcloud container images \
-          add-tag \
-          gcr.io/${{ env.gcr_google_project }}/jade-data-repo-ui:"${GCR_TAG}" \
-          gcr.io/${{ env.gcr_google_project }}/jade-data-repo-ui:"${{ steps.uiprevioustag.outputs.tag }}" --quiet
+            add-tag \
+            gcr.io/${{ env.gcr_google_project }}/jade-data-repo-ui:"${GCR_TAG}" \
+            gcr.io/${{ env.gcr_google_project }}/jade-data-repo-ui:"${{ steps.uiprevioustag.outputs.tag }}" --quiet
+          gcloud container images \
+            add-tag \
+            gcr.io/${{ env.gcr_google_project }}/jade-data-repo-ui:"${GCR_TAG}" \
+            gcr.io/${{ env.gcr_google_project }}/jade-data-repo-ui:"${GCR_TAG}-develop" --quiet
   helm_tag_bump:
     needs: update_image
     uses: ./.github/workflows/helmtagbump.yaml

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -37,12 +37,6 @@ jobs:
           fetch-depth: 0
           ref: develop
           token: ${{ secrets.BROADBOT_TOKEN }}
-      - name: 'Checkout datarepo-helm-definitions repo'
-        uses: actions/checkout@v3
-        with:
-          repository: 'broadinstitute/datarepo-helm-definitions'
-          token: ${{ secrets.BROADBOT_TOKEN }}
-          path: datarepo-helm-definitions
       - name: 'Bump the tag to a new version'
         uses: broadinstitute/datarepo-actions/actions/main@0.67.0
         id: bumperstep
@@ -88,12 +82,6 @@ jobs:
           add-tag \
           gcr.io/${{ env.gcr_google_project }}/jade-data-repo-ui:"${GCR_TAG}" \
           gcr.io/${{ env.gcr_google_project }}/jade-data-repo-ui:"${{ steps.uiprevioustag.outputs.tag }}" --quiet
-      - name: 'Check and edit Helm definition for dev'
-        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
-        with:
-          actions_subcommand: 'deploytagupdate'
-          helm_env_prefix: dev
-          helm_imagetag_update: ui
   helm_tag_bump:
     needs: update_image
     uses: ./.github/workflows/helmtagbump.yaml


### PR DESCRIPTION
Related to https://github.com/broadinstitute/datarepo-helm-definitions/pull/474, there's no reason to update these files anymore.

I'm not touching the other parts of this repo's GHA, which seem to:
- update datarepo-helm's UI chart with the new versions
- update integration environments with the new UI versions
- propagate UI images across the different GCRs