### PR TITLE
[DR-3429] Expand Dependabot ignore list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,9 +23,28 @@ updates:
         - "patch"
   ignore:
   # newer versions of prettier seem to format the code in a way that is incompatible with eslint (DR-2953)
+  # more generally, eslint and prettier upgrades are likely to need developer intervention
+  - dependency-name: "@typescript-eslint/eslint-plugin"
+  - dependency-name: "eslint-config-prettier"
+  - dependency-name: "eslint-plugin-prettier"
   - dependency-name: "prettier"
   # newer versions of material ui (MUI) cause our styling to not respect theming or straight up break the UI (DR-2952)
   - dependency-name: "@mui/*"
   # @mui/styles is incompatible with react 18, we should replace @mui/styles with tss-react (DR-3428)
-  - dependency-name: "@types/react"
+  # more generally, react 18 / redux 8 upgrades are a large lift (DR-2799)
+  - dependency-name: "@reduxjs/tookit"
+    update-types: [ "version-update:semver-major" ]
+  - dependency-name: "@testing-library/react"
+    update-types: [ "version-update:semver-major" ]
+  - dependency-name: "@types/react*"                # @types/react, @types/react-dom, etc.
+    update-types: [ "version-update:semver-major" ]
+  - dependency-name: "react*"                       # react, react-dom, etc.
+    update-types: [ "version-update:semver-major" ]
+  - dependency-name: "redux"
+    update-types: [ "version-update:semver-major" ]
+  # later versions of history yield a warning on npm install (DR-3432)
+  - dependency-name: "history"
+    update-types: [ "version-update:semver-major" ]
+  # later versions of vite break e2e tests (DR-3433)
+  - dependency-name: "vite"
     update-types: [ "version-update:semver-major" ]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,11 +10,8 @@ updates:
   # runs all stand a chance at success rather than some being guaranteed to time out waiting for an available namespace.
   open-pull-requests-limit: 4
   groups:
-    npm-major-dependencies:
-      patterns:
-        - "*"
-      update-types:
-        - "major"
+    # We group minor and patch updates together because they are unexpected to break things.
+    # Major updates will be PR-ed individually: they are more likely to need developer intervention.
     npm-minor-patch-dependencies:
       patterns:
         - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,6 @@ updates:
   - dependency-name: "prettier"
   # newer versions of material ui (MUI) cause our styling to not respect theming or straight up break the UI (DR-2952)
   - dependency-name: "@mui/*"
+  # @mui/styles is incompatible with react 18, we should replace @mui/styles with tss-react (DR-3428)
+  - dependency-name: "@types/react"
+    update-types: [ "version-update:semver-major" ]


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3429

These are all of the major dependency updates that I couldn't get [working](https://github.com/DataBiosphere/jade-data-repo-ui/pull/1599), using Dependabot's [last grouped major update PR](https://github.com/DataBiosphere/jade-data-repo-ui/pull/1597) as a reference.

Many are related to React 18 / Redux 8 upgrades or linting.

I filed tickets for the upgrades or referenced existing ones:
- https://broadworkbench.atlassian.net/browse/DR-2953
- https://broadworkbench.atlassian.net/browse/DR-2952
- https://broadworkbench.atlassian.net/browse/DR-3428
- https://broadworkbench.atlassian.net/browse/DR-2799
- https://broadworkbench.atlassian.net/browse/DR-3432
- https://broadworkbench.atlassian.net/browse/DR-3433

We no longer group major version updates: they will be PR-ed individually.