### PR TITLE
[DC-874]Fix e2e tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ npm install
 
   - `export PROXY_URL=https://jade.datarepo-dev.broadinstitute.org`
   - `export CYPRESS_BASE_URL=http://localhost:3000`
+    
+- If running E2E tests and/or you want to replicate the conditions of a run on GitHub, you may want to change PROXY_URL. You can see what environment was used on a GitHub run by viewing the test error and then the "Check for an available namespace to deploy API to and set state lock" step. In the final lines, this will include a namespace such as integration-N where N is some number. Then, you can set the PROXY_URL accordingly:
+  
+  - `export PROXY_URL=https://jade-N.datarepo-integration.broadinstitute.org`
 
 - For performance gains, you should disable linting (don't worry, it gets checked in GitHub actions) by setting the following environment variable:
 

--- a/cypress/integration/queryBuilder.spec.js
+++ b/cypress/integration/queryBuilder.spec.js
@@ -100,6 +100,12 @@ testPlatforms.forEach((testPlatform) => {
       beforeEach(() => {
         // make sure table is loaded
         cy.get('[data-cy=columnHeader-variant_id]').should('be.visible');
+        // select the drop-down menu
+        cy.get('[data-cy=selectTable]').click();
+        // select the table
+        cy.get('[data-cy=menuItem-ancestry_specific_meta_analysis]').click();
+        // make sure table is loaded
+        cy.get('[data-cy=columnHeader-variant_id]').should('be.visible');
         // selects the filter button in the sidebar
         cy.get('div.MuiButtonBase-root:nth-child(2) > svg:nth-child(1)').click();
         cy.get('[data-cy=filterItem]').contains('ancestry').click();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jade-data-repo-ui",
-  "version": "0.288.0",
+  "version": "0.289.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jade-data-repo-ui",
-      "version": "0.288.0",
+      "version": "0.289.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/runtime": "^7.23.9",


### PR DESCRIPTION
**Background:**
Ticket: https://broadworkbench.atlassian.net/browse/DC-874
E2E tests have been failing for almost two weeks. See failing run here: https://github.com/DataBiosphere/jade-data-repo-ui/actions/runs/8014582295 

**Context**
The test was running in an integration environment where there are two equivalent datasets, one on Azure and one on GCP. Not all tables in the datasets are populated. Additionally, the order of the tables in the drop down table menu are not the same. So, there were different tables rendering on page load for Azure as compared to GCP. Due to this, the initial table on page load was populated for the Azure dataset, while the initial table on page load for the GCP was not populated.  Filtering could not work on the empty table.


**Solution:**
Add to the test to explicitly chose a table that is populated. Then the test can continue as normal. 