### PR TITLE
DR-3406: Send slack alerts on nightly test failures; Update to use slack's GHA Integration

### DIFF
--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -103,5 +103,5 @@ jobs:
     uses: ./.github/workflows/notify-slack.yaml
     secrets: inherit
     with:
-      workflow_name: Dev Image Udpate
+      workflow_name: Dev Image Update
       notify_on_success: true

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -98,19 +98,10 @@ jobs:
       gcr_tag: ${{ needs.update_image.outputs.ui_image_tag }}
       source_gcr_url: 'gcr.io/broad-jade-dev/jade-data-repo-ui'
       target_gcr_url: 'gcr.io/datarepo-public-gcr/jade-data-repo-ui'
-  action_notify:
-    runs-on: ubuntu-latest
-    if: always()
-    needs:
-      - update_image
-      - helm_tag_bump
-      - cherry_pick_image_to_production_gcr
-    steps:
-    - name: Slack job status
-      uses: broadinstitute/action-slack@v3.15.0
-      with:
-        status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
-        author_name: Integration Test
-      env:
-        GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  notify-slack:
+    needs: [ update_image, helm_tag_bump, cherry_pick_image_to_production_gcr ]
+    uses: ./.github/workflows/notify-slack.yaml
+    secrets: inherit
+    with:
+      workflow_name: Dev Image Udpate
+      notify_on_success: true

--- a/.github/workflows/helmtagbump.yaml
+++ b/.github/workflows/helmtagbump.yaml
@@ -62,15 +62,6 @@ jobs:
           GITHUB_REPO: datarepo-helm-definitions
           SWITCH_DIRECTORIES: true
           MERGE_BRANCH: master
-      - name: Slack job status
-        if: ${{ inputs.notify-slack && always() }}
-        uses: broadinstitute/action-slack@v2
-        with:
-          status: ${{ job.status }}
-          author_name: ui_helm_bumper
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   ui_helm_default_chart_tag:
     runs-on: ubuntu-20.04
     steps:
@@ -118,12 +109,12 @@ jobs:
           GITHUB_REPO: datarepo-helm
           SWITCH_DIRECTORIES: true
           MERGE_BRANCH: master
-      - name: Slack job status
-        if: ${{ inputs.notify-slack && always() }}
-        uses: broadinstitute/action-slack@v2
-        with:
-          status: ${{ job.status }}
-          author_name: ui_helm_bumper
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  notify-slack:
+    needs: [ integration_helm_tag_update, ui_helm_default_chart_tag ]
+    uses: ./.github/workflows/notify-slack.yaml
+    secrets: inherit
+    with:
+      workflow_name: Helm Tag Bump
+      notify_on_failure: ${{ inputs.notify-slack }}
+      notify_on_success: ${{ inputs.notify-slack }}
+

--- a/.github/workflows/notify-slack.yaml
+++ b/.github/workflows/notify-slack.yaml
@@ -27,7 +27,7 @@ on:
 jobs:
     notify-slack:
         runs-on: ubuntu-latest
-        if: ${{ !cancelled() }} && github.ref == 'refs/heads/dev' && (inputs.notify_on_failure || inputs.notify_on_success)
+        if: ${{ !cancelled() && github.ref == 'refs/heads/dev' }}
         steps:
           - name: Notify slack on failure
             if: inputs.notify_on_failure && failure()

--- a/.github/workflows/notify-slack.yaml
+++ b/.github/workflows/notify-slack.yaml
@@ -35,7 +35,7 @@ jobs:
             #if: inputs.notify_on_failure && failure()
             uses: slackapi/slack-github-action@v1.24.0
             with:
-              channel-id: ${{ env.FAILURE_SLACK_CHANNEL_ID }}
+              channel-id: ${{ inputs.failure_slack_channel_id }}
               payload: |
                 {
                   "text": "${{ env.REPO_NAME }} ${{ inputs.workflow_name }}",
@@ -60,7 +60,7 @@ jobs:
             #if: inputs.notify_on_success && success()
             uses: slackapi/slack-github-action@v1.24.0
             with:
-              channel-id: ${{ env.SUCCESS_SLACK_CHANNEL_ID }}
+              channel-id: ${{ inputs.success_slack_channel_id }}
               payload: |
                 {
                   "text": "${{ env.REPO_NAME }} ${{ inputs.workflow_name }}",

--- a/.github/workflows/notify-slack.yaml
+++ b/.github/workflows/notify-slack.yaml
@@ -21,11 +21,10 @@ on:
 jobs:
     notify-slack:
         runs-on: ubuntu-latest
-        # if: github.ref == 'refs/heads/dev' && (inputs.notify_on_failure || inputs.notify_on_success)
+        if: github.ref == 'refs/heads/dev' && (inputs.notify_on_failure || inputs.notify_on_success)
         steps:
           - name: Notify slack on failure
-            #if: inputs.notify_on_failure && failure()
-            if: inputs.notify_on_success && success()
+            if: inputs.notify_on_failure && failure()
             uses: slackapi/slack-github-action@v1.24.0
             with:
               channel-id: ${{ env.FAILURE_SLACK_CHANNEL_ID }}
@@ -50,7 +49,7 @@ jobs:
             env:
               SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN}}
           - name: Notify slack on Success
-            #if: inputs.notify_on_success && success()
+            if: inputs.notify_on_success && success()
             uses: slackapi/slack-github-action@v1.24.0
             with:
               channel-id: ${{ env.SUCCESS_SLACK_CHANNEL_ID }}

--- a/.github/workflows/notify-slack.yaml
+++ b/.github/workflows/notify-slack.yaml
@@ -20,10 +20,11 @@ on:
 jobs:
     notify-slack:
         runs-on: ubuntu-latest
-        if: github.ref == 'refs/heads/dev' && (inputs.notify_on_failure || inputs.notify_on_success)
+        # if: github.ref == 'refs/heads/dev' && (inputs.notify_on_failure || inputs.notify_on_success)
         steps:
           - name: Notify slack on failure
-            if: inputs.notify_on_failure && failure()
+            #if: inputs.notify_on_failure && failure()
+            if: inputs.notify_on_success && success()
             uses: slackapi/slack-github-action@v1.24.0
             with:
               channel-id: ${{ env.SLACK_CHANNEL_ID }}
@@ -48,7 +49,7 @@ jobs:
             env:
               SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN}}
           - name: Notify slack on Success
-            if: inputs.notify_on_success && success()
+            #if: inputs.notify_on_success && success()
             uses: slackapi/slack-github-action@v1.24.0
             with:
               channel-id: ${{ env.SLACK_CHANNEL_ID }}

--- a/.github/workflows/notify-slack.yaml
+++ b/.github/workflows/notify-slack.yaml
@@ -27,7 +27,9 @@ on:
 jobs:
     notify-slack:
         runs-on: ubuntu-latest
-        #if: github.ref == 'refs/heads/dev' && (inputs.notify_on_failure || inputs.notify_on_success)
+        ## Run if success or failure, but not cancelled
+        if: ${{ !cancelled() }}
+        #if: !cancelled() && github.ref == 'refs/heads/dev' && (inputs.notify_on_failure || inputs.notify_on_success)
         steps:
           - name: Notify slack on failure
             #if: inputs.notify_on_failure && failure()

--- a/.github/workflows/notify-slack.yaml
+++ b/.github/workflows/notify-slack.yaml
@@ -1,7 +1,8 @@
 name: notify-slack
 env:
-  SLACK_BOT_TOKEN: ${{ secrets.TEST_SLACK_BOT_TOKEN}}
-  SLACK_CHANNEL_ID: "CMYTGJVFY"
+  SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN}}
+  FAILURE_SLACK_CHANNEL_ID: "CMYTGJVFY" # #jade-alerts
+  SUCCESS_SLACK_CHANNEL_ID: "CK9M0ENRJ" # #jade-spam
   REPO_NAME: "Data Repo UI"
 on:
     workflow_call:
@@ -26,7 +27,7 @@ jobs:
             if: inputs.notify_on_failure && failure()
             uses: slackapi/slack-github-action@v1.24.0
             with:
-              channel-id: ${{ env.SLACK_CHANNEL_ID }}
+              channel-id: ${{ env.FAILURE_SLACK_CHANNEL_ID }}
               payload: |
                 {
                   "text": "${{ env.REPO_NAME }} ${{ inputs.workflow_name }}",
@@ -51,7 +52,7 @@ jobs:
             if: inputs.notify_on_success && success()
             uses: slackapi/slack-github-action@v1.24.0
             with:
-              channel-id: ${{ env.SLACK_CHANNEL_ID }}
+              channel-id: ${{ env.SUCCESS_SLACK_CHANNEL_ID }}
               payload: |
                 {
                   "text": "${{ env.REPO_NAME }} ${{ inputs.workflow_name }}",

--- a/.github/workflows/notify-slack.yaml
+++ b/.github/workflows/notify-slack.yaml
@@ -27,12 +27,10 @@ on:
 jobs:
     notify-slack:
         runs-on: ubuntu-latest
-        ## Run if success or failure, but not cancelled
-        if: ${{ !cancelled() }}
-        #if: !cancelled() && github.ref == 'refs/heads/dev' && (inputs.notify_on_failure || inputs.notify_on_success)
+        if: ${{ !cancelled() }} && github.ref == 'refs/heads/dev' && (inputs.notify_on_failure || inputs.notify_on_success)
         steps:
           - name: Notify slack on failure
-            #if: inputs.notify_on_failure && failure()
+            if: inputs.notify_on_failure && failure()
             uses: slackapi/slack-github-action@v1.24.0
             with:
               channel-id: ${{ inputs.failure_slack_channel_id }}
@@ -57,7 +55,7 @@ jobs:
             env:
               SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN}}
           - name: Notify slack on Success
-            #if: inputs.notify_on_success && success()
+            if: inputs.notify_on_success && success()
             uses: slackapi/slack-github-action@v1.24.0
             with:
               channel-id: ${{ inputs.success_slack_channel_id }}

--- a/.github/workflows/notify-slack.yaml
+++ b/.github/workflows/notify-slack.yaml
@@ -20,11 +20,10 @@ on:
 jobs:
     notify-slack:
         runs-on: ubuntu-latest
-        # if: github.ref == 'refs/heads/dev' && (inputs.notify_on_failure || inputs.notify_on_success)
+        if: github.ref == 'refs/heads/dev' && (inputs.notify_on_failure || inputs.notify_on_success)
         steps:
           - name: Notify slack on failure
-            #if: inputs.notify_on_failure && failure()
-            if: inputs.notify_on_success && success()
+            if: inputs.notify_on_failure && failure()
             uses: slackapi/slack-github-action@v1.24.0
             with:
               channel-id: ${{ env.SLACK_CHANNEL_ID }}
@@ -49,7 +48,7 @@ jobs:
             env:
               SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN}}
           - name: Notify slack on Success
-            #if: inputs.notify_on_success && success()
+            if: inputs.notify_on_success && success()
             uses: slackapi/slack-github-action@v1.24.0
             with:
               channel-id: ${{ env.SLACK_CHANNEL_ID }}

--- a/.github/workflows/notify-slack.yaml
+++ b/.github/workflows/notify-slack.yaml
@@ -21,10 +21,11 @@ on:
 jobs:
     notify-slack:
         runs-on: ubuntu-latest
-        if: github.ref == 'refs/heads/dev' && (inputs.notify_on_failure || inputs.notify_on_success)
+        # if: github.ref == 'refs/heads/dev' && (inputs.notify_on_failure || inputs.notify_on_success)
         steps:
           - name: Notify slack on failure
-            if: inputs.notify_on_failure && failure()
+            #if: inputs.notify_on_failure && failure()
+            if: inputs.notify_on_success && success()
             uses: slackapi/slack-github-action@v1.24.0
             with:
               channel-id: ${{ env.FAILURE_SLACK_CHANNEL_ID }}
@@ -49,7 +50,7 @@ jobs:
             env:
               SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN}}
           - name: Notify slack on Success
-            if: inputs.notify_on_success && success()
+            #if: inputs.notify_on_success && success()
             uses: slackapi/slack-github-action@v1.24.0
             with:
               channel-id: ${{ env.SUCCESS_SLACK_CHANNEL_ID }}

--- a/.github/workflows/notify-slack.yaml
+++ b/.github/workflows/notify-slack.yaml
@@ -27,10 +27,10 @@ on:
 jobs:
     notify-slack:
         runs-on: ubuntu-latest
-        if: github.ref == 'refs/heads/dev' && (inputs.notify_on_failure || inputs.notify_on_success)
+        #if: github.ref == 'refs/heads/dev' && (inputs.notify_on_failure || inputs.notify_on_success)
         steps:
           - name: Notify slack on failure
-            if: inputs.notify_on_failure && failure()
+            #if: inputs.notify_on_failure && failure()
             uses: slackapi/slack-github-action@v1.24.0
             with:
               channel-id: ${{ env.FAILURE_SLACK_CHANNEL_ID }}
@@ -55,7 +55,7 @@ jobs:
             env:
               SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN}}
           - name: Notify slack on Success
-            if: inputs.notify_on_success && success()
+            #if: inputs.notify_on_success && success()
             uses: slackapi/slack-github-action@v1.24.0
             with:
               channel-id: ${{ env.SUCCESS_SLACK_CHANNEL_ID }}

--- a/.github/workflows/notify-slack.yaml
+++ b/.github/workflows/notify-slack.yaml
@@ -1,0 +1,74 @@
+name: notify-slack
+env:
+  SLACK_BOT_TOKEN: ${{ secrets.TEST_SLACK_BOT_TOKEN}}
+  SLACK_CHANNEL_ID: "CMYTGJVFY"
+  REPO_NAME: "Data Repo UI"
+on:
+    workflow_call:
+      inputs:
+        workflow_name:
+          required: true
+          type: string
+        notify_on_failure:
+            required: false
+            type: boolean
+            default: true
+        notify_on_success:
+          required: false
+          type: boolean
+          default: false
+jobs:
+    notify-slack:
+        runs-on: ubuntu-latest
+        if: github.ref == 'refs/heads/dev' && (inputs.notify_on_failure || inputs.notify_on_success)
+        steps:
+          - name: Notify slack on failure
+            if: inputs.notify_on_failure && failure()
+            uses: slackapi/slack-github-action@v1.24.0
+            with:
+              channel-id: ${{ env.SLACK_CHANNEL_ID }}
+              payload: |
+                {
+                  "text": "${{ env.REPO_NAME }} ${{ inputs.workflow_name }}",
+                  "attachments": [
+                    {
+                      "title": "${{ inputs.workflow_name }} Failed",
+                      "title_link" : "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                      "color": "e51313",
+                      "fields": [
+                        {
+                          "title": "Status",
+                          "short": true,
+                          "value": "Failed"
+                        }
+                      ]
+                    }
+                  ]
+                }
+            env:
+              SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN}}
+          - name: Notify slack on Success
+            if: inputs.notify_on_success && success()
+            uses: slackapi/slack-github-action@v1.24.0
+            with:
+              channel-id: ${{ env.SLACK_CHANNEL_ID }}
+              payload: |
+                {
+                  "text": "${{ env.REPO_NAME }} ${{ inputs.workflow_name }}",
+                  "attachments": [
+                    {
+                      "title": "${{ inputs.workflow_name }} Succeeded",
+                      "title_link" : "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                      "color": "008000",
+                      "fields": [
+                        {
+                          "title": "Status",
+                          "short": true,
+                          "value": "Success"
+                        }
+                      ]
+                    }
+                  ]
+                }
+            env:
+              SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN}}

--- a/.github/workflows/notify-slack.yaml
+++ b/.github/workflows/notify-slack.yaml
@@ -1,8 +1,6 @@
 name: notify-slack
 env:
   SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN}}
-  FAILURE_SLACK_CHANNEL_ID: "CMYTGJVFY" # #jade-alerts
-  SUCCESS_SLACK_CHANNEL_ID: "CK9M0ENRJ" # #jade-spam
   REPO_NAME: "Data Repo UI"
 on:
     workflow_call:
@@ -18,6 +16,14 @@ on:
           required: false
           type: boolean
           default: false
+        failure_slack_channel_id:
+          required: false
+          type: string
+          default: "CMYTGJVFY" # #jade-alerts
+        success_slack_channel_id:
+          required: false
+          type: string
+          default: "CK9M0ENRJ" # #jade-spam
 jobs:
     notify-slack:
         runs-on: ubuntu-latest

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -120,3 +120,6 @@ jobs:
     secrets: inherit
     with:
       workflow_name: Nightly E2E Tests
+      notify_on_success: true
+      failure_slack_channel_id: "CMYTGJVFY,C53JYBV9A" # #jade-alerts & #dsde-qa
+      success_slack_channel_id: "CK9M0ENRJ,C53JYBV9A" # #jade-spam & #dsde-qa

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -114,3 +114,9 @@ jobs:
         uses: broadinstitute/datarepo-actions/actions/main@0.67.0
         with:
           actions_subcommand: 'gcp_whitelist_clean'
+  notify-slack:
+    needs: [ e2e_test ]
+    uses: ./.github/workflows/notify-slack.yaml
+    secrets: inherit
+    with:
+      workflow_name: Nightly E2E Tests

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -39,3 +39,5 @@ jobs:
     secrets: inherit
     with:
       workflow_name: Nightly Unit Tests
+      # UNDO BEFORE MERGE
+      notify_on_success: true

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -39,5 +39,3 @@ jobs:
     secrets: inherit
     with:
       workflow_name: Nightly Unit Tests
-      # UNDO BEFORE MERGE
-      notify_on_success: true

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -39,3 +39,4 @@ jobs:
     secrets: inherit
     with:
       workflow_name: Nightly Unit Tests
+      notify_on_success: true

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -33,3 +33,9 @@ jobs:
         with:
           command: |
             npx cypress run-ct
+  notify-slack:
+    needs: [ unit_test ]
+    uses: ./.github/workflows/notify-slack.yaml
+    secrets: inherit
+    with:
+      workflow_name: Nightly Unit Tests


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3406

Remaining TODO:

- [x] Get SLACK_BOT_TOKEN added to GHA secrets via [terraform-ap-deployments PR](https://github.com/broadinstitute/terraform-ap-deployments/pull/1323/files)
- [x] Rename slack bot token secret in PR
- [x] Remove TEST_SLACK_BOT_TOKEN secret
- [ ] Once PR is merged, remove webhook url secret

___________

Example Output: 
Nightly runs of e2e tests report to #dsde-qa.
Successful runs report to #jade-spam:
<img width="433" alt="image" src="https://github.com/DataBiosphere/jade-data-repo-ui/assets/13254229/30507ae0-7126-43d8-b2b9-28c8071b94ed">

Failures report to #jade-alerts:
<img width="351" alt="image" src="https://github.com/DataBiosphere/jade-data-repo-ui/assets/13254229/80a15146-4634-4caa-91c5-14a4434d37d2">



Following a similar pattern to what we did in [DRS Hub](https://github.com/DataBiosphere/terra-drs-hub/pull/100). 
### Using Slack GHA integration with Slack Apps
- Utilizing the [slack-backed GHA](https://github.com/slackapi/slack-github-action?tab=readme-ov-file#technique-2-slack-app) integration
- Created new slack app named "Data Repo UI Notification" and added app to #jade-alerts, #jade-spam and #dsde-qa channel
- Gave the bot associated with the app "chat:write" permissions and then added the bot's token to github action secrets
- App can be managed here: https://api.slack.com/apps/A06C4JEBDTR

