### PR TITLE
DC-902: Bump datarepo-actions version to fix issue with google apt-key

### DIFF
--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -38,7 +38,7 @@ jobs:
           ref: develop
           token: ${{ secrets.BROADBOT_TOKEN }}
       - name: 'Bump the tag to a new version'
-        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.71.0
         id: bumperstep
         with:
           actions_subcommand: 'bumper'
@@ -48,7 +48,7 @@ jobs:
           version_variable_name: version
           GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
       - name: 'Get gcp credentials'
-        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.71.0
         with:
           actions_subcommand: 'skip'
           role_id: ${{ secrets.ROLE_ID }}

--- a/.github/workflows/helmtagbump.yaml
+++ b/.github/workflows/helmtagbump.yaml
@@ -56,7 +56,7 @@ jobs:
         with:
           args: yq w -i datarepo-helm-definitions/integration/integration-6/datarepo-ui.yaml image.tag ${{ steps.uiprevioustag.outputs.tag }}"
       - name: '[datarepo-helm-definitions] Merge chart version update'
-        uses: broadinstitute/datarepo-actions/actions/merger@0.70.0
+        uses: broadinstitute/datarepo-actions/actions/merger@0.71.0
         env:
           COMMIT_MESSAGE: 'Datarepo ui tag version update: ${{ steps.uiprevioustag.outputs.tag }}'
           GITHUB_REPO: datarepo-helm-definitions
@@ -103,7 +103,7 @@ jobs:
         with:
           args: yq w -i datarepo-helm/charts/datarepo-ui/Chart.yaml version ${{ steps.new_version.outputs.new_version }}"
       - name: '[datarepo-helm] Merge chart version update'
-        uses: broadinstitute/datarepo-actions/actions/merger@0.70.0
+        uses: broadinstitute/datarepo-actions/actions/merger@0.71.0
         env:
           COMMIT_MESSAGE: 'Datarepo ui tag version update: ${{ steps.uiprevioustag.outputs.tag }}'
           GITHUB_REPO: datarepo-helm

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -29,14 +29,14 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: 'Whitelist Runner IP'
-        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.71.0
         with:
           actions_subcommand: 'gcp_whitelist'
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
       - name: 'Check for an available namespace to deploy API to and set state lock'
         id: namespace
-        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.71.0
         with:
           actions_subcommand: 'k8_checknamespace'
           # See https://github.com/DataBiosphere/jade-data-repo-ui/blob/develop/tools/ui_integration/README.md
@@ -77,7 +77,7 @@ jobs:
         run: |
           echo "Pushed docker image gcr.io/broad-jade-dev/jade-data-repo-ui:${GCR_TAG}"
       - name: 'Deploy to cluster with Helm'
-        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.71.0
         with:
           actions_subcommand: 'helmdeploy'
           helm_create_secret_manager_secret_version: '0.0.6'
@@ -87,7 +87,7 @@ jobs:
           helm_oidc_proxy_chart_version: 0.0.42
           helm_imagetag_update: 'ui'
       - name: 'Wait for deployment to come back online'
-        uses: broadinstitute/datarepo-actions/actions/wait-for-deployment@0.70.0
+        uses: broadinstitute/datarepo-actions/actions/wait-for-deployment@0.71.0
         env:
           DEPLOYMENT_TYPE: 'ui'
       - name: set cypresss env
@@ -105,12 +105,12 @@ jobs:
           npx cypress run --record
       - name: 'Clean state lock from used Namespace on API deploy'
         if: always()
-        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.71.0
         with:
           actions_subcommand: 'k8_checknamespace_clean'
       - name: 'Clean whitelisted Runner IP'
         if: always()
-        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.71.0
         with:
           actions_subcommand: 'gcp_whitelist_clean'
   report-workflow:


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DC-902

This PR bumps our repo to the latest version of the [datarepo-actions](https://github.com/broadinstitute/datarepo-actions).

Details about the root issue can be found in the [datarepo-actions PR](https://github.com/broadinstitute/datarepo-actions/pull/82). Our github actions fail without this fix.