### PR TITLE
DR-3408: SqlSortDirection Model no longer generated

### DIFF
--- a/src/sagas/repository.ts
+++ b/src/sagas/repository.ts
@@ -791,7 +791,7 @@ export function* previewData({ payload }: any): any {
     offset: queryState.page * queryState.rowsPerPage,
     limit: queryState.rowsPerPage,
     sort: _.isEmpty(queryState.orderProperty) ? DbColumns.ROW_ID : `${queryState.orderProperty}`,
-    direction: queryState.orderDirection, // query data enndpoint defaults sort direction to asc
+    direction: queryState.orderDirection, // query data endpoint defaults sort direction to asc
     filter: _.isEmpty(queryState.filterStatement) ? '' : `${queryState.filterStatement}`,
   };
   const query = `/api/repository/v1/${payload.resourceType}s/${payload.resourceId}/data/${payload.table}`;

--- a/src/sagas/repository.ts
+++ b/src/sagas/repository.ts
@@ -20,7 +20,7 @@ import _ from 'lodash';
 import { RouterRootState } from 'connected-react-router';
 
 import { showNotification } from 'modules/notifications';
-import { JobModelJobStatusEnum, SqlSortDirection } from 'generated/tdr';
+import { JobModelJobStatusEnum, SqlSortDirectionAscDefault } from 'generated/tdr';
 import {
   ActionTypes,
   Status,
@@ -792,7 +792,7 @@ export function* previewData({ payload }: any): any {
     limit: queryState.rowsPerPage,
     sort: _.isEmpty(queryState.orderProperty) ? DbColumns.ROW_ID : `${queryState.orderProperty}`,
     direction: _.isEmpty(queryState.orderDirection)
-      ? SqlSortDirection.Asc
+      ? SqlSortDirectionAscDefault.Asc
       : `${queryState.orderDirection}`,
     filter: _.isEmpty(queryState.filterStatement) ? '' : `${queryState.filterStatement}`,
   };

--- a/src/sagas/repository.ts
+++ b/src/sagas/repository.ts
@@ -20,7 +20,7 @@ import _ from 'lodash';
 import { RouterRootState } from 'connected-react-router';
 
 import { showNotification } from 'modules/notifications';
-import { JobModelJobStatusEnum, SqlSortDirectionAscDefault } from 'generated/tdr';
+import { JobModelJobStatusEnum } from 'generated/tdr';
 import {
   ActionTypes,
   Status,
@@ -791,9 +791,7 @@ export function* previewData({ payload }: any): any {
     offset: queryState.page * queryState.rowsPerPage,
     limit: queryState.rowsPerPage,
     sort: _.isEmpty(queryState.orderProperty) ? DbColumns.ROW_ID : `${queryState.orderProperty}`,
-    direction: _.isEmpty(queryState.orderDirection)
-      ? SqlSortDirectionAscDefault.Asc
-      : `${queryState.orderDirection}`,
+    direction: queryState.orderDirection, // query data enndpoint defaults sort direction to asc
     filter: _.isEmpty(queryState.filterStatement) ? '' : `${queryState.filterStatement}`,
   };
   const query = `/api/repository/v1/${payload.resourceType}s/${payload.resourceId}/data/${payload.table}`;


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3408
____________
With a [recent TDR change](https://github.com/DataBiosphere/jade-data-repo/pull/1541), we no longer generate the "SqlSortDirection" model via swagger. Instead we generate "SqlSortDirectionAscDefault" and "SqlSortDirectionDescDefault" models. 

Since we are now setting a default for the query data endpoint in the TDR code, we can pass through an empty sort direction and it will default to "asc." So, we can remove the empty string handling and the reference to the SQLSortDirection model.

A few notes:
**How we sort in the UI**
- By default, we sort by the datarepo_row_id "desc" when viewing data in the UI
- However, we do not show the datarepo_row_id, so the order looks random.

This is not ideal.  We should instead default to sorting by the first non-datarepo-row-id, default to "asc". But, this needs to be communicated well with the users so that they're not confused as to why their data is suddenly appearing different to them. [Added ticket for this - DR-3407](https://broadworkbench.atlassian.net/browse/DR-3407) 

**We missed that the UI code was no longer building**
- Our UI e2e tests have been failing for a week, but we haven't noticed because we do not send nightly test failure alerts to the sack. We should add a slack notification on failure. https://broadworkbench.atlassian.net/browse/DR-3406
 


