### PR TITLE
DR-3406: Update slack notify action: Correct branch; Move status check to action call

### DIFF
--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -102,6 +102,8 @@ jobs:
     needs: [ update_image, helm_tag_bump, cherry_pick_image_to_production_gcr ]
     uses: ./.github/workflows/notify-slack.yaml
     secrets: inherit
+    if: ${{ !cancelled() }}
     with:
       workflow_name: Dev Image Update
       notify_on_success: true
+      success: ${{ needs.update_image.result == 'success' && needs.helm_tag_bump.result == 'success' && needs.cherry_pick_image_to_production_gcr.result == 'success' }}

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -102,7 +102,7 @@ jobs:
     needs: [ update_image, helm_tag_bump, cherry_pick_image_to_production_gcr ]
     uses: ./.github/workflows/notify-slack.yaml
     secrets: inherit
-    if: ${{ !cancelled() }}
+    if: ${{ always() }}
     with:
       workflow_name: Dev Image Update
       notify_on_success: true

--- a/.github/workflows/helmtagbump.yaml
+++ b/.github/workflows/helmtagbump.yaml
@@ -113,8 +113,10 @@ jobs:
     needs: [ integration_helm_tag_update, ui_helm_default_chart_tag ]
     uses: ./.github/workflows/notify-slack.yaml
     secrets: inherit
+    if: ${{ !cancelled() }}
     with:
       workflow_name: Helm Tag Bump
       notify_on_failure: ${{ inputs.notify-slack }}
       notify_on_success: ${{ inputs.notify-slack }}
+      success: ${{ needs.integration_helm_tag_update.result == 'success' && needs.ui_helm_default_chart_tag.result == 'success' }}
 

--- a/.github/workflows/helmtagbump.yaml
+++ b/.github/workflows/helmtagbump.yaml
@@ -113,7 +113,7 @@ jobs:
     needs: [ integration_helm_tag_update, ui_helm_default_chart_tag ]
     uses: ./.github/workflows/notify-slack.yaml
     secrets: inherit
-    if: ${{ !cancelled() }}
+    if: ${{ always() }}
     with:
       workflow_name: Helm Tag Bump
       notify_on_failure: ${{ inputs.notify-slack }}

--- a/.github/workflows/notify-slack.yaml
+++ b/.github/workflows/notify-slack.yaml
@@ -27,7 +27,7 @@ on:
 jobs:
     notify-slack:
         runs-on: ubuntu-latest
-        if: ${{ !cancelled() && github.ref == 'refs/heads/dev' }}
+        if: ${{ !cancelled() && github.ref == 'refs/heads/develop' }}
         steps:
           - name: Notify slack on failure
             if: inputs.notify_on_failure && failure()

--- a/.github/workflows/notify-slack.yaml
+++ b/.github/workflows/notify-slack.yaml
@@ -5,6 +5,9 @@ env:
 on:
     workflow_call:
       inputs:
+        success:
+          required: true
+          type: boolean
         workflow_name:
           required: true
           type: string
@@ -27,10 +30,10 @@ on:
 jobs:
     notify-slack:
         runs-on: ubuntu-latest
-        if: ${{ !cancelled() && github.ref == 'refs/heads/develop' }}
+        if: ${{ github.ref == 'refs/heads/develop' }}
         steps:
           - name: Notify slack on failure
-            if: inputs.notify_on_failure && failure()
+            if: ${{ inputs.notify_on_failure && !inputs.success }}
             uses: slackapi/slack-github-action@v1.24.0
             with:
               channel-id: ${{ inputs.failure_slack_channel_id }}
@@ -55,7 +58,7 @@ jobs:
             env:
               SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN}}
           - name: Notify slack on Success
-            if: inputs.notify_on_success && success()
+            if: ${{ inputs.notify_on_success && inputs.success }}
             uses: slackapi/slack-github-action@v1.24.0
             with:
               channel-id: ${{ inputs.success_slack_channel_id }}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -118,7 +118,7 @@ jobs:
     needs: [e2e_test]
     uses: ./.github/workflows/notify-slack.yaml
     secrets: inherit
-    if: ${{ !cancelled() }}
+    if: ${{ always() }}
     with:
       workflow_name: Nightly E2E Tests
       notify_on_success: true

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -118,8 +118,10 @@ jobs:
     needs: [e2e_test]
     uses: ./.github/workflows/notify-slack.yaml
     secrets: inherit
+    if: ${{ !cancelled() }}
     with:
       workflow_name: Nightly E2E Tests
       notify_on_success: true
       failure_slack_channel_id: "CMYTGJVFY,C53JYBV9A" # #jade-alerts & #dsde-qa
       success_slack_channel_id: "CK9M0ENRJ,C53JYBV9A" # #jade-spam & #dsde-qa
+      success: ${{ needs.e2e_test.result == 'success' }}

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -37,6 +37,8 @@ jobs:
     needs: [ unit_test ]
     uses: ./.github/workflows/notify-slack.yaml
     secrets: inherit
+    if: ${{ !cancelled() }}
     with:
       workflow_name: Nightly Unit Tests
       notify_on_success: true
+      success: ${{ needs.unit_test.result == 'success' }}

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -37,7 +37,7 @@ jobs:
     needs: [ unit_test ]
     uses: ./.github/workflows/notify-slack.yaml
     secrets: inherit
-    if: ${{ !cancelled() }}
+    if: ${{ always() }}
     with:
       workflow_name: Nightly Unit Tests
       notify_on_success: true


### PR DESCRIPTION
### The changes
- Point to the correct dev branch (We use 'develop' in jade-data-repo-ui, not 'dev' like in drs-hub). 
- It appears that the reusable workflow cannot correctly assess the status of the calling workflow. So, we need to move this logic into the calling workflow. 
      -> I don't love the way we're now passing the status: "needs.update_image.result == 'success'" appears to be the right move from some online research but definitely is verbose 😞. We don't have access to the "success()" and "failure()" functions when setting the arguments (at least as far as I can tell).  

### Testing
With change - successfully sending failure notification on job failure:
<img width="623" alt="image" src="https://github.com/DataBiosphere/jade-data-repo-ui/assets/13254229/64d82ab6-a75a-4777-830e-62e55368d4b4">

and success notification on job success:
<img width="635" alt="image" src="https://github.com/DataBiosphere/jade-data-repo-ui/assets/13254229/defbba14-9c75-4de7-a1b8-3f25ab30ad0d">
