### PR TITLE
DCJ-34: Configure vite for optimized dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jade-data-repo-ui",
-  "version": "0.304.0",
+  "version": "0.305.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jade-data-repo-ui",
-      "version": "0.304.0",
+      "version": "0.305.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/runtime": "^7.24.4",

--- a/vite.config.js
+++ b/vite.config.js
@@ -12,7 +12,7 @@ const driveApi = 'https://www.googleapis.com';
 
 dns.setDefaultResultOrder('verbatim');
 
-const getPluggins = () => {
+const getPlugins = () => {
   const plugins = [react(), svgr(), tsconfigPaths()];
   if (process.env.DISABLE_ESLINT_PLUGIN !== 'true') {
     plugins.push(eslint({ lintOnStart: false }));
@@ -30,7 +30,7 @@ export default defineConfig({
   optimizeDeps: {
     entries: ['cypress/**/*'],
   },
-  plugins: getPluggins(),
+  plugins: getPlugins(),
   server: {
     port: 3000,
     host: 'localhost',

--- a/vite.config.js
+++ b/vite.config.js
@@ -27,6 +27,9 @@ export default defineConfig({
   define: {
     'process.env': process.env,
   },
+  optimizeDeps: {
+    entries: ['cypress/**/*'],
+  },
   plugins: getPluggins(),
   server: {
     port: 3000,


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DCJ-34

## Summary
Add a config to address the [issue described here](https://github.com/cypress-io/cypress/issues/25913) as seen in our [automated unit test failures](https://github.com/DataBiosphere/jade-data-repo-ui/actions/runs/8947894489/job/24580384949)

List of GHA reruns here: https://github.com/DataBiosphere/jade-data-repo-ui/actions/runs/8958104129?pr=1649

Note: There also seems to be a [flaky e2e test](https://github.com/DataBiosphere/jade-data-repo-ui/actions/runs/8958104127/job/24601973802) that is not addressed by this PR.