### PR TITLE
DR-3431 follow-up: Skip slack notification for broadbot PR

### DIFF
--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -99,6 +99,7 @@ jobs:
       source_gcr_url: 'gcr.io/broad-jade-dev/jade-data-repo-ui'
       target_gcr_url: 'gcr.io/datarepo-public-gcr/jade-data-repo-ui'
   report-workflow:
+    needs: update_image
     uses: broadinstitute/sherlock/.github/workflows/client-report-workflow.yaml@main
     with:
       notify-slack-channels-upon-workflow-completion: "#jade-spam"

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -23,13 +23,14 @@ env:
 
 jobs:
   update_image:
-    outputs:
-      ui_image_tag: ${{ steps.bumperstep.outputs.tag }}
+    # outputs:
+    #   ui_image_tag: ${{ steps.bumperstep.outputs.tag }}
     strategy:
       matrix:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
-    if: "!contains( github.event.sender.login, 'broadbot')"
+    if: ${{ failure() }}
+    # if: "!contains( github.event.sender.login, 'broadbot')"
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -37,67 +38,67 @@ jobs:
           fetch-depth: 0
           ref: develop
           token: ${{ secrets.BROADBOT_TOKEN }}
-      - name: 'Bump the tag to a new version'
-        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
-        id: bumperstep
-        with:
-          actions_subcommand: 'bumper'
-          role_id: ${{ secrets.ROLE_ID }}
-          secret_id: ${{ secrets.SECRET_ID }}
-          version_file_path: package.json
-          version_variable_name: version
-          GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
-      - name: 'Get gcp credentials'
-        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
-        with:
-          actions_subcommand: 'skip'
-          role_id: ${{ secrets.ROLE_ID }}
-          secret_id: ${{ secrets.SECRET_ID }}
-      - name: 'Pull down new tags'
-        run: git fetch --all --tags
-      - name: 'Get Previous tag'
-        id: uiprevioustag
-        uses: 'broadinstitute/github-action-get-previous-tag@master'
-        env:
-          GITHUB_TOKEN: '${{ secrets.BROADBOT_TOKEN }}'
-      - name: Build nmp build for new ui container
-        run: |
-          git pull
-          GCR_TAG=$(git rev-parse --short HEAD)
-          echo "GCR_TAG=$(echo ${GCR_TAG})" >> $GITHUB_ENV
-      # Build the Docker image
-      - name: Build docker container
-        env:
-          DISABLE_ESLINT_PLUGIN: true
-        run: |
-          rm -rf jade-dev-account.pem
-          docker build -t gcr.io/${{ env.gcr_google_project }}/jade-data-repo-ui:${GCR_TAG} --build-arg CACHEBUST=$(date +%s) .
-      # Push the Docker image to Google Container Registry
-      - name: Publish and tag new docker container to GCR
-        run: |
-          gcloud auth activate-service-account --key-file jade-dev-account.json
-          gcloud auth configure-docker --quiet
-          docker push gcr.io/${{ env.gcr_google_project }}/jade-data-repo-ui:${GCR_TAG}
-          gcloud container images \
-            add-tag \
-            gcr.io/${{ env.gcr_google_project }}/jade-data-repo-ui:"${GCR_TAG}" \
-            gcr.io/${{ env.gcr_google_project }}/jade-data-repo-ui:"${{ steps.uiprevioustag.outputs.tag }}" --quiet
-          gcloud container images \
-            add-tag \
-            gcr.io/${{ env.gcr_google_project }}/jade-data-repo-ui:"${GCR_TAG}" \
-            gcr.io/${{ env.gcr_google_project }}/jade-data-repo-ui:"${GCR_TAG}-develop" --quiet
-  helm_tag_bump:
-    needs: update_image
-    uses: ./.github/workflows/helmtagbump.yaml
-    secrets: inherit
-  cherry_pick_image_to_production_gcr:
-    needs: update_image
-    uses: DataBiosphere/jade-data-repo/.github/workflows/cherry-pick-image.yaml@1.536.0
-    secrets: inherit
-    with:
-      gcr_tag: ${{ needs.update_image.outputs.ui_image_tag }}
-      source_gcr_url: 'gcr.io/broad-jade-dev/jade-data-repo-ui'
-      target_gcr_url: 'gcr.io/datarepo-public-gcr/jade-data-repo-ui'
+      # - name: 'Bump the tag to a new version'
+      #   uses: broadinstitute/datarepo-actions/actions/main@0.67.0
+      #   id: bumperstep
+      #   with:
+      #     actions_subcommand: 'bumper'
+      #     role_id: ${{ secrets.ROLE_ID }}
+      #     secret_id: ${{ secrets.SECRET_ID }}
+      #     version_file_path: package.json
+      #     version_variable_name: version
+      #     GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
+      # - name: 'Get gcp credentials'
+      #   uses: broadinstitute/datarepo-actions/actions/main@0.67.0
+      #   with:
+      #     actions_subcommand: 'skip'
+      #     role_id: ${{ secrets.ROLE_ID }}
+      #     secret_id: ${{ secrets.SECRET_ID }}
+      # - name: 'Pull down new tags'
+      #   run: git fetch --all --tags
+      # - name: 'Get Previous tag'
+      #   id: uiprevioustag
+      #   uses: 'broadinstitute/github-action-get-previous-tag@master'
+      #   env:
+      #     GITHUB_TOKEN: '${{ secrets.BROADBOT_TOKEN }}'
+      # - name: Build nmp build for new ui container
+      #   run: |
+      #     git pull
+      #     GCR_TAG=$(git rev-parse --short HEAD)
+      #     echo "GCR_TAG=$(echo ${GCR_TAG})" >> $GITHUB_ENV
+      # # Build the Docker image
+      # - name: Build docker container
+      #   env:
+      #     DISABLE_ESLINT_PLUGIN: true
+      #   run: |
+      #     rm -rf jade-dev-account.pem
+      #     docker build -t gcr.io/${{ env.gcr_google_project }}/jade-data-repo-ui:${GCR_TAG} --build-arg CACHEBUST=$(date +%s) .
+      # # Push the Docker image to Google Container Registry
+      # - name: Publish and tag new docker container to GCR
+      #   run: |
+      #     gcloud auth activate-service-account --key-file jade-dev-account.json
+      #     gcloud auth configure-docker --quiet
+      #     docker push gcr.io/${{ env.gcr_google_project }}/jade-data-repo-ui:${GCR_TAG}
+      #     gcloud container images \
+      #       add-tag \
+      #       gcr.io/${{ env.gcr_google_project }}/jade-data-repo-ui:"${GCR_TAG}" \
+      #       gcr.io/${{ env.gcr_google_project }}/jade-data-repo-ui:"${{ steps.uiprevioustag.outputs.tag }}" --quiet
+      #     gcloud container images \
+      #       add-tag \
+      #       gcr.io/${{ env.gcr_google_project }}/jade-data-repo-ui:"${GCR_TAG}" \
+      #       gcr.io/${{ env.gcr_google_project }}/jade-data-repo-ui:"${GCR_TAG}-develop" --quiet
+  # helm_tag_bump:
+  #   needs: update_image
+  #   uses: ./.github/workflows/helmtagbump.yaml
+  #   secrets: inherit
+  # cherry_pick_image_to_production_gcr:
+  #   needs: update_image
+  #   uses: DataBiosphere/jade-data-repo/.github/workflows/cherry-pick-image.yaml@1.536.0
+  #   secrets: inherit
+  #   with:
+  #     gcr_tag: ${{ needs.update_image.outputs.ui_image_tag }}
+  #     source_gcr_url: 'gcr.io/broad-jade-dev/jade-data-repo-ui'
+  #     target_gcr_url: 'gcr.io/datarepo-public-gcr/jade-data-repo-ui'
   report-workflow:
     needs: update_image
     uses: broadinstitute/sherlock/.github/workflows/client-report-workflow.yaml@main

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -23,14 +23,13 @@ env:
 
 jobs:
   update_image:
-    # outputs:
-    #   ui_image_tag: ${{ steps.bumperstep.outputs.tag }}
+    outputs:
+      ui_image_tag: ${{ steps.bumperstep.outputs.tag }}
     strategy:
       matrix:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
-    if: ${{ failure() }}
-    # if: "!contains( github.event.sender.login, 'broadbot')"
+    if: "!contains( github.event.sender.login, 'broadbot')"
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -38,67 +37,67 @@ jobs:
           fetch-depth: 0
           ref: develop
           token: ${{ secrets.BROADBOT_TOKEN }}
-      # - name: 'Bump the tag to a new version'
-      #   uses: broadinstitute/datarepo-actions/actions/main@0.67.0
-      #   id: bumperstep
-      #   with:
-      #     actions_subcommand: 'bumper'
-      #     role_id: ${{ secrets.ROLE_ID }}
-      #     secret_id: ${{ secrets.SECRET_ID }}
-      #     version_file_path: package.json
-      #     version_variable_name: version
-      #     GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
-      # - name: 'Get gcp credentials'
-      #   uses: broadinstitute/datarepo-actions/actions/main@0.67.0
-      #   with:
-      #     actions_subcommand: 'skip'
-      #     role_id: ${{ secrets.ROLE_ID }}
-      #     secret_id: ${{ secrets.SECRET_ID }}
-      # - name: 'Pull down new tags'
-      #   run: git fetch --all --tags
-      # - name: 'Get Previous tag'
-      #   id: uiprevioustag
-      #   uses: 'broadinstitute/github-action-get-previous-tag@master'
-      #   env:
-      #     GITHUB_TOKEN: '${{ secrets.BROADBOT_TOKEN }}'
-      # - name: Build nmp build for new ui container
-      #   run: |
-      #     git pull
-      #     GCR_TAG=$(git rev-parse --short HEAD)
-      #     echo "GCR_TAG=$(echo ${GCR_TAG})" >> $GITHUB_ENV
-      # # Build the Docker image
-      # - name: Build docker container
-      #   env:
-      #     DISABLE_ESLINT_PLUGIN: true
-      #   run: |
-      #     rm -rf jade-dev-account.pem
-      #     docker build -t gcr.io/${{ env.gcr_google_project }}/jade-data-repo-ui:${GCR_TAG} --build-arg CACHEBUST=$(date +%s) .
-      # # Push the Docker image to Google Container Registry
-      # - name: Publish and tag new docker container to GCR
-      #   run: |
-      #     gcloud auth activate-service-account --key-file jade-dev-account.json
-      #     gcloud auth configure-docker --quiet
-      #     docker push gcr.io/${{ env.gcr_google_project }}/jade-data-repo-ui:${GCR_TAG}
-      #     gcloud container images \
-      #       add-tag \
-      #       gcr.io/${{ env.gcr_google_project }}/jade-data-repo-ui:"${GCR_TAG}" \
-      #       gcr.io/${{ env.gcr_google_project }}/jade-data-repo-ui:"${{ steps.uiprevioustag.outputs.tag }}" --quiet
-      #     gcloud container images \
-      #       add-tag \
-      #       gcr.io/${{ env.gcr_google_project }}/jade-data-repo-ui:"${GCR_TAG}" \
-      #       gcr.io/${{ env.gcr_google_project }}/jade-data-repo-ui:"${GCR_TAG}-develop" --quiet
-  # helm_tag_bump:
-  #   needs: update_image
-  #   uses: ./.github/workflows/helmtagbump.yaml
-  #   secrets: inherit
-  # cherry_pick_image_to_production_gcr:
-  #   needs: update_image
-  #   uses: DataBiosphere/jade-data-repo/.github/workflows/cherry-pick-image.yaml@1.536.0
-  #   secrets: inherit
-  #   with:
-  #     gcr_tag: ${{ needs.update_image.outputs.ui_image_tag }}
-  #     source_gcr_url: 'gcr.io/broad-jade-dev/jade-data-repo-ui'
-  #     target_gcr_url: 'gcr.io/datarepo-public-gcr/jade-data-repo-ui'
+      - name: 'Bump the tag to a new version'
+        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
+        id: bumperstep
+        with:
+          actions_subcommand: 'bumper'
+          role_id: ${{ secrets.ROLE_ID }}
+          secret_id: ${{ secrets.SECRET_ID }}
+          version_file_path: package.json
+          version_variable_name: version
+          GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
+      - name: 'Get gcp credentials'
+        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
+        with:
+          actions_subcommand: 'skip'
+          role_id: ${{ secrets.ROLE_ID }}
+          secret_id: ${{ secrets.SECRET_ID }}
+      - name: 'Pull down new tags'
+        run: git fetch --all --tags
+      - name: 'Get Previous tag'
+        id: uiprevioustag
+        uses: 'broadinstitute/github-action-get-previous-tag@master'
+        env:
+          GITHUB_TOKEN: '${{ secrets.BROADBOT_TOKEN }}'
+      - name: Build nmp build for new ui container
+        run: |
+          git pull
+          GCR_TAG=$(git rev-parse --short HEAD)
+          echo "GCR_TAG=$(echo ${GCR_TAG})" >> $GITHUB_ENV
+      # Build the Docker image
+      - name: Build docker container
+        env:
+          DISABLE_ESLINT_PLUGIN: true
+        run: |
+          rm -rf jade-dev-account.pem
+          docker build -t gcr.io/${{ env.gcr_google_project }}/jade-data-repo-ui:${GCR_TAG} --build-arg CACHEBUST=$(date +%s) .
+      # Push the Docker image to Google Container Registry
+      - name: Publish and tag new docker container to GCR
+        run: |
+          gcloud auth activate-service-account --key-file jade-dev-account.json
+          gcloud auth configure-docker --quiet
+          docker push gcr.io/${{ env.gcr_google_project }}/jade-data-repo-ui:${GCR_TAG}
+          gcloud container images \
+            add-tag \
+            gcr.io/${{ env.gcr_google_project }}/jade-data-repo-ui:"${GCR_TAG}" \
+            gcr.io/${{ env.gcr_google_project }}/jade-data-repo-ui:"${{ steps.uiprevioustag.outputs.tag }}" --quiet
+          gcloud container images \
+            add-tag \
+            gcr.io/${{ env.gcr_google_project }}/jade-data-repo-ui:"${GCR_TAG}" \
+            gcr.io/${{ env.gcr_google_project }}/jade-data-repo-ui:"${GCR_TAG}-develop" --quiet
+  helm_tag_bump:
+    needs: update_image
+    uses: ./.github/workflows/helmtagbump.yaml
+    secrets: inherit
+  cherry_pick_image_to_production_gcr:
+    needs: update_image
+    uses: DataBiosphere/jade-data-repo/.github/workflows/cherry-pick-image.yaml@1.536.0
+    secrets: inherit
+    with:
+      gcr_tag: ${{ needs.update_image.outputs.ui_image_tag }}
+      source_gcr_url: 'gcr.io/broad-jade-dev/jade-data-repo-ui'
+      target_gcr_url: 'gcr.io/datarepo-public-gcr/jade-data-repo-ui'
   report-workflow:
     needs: update_image
     uses: broadinstitute/sherlock/.github/workflows/client-report-workflow.yaml@main


### PR DESCRIPTION
Bug found after merging https://github.com/DataBiosphere/jade-data-repo-ui/pull/1600

![image](https://github.com/DataBiosphere/jade-data-repo-ui/assets/13254229/78dcb0d7-5fb8-47fc-9781-b6f5dbe08002)

We're getting two messages because we always have a broadbot PR that merges to update the chart version in our GHA. 
![image](https://github.com/DataBiosphere/jade-data-repo-ui/assets/13254229/348452bd-2503-40d6-aaaa-3b10724bc605)

We skip all of the steps in the action filed by broadbot. 
![image](https://github.com/DataBiosphere/jade-data-repo-ui/assets/13254229/0e1ad7f2-be12-4f04-bdb3-c23b57c89707)

### Solution: Let's also skip the slack notification job.
Then, we'll only get one slack notification.


# Testing
Forced all steps to skip to prove that the slack notification step would also be skipped.
<img width="522" alt="image" src="https://github.com/DataBiosphere/jade-data-repo-ui/assets/13254229/aa82e387-9a71-4948-bf0a-7e34e276dc70">
