### PR TITLE
DC-994 - Fix remove user from role on datasets/snapshots

### DIFF
--- a/cypress/integration/datasetSharing.spec.js
+++ b/cypress/integration/datasetSharing.spec.js
@@ -1,3 +1,4 @@
+const newUser = 'voldemort.admin@test.firecloud.org';
 describe('test dataset sharing', () => {
   beforeEach(() => {
     cy.intercept('GET', 'api/repository/v1/datasets/**').as('getDataset');
@@ -22,6 +23,26 @@ describe('test dataset sharing', () => {
     cy.get('a > .MuiButtonBase-root').click();
 
     cy.wait(['@getDataset', '@getDatasetPolicies', '@getBillingProfileById']);
-    cy.get('[data-cy="manageAccessContainer"]').should('not.exist');
+    cy.get('[data-cy="roles-tab"]').should('not.exist');
+  });
+  it('A steward can add and remove a user to a dataset', () => {
+    cy.get('[placeholder="Search keyword or description"]').type('V2F_GWAS');
+    cy.contains(/V2F_GWAS_Summary_Stats|V2F_GWAS_Summary_Statistics/g).should('be.visible');
+    cy.contains(/V2F_GWAS_Summary_Stats|V2F_GWAS_Summary_Statistics/g).click({ force: true });
+
+    cy.wait(['@getDataset', '@getDatasetPolicies', '@getBillingProfileById']);
+    cy.get('[data-cy="roles-tab"]').click();
+    // Add user as a custodian on the dataset
+    cy.get('[data-cy="enterEmailBox"]').type(newUser);
+    cy.get('[data-cy="roleSelect"]').click();
+    cy.get('[data-cy="roleOption-custodian"]').click();
+    cy.get('[data-cy="inviteButton"]').click();
+    // Confirm the user was added
+    cy.get('[data-cy="user-list-Custodians"]').click();
+    cy.get(`[data-cy="chip-${newUser}"]`).should('be.visible');
+
+    // Now, let's remove this user
+    cy.get(`[data-cy="chip-${newUser}"]`).find('[data-testid="CancelIcon"]').click();
+    cy.get(`[data-cy="chip-${newUser}"]`).should('not.exist');
   });
 });

--- a/src/components/ManageUsersView.test.tsx
+++ b/src/components/ManageUsersView.test.tsx
@@ -10,7 +10,7 @@ import ManageUsersView from './ManageUsersView';
 
 describe('ManageUsersView', () => {
   [true, false].forEach((canManageUsers) => {
-    it('Renders user list indepedent of whether you can manage users', () => {
+    it('Renders user list independent of whether you can manage users', () => {
       const mockStore = createMockStore([]);
       const store = mockStore({});
       mount(

--- a/src/components/ManageUsersView.tsx
+++ b/src/components/ManageUsersView.tsx
@@ -14,7 +14,7 @@ const styles = (theme: CustomTheme) => ({
 });
 
 interface ManageUsersProps extends WithStyles<typeof styles> {
-  removeUser?: () => void;
+  removeUser?: (removableEmail: string) => void;
   users: Array<string>;
 }
 
@@ -28,7 +28,7 @@ function ManageUsersView({ classes, removeUser, users }: ManageUsersProps) {
           color="primary"
           label={user}
           key={user}
-          onDelete={removeUser}
+          onDelete={() => (removeUser ? removeUser(user) : null)}
           variant="outlined"
         />
       </div>

--- a/src/components/ManageUsersView.tsx
+++ b/src/components/ManageUsersView.tsx
@@ -30,6 +30,7 @@ function ManageUsersView({ classes, removeUser, users }: ManageUsersProps) {
           key={user}
           onDelete={() => (removeUser ? removeUser(user) : null)}
           variant="outlined"
+          data-cy={`chip-${user}`}
         />
       </div>
     ));

--- a/src/components/ManageUsersView.tsx
+++ b/src/components/ManageUsersView.tsx
@@ -28,7 +28,7 @@ function ManageUsersView({ classes, removeUser, users }: ManageUsersProps) {
           color="primary"
           label={user}
           key={user}
-          onDelete={() => (removeUser ? removeUser(user) : null)}
+          onDelete={() => removeUser?.(user)}
           variant="outlined"
           data-cy={`chip-${user}`}
         />

--- a/src/components/UserList.tsx
+++ b/src/components/UserList.tsx
@@ -37,7 +37,7 @@ const styles = (theme: CustomTheme) =>
 interface UserListProps extends WithStyles<typeof styles> {
   canManageUsers: boolean;
   defaultOpen?: boolean;
-  removeUser?: any;
+  removeUser?: (removableEmail: string) => void;
   typeOfUsers: string;
   users: Array<string>;
 }

--- a/src/components/UserList.tsx
+++ b/src/components/UserList.tsx
@@ -55,6 +55,7 @@ function UserList({
       <AccordionSummary
         expandIcon={<ExpandMore className={classes.expandIcon} />}
         className={classes.header}
+        data-cy={`user-list-${typeOfUsers}`}
       >
         {typeOfUsers}
       </AccordionSummary>

--- a/src/components/common/AddUserAccess.tsx
+++ b/src/components/common/AddUserAccess.tsx
@@ -154,12 +154,14 @@ function AddUserAccess({ classes, permissions, onAdd }: AddUserAccessProps) {
             className={classes.input}
             fullWidth
             onChange={(event: SelectChangeEvent) => setPolicyName(event.target.value)}
+            data-cy="roleSelect"
           >
             {permissions.map((permission: any, i: number) => (
               <MenuItem
                 key={`${i}-${permission.policy}`}
                 value={permission.policy}
                 disabled={permission.disabled}
+                data-cy={`roleOption-${permission.policy}`}
               >
                 {permissionDisplays[i]}
               </MenuItem>


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DC-994
______
### Original bug
Removing a dataset or snapshot policy member in the TDR UI no longer works, and yields an “InvalidMemberEmail” toast notification.

https://github.com/DataBiosphere/jade-data-repo-ui/assets/13254229/b2b5fbdd-edef-48bc-adc2-1bb3b09052ce


### With fix

https://github.com/DataBiosphere/jade-data-repo-ui/assets/13254229/792905fc-dea3-4132-9594-672fe9f4751a

### Code Changes
- Pass in the user email to be removed
- Define function parameters in typescript
- Add E2E test for dataset add and remove policies
