### PR TITLE
DC-833: Update slack channel for E2E tests

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -117,7 +117,7 @@ jobs:
     uses: broadinstitute/sherlock/.github/workflows/client-report-workflow.yaml@main
     if: ${{ github.ref == 'refs/heads/develop' }}
     with:
-      notify-slack-channels-upon-workflow-completion: '#jade-alerts,#dsde-qa'
+      notify-slack-channels-upon-workflow-completion: '#jade-spam'
       notify-slack-custom-icon: ':terra-horse:'
     permissions:
       id-token: write


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DC-833

Any notifications sent to the qa channel are considered release blockers if they fail. We do not consider E2E tests release blockers, so we’re going to remove notifications sent to QA. 

Since it’s no longer sent to QA, I will also move the destination channel to #jade-spam