### PR TITLE
DC-942 - E2E test failure - Check if any table has loaded instead of specific table

### DIFF
--- a/cypress/integration/queryBuilder.spec.js
+++ b/cypress/integration/queryBuilder.spec.js
@@ -37,7 +37,7 @@ testPlatforms.forEach((testPlatform) => {
 
     describe('arrays work as expected', () => {
       beforeEach(() => {
-        cy.get('[data-cy=columnHeader-variant_id]').should('be.visible');
+        cy.get('[data-cy=tableBody]').should('be.visible');
         cy.get('[data-cy=selectTable]').click();
         cy.get('[data-cy=menuItem-feature_consequence]').click();
       });
@@ -57,7 +57,7 @@ testPlatforms.forEach((testPlatform) => {
 
     describe('timestamps are displayed as expected', () => {
       beforeEach(() => {
-        cy.get('[data-cy=columnHeader-variant_id]').should('be.visible');
+        cy.get('[data-cy=tableBody]').should('be.visible');
         cy.get('[data-cy=selectTable]').click();
         cy.get('[data-cy=menuItem-all_data_types]').click();
       });
@@ -99,7 +99,7 @@ testPlatforms.forEach((testPlatform) => {
     describe('test filter panel', () => {
       beforeEach(() => {
         // make sure table is loaded
-        cy.get('[data-cy=columnHeader-variant_id]').should('be.visible');
+        cy.get('[data-cy=tableBody]').should('be.visible');
         // select the drop-down menu
         cy.get('[data-cy=selectTable]').click();
         // select the table
@@ -203,7 +203,7 @@ testPlatforms.forEach((testPlatform) => {
     describe('filtering on null checkbox value', () => {
       it('filters on null', () => {
         // Wait for initial table to load
-        cy.get('[data-cy=columnHeader-variant_id]').should('be.visible');
+        cy.get('[data-cy=tableBody]').should('be.visible');
         // Switch to variant table
         cy.get('[data-cy=selectTable]').click();
         cy.get('[data-cy=menuItem-variant]').click();


### PR DESCRIPTION
Paired with @s-rubenstein  for this work!

We had previously assumed that the first table that would load would contain the column "variant_id". This is not the case when the "variant" table loads first. We cannot expect that the table order remains constant. So, instead, we'll just check if any table element has loaded before moving onto the next test check. 