### PR TITLE
DR-2817: Remove Husky

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jade-data-repo-ui",
-  "version": "0.285.0",
+  "version": "0.286.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jade-data-repo-ui",
-      "version": "0.285.0",
+      "version": "0.286.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
@@ -111,7 +111,6 @@
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-redux-saga": "^1.3.2",
-        "husky": "^8.0.3",
         "inquirer": "^9.2.14",
         "prettier": "2.2.1",
         "react-dom": "^17.0.2",
@@ -8780,21 +8779,6 @@
       "dev": true,
       "engines": {
         "node": ">=8.12.0"
-      }
-    },
-    "node_modules/husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
-      "dev": true,
-      "bin": {
-        "husky": "lib/bin.js"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/hyphenate-style-name": {
@@ -20551,12 +20535,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
       "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
-      "dev": true
-    },
-    "husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
       "dev": true
     },
     "hyphenate-style-name": {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,6 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-redux-saga": "^1.3.2",
-    "husky": "^8.0.3",
     "inquirer": "^9.2.14",
     "prettier": "2.2.1",
     "react-dom": "^17.0.2",
@@ -145,11 +144,6 @@
     "ingest": "node --inspect tools/ingest ingest",
     "codegen": "docker run --rm -v \"${PWD}:/local\" openapitools/openapi-generator-cli:v6.2.1 generate -g typescript-axios -i ${TDR_OPEN_API_YAML_LOCATION:=https://jade.datarepo-dev.broadinstitute.org/data-repository-openapi.yaml} -o /local/src/generated/tdr --skip-validate-spec",
     "clean": "rm -fr build src/generated/*"
-  },
-  "husky": {
-    "hooks": {
-      "post-merge": "npm install"
-    }
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
Quite a few years ago with added a husky git hook on post-merge to make sure we ran `npm install` after pulling down changes from the develop branch. However, we never upgraded to using the updated format with husky, as described in this documentation: https://typicode.github.io/husky/migrate-from-v4.html. So, I don't think that it has been operational for quite some time. 
Additionally, I think many engineers on the team use Intellij, which I found to have a popup to remind us to run `npm install` on merging in dependency changes from the develop branch. 
I propose we remove this dependency until we find the need to add it back in. For example, Terra UI uses husky to do a [pre-commit hook](https://github.com/DataBiosphere/terra-ui/blob/dev/.husky/pre-commit) to make sure code is linted. 
