### PR TITLE
[DCJ-15] Make DCJ team the default codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,13 +1,7 @@
 # Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners.
+# Documentation with syntax examples:
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # These owners will be the default owners for everything in the repo.
-*       @DataBiosphere/jadeteam
-
-# Order is important. The last matching pattern has the most precedence.
-# So if a pull request only touches javascript files, only these owners
-# will be requested to review.
-#*.js    @octocat @github/js
-
-# You can also use email addresses if you prefer.
-#docs/*  docs@example.com
+*       @DataBiosphere/data-custodian-journeys


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DCJ-15

Make @DataBiosphere/data-custodian-journeys (new Github team) the default codeowners.  I have also made the team an admin of this repository.

Related PR with more context on team makeup, code review settings, and Slack scheduled reminders: https://github.com/DataBiosphere/jade-data-repo/pull/1665

(Note: as @DataBiosphere/data-explorer-eng isn't working much in this repo, I did not make them codeowners here like I did in `jade-data-repo`.)