### PR TITLE
[DCJ-28] Slack DCJ team on nightly test failures, retries

### DIFF
--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -98,11 +98,3 @@ jobs:
       gcr_tag: ${{ needs.update_image.outputs.ui_image_tag }}
       source_gcr_url: 'gcr.io/broad-jade-dev/jade-data-repo-ui'
       target_gcr_url: 'gcr.io/datarepo-public-gcr/jade-data-repo-ui'
-  report-workflow:
-    needs: update_image
-    uses: broadinstitute/sherlock/.github/workflows/client-report-workflow.yaml@main
-    with:
-      notify-slack-channels-upon-workflow-completion: '#jade-spam'
-      notify-slack-custom-icon: ':github_merged:'
-    permissions:
-      id-token: write

--- a/.github/workflows/helmtagbump.yaml
+++ b/.github/workflows/helmtagbump.yaml
@@ -1,15 +1,8 @@
 name: Update integration ui helm image tag
 on:
-  workflow_dispatch:
-    inputs:
-      notify-slack:
-        default: true
-        type: boolean
-  workflow_call:
-    inputs:
-      notify-slack:
-        default: false
-        type: boolean
+  workflow_dispatch: {}
+  workflow_call: {}
+
 jobs:
   # new integration image updater
   integration_helm_tag_update:
@@ -109,11 +102,3 @@ jobs:
           GITHUB_REPO: datarepo-helm
           SWITCH_DIRECTORIES: true
           MERGE_BRANCH: master
-  report-workflow:
-    uses: broadinstitute/sherlock/.github/workflows/client-report-workflow.yaml@main
-    if: ${{ inputs.notify-slack }}
-    with:
-      notify-slack-channels-upon-workflow-completion: '#jade-spam'
-      notify-slack-custom-icon: ':github_merged:'
-    permissions:
-      id-token: write

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -117,7 +117,9 @@ jobs:
     uses: broadinstitute/sherlock/.github/workflows/client-report-workflow.yaml@main
     if: ${{ github.ref == 'refs/heads/develop' }}
     with:
-      notify-slack-channels-upon-workflow-completion: '#jade-spam'
+      relates-to-chart-releases: 'datarepo-dev'
+      notify-slack-channels-upon-workflow-failure: ${{ vars.SLACK_NOTIFICATION_CHANNELS }}
+      notify-slack-channels-upon-workflow-retry: ${{ vars.SLACK_NOTIFICATION_CHANNELS }}
       notify-slack-custom-icon: ':terra-horse:'
     permissions:
       id-token: write

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -37,7 +37,9 @@ jobs:
     uses: broadinstitute/sherlock/.github/workflows/client-report-workflow.yaml@main
     if: ${{ github.ref == 'refs/heads/develop' }}
     with:
-      notify-slack-channels-upon-workflow-completion: "#jade-spam"
+      relates-to-chart-releases: 'datarepo-dev'
+      notify-slack-channels-upon-workflow-failure: ${{ vars.SLACK_NOTIFICATION_CHANNELS }}
+      notify-slack-channels-upon-workflow-retry: ${{ vars.SLACK_NOTIFICATION_CHANNELS }}
       notify-slack-custom-icon: ":terra-horse:"
     permissions:
       id-token: write


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DCJ-28

More thorough background: https://github.com/DataBiosphere/jade-data-repo/pull/1654

TDR UI already used Sherlock to emit its Slack notifications in CI runs, but sent them on completion (including success) to #jade-spam.

I set up a new Github repository variable `SLACK_NOTIFICATION_CHANNELS`, and used this to configure the emission of Slack notifications when a test run on `develop` branch fails or is retried (this encompasses our nightly test runs along with any retries triggered due to initial failure).

<img width="1358" alt="Screenshot 2024-04-18 at 6 31 13 PM" src="https://github.com/DataBiosphere/jade-data-repo-ui/assets/79769153/2bab1814-ea8c-4c83-95e8-5136e0f99c55">

Removed Slack notification from image and Helm tag bumps: we will get visibility into deployments via Beehive's deployment Slack hook.