### PR TITLE
[DR-3427] Use Dependabot grouped version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,24 @@ updates:
 - package-ecosystem: npm
   directory: "/"
   schedule:
-    interval: daily
-  # Disable automatic rebasing to avoid tests kicking off all at once
-  rebase-strategy: "disabled"
-  open-pull-requests-limit: 10
+    interval: weekly
+  # See workflows/test-e2e.yml for the current list of k8s namespaces available for integration testing.
+  # Presently, there are only 2.
+  # Keeping the open PR limit low at 4 so that when automatically rebasing, 4 concurrent Dependabot PR integration test
+  # runs all stand a chance at success rather than some being guaranteed to time out waiting for an available namespace.
+  open-pull-requests-limit: 4
+  groups:
+    npm-major-dependencies:
+      patterns:
+        - "*"
+      update-types:
+        - "major"
+    npm-minor-patch-dependencies:
+      patterns:
+        - "*"
+      update-types:
+        - "minor"
+        - "patch"
   ignore:
   # newer versions of prettier seem to format the code in a way that is incompatible with eslint (DR-2953)
   - dependency-name: "prettier"

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -39,9 +39,8 @@ jobs:
         uses: broadinstitute/datarepo-actions/actions/main@0.67.0
         with:
           actions_subcommand: 'k8_checknamespace'
-          # Note: Integration-4 is also set up for UI testing, except that the datasets
-          # have been removed. We'd need to run the "ingest.js" script to ingest the datasets
-          # in order to use int-4 again.
+          # See https://github.com/DataBiosphere/jade-data-repo-ui/blob/develop/tools/ui_integration/README.md
+          # if setting up a new namespace for testing.
           k8_namespaces: 'integration-4,integration-5'
       - name: initialize npm
         env:


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3427
Reference: https://github.blog/changelog/2023-08-24-grouped-version-updates-for-dependabot-are-generally-available/
Slack discussion: https://broadinstitute.slack.com/archives/C01VBGH431S/p1678899992604489

Our Dependabot configuration will now create up to two new PRs weekly:
- A grouping of all major dependency updates
- A grouping of all minor/patch dependency updates
I elected to split these groupings because minor/patch dependency updates are more likely to 

I have capped our open Dependabot PR limit to 4, which allows us to reenable auto-rebase.  We previously disabled auto-rebase to avoid too many concurrent integration test attempts against our 2 available namespaces (a subset of unlucky attempts would time out waiting for a namespace to become available).

We can certainly tweak settings further as needed (e.g. we may wish to ungroup major dependency updates) but I think this is a good starting point to hopefully make it easier for us to stay on top of dependency bumps.

DUOS team has been using this functionality for several months, starting from when it was in preview (it is now GA).