### PR TITLE
DCJ-392: Add copy buttons for Job ID

### DIFF
--- a/src/components/job/JobResultModal.tsx
+++ b/src/components/job/JobResultModal.tsx
@@ -21,6 +21,7 @@ import { RouterLocation, RouterRootState } from 'connected-react-router';
 import { LocationState } from 'history';
 import { push } from 'modules/hist';
 import LoadingSpinner from '../common/LoadingSpinner';
+import CopyTextButton from '../common/CopyTextButton';
 
 const styles = () => ({
   dialog: {
@@ -109,7 +110,10 @@ function JobResultModal({ classes, dispatch, loading, jobResult, location }: Job
               <div>
                 <div className={classes.dialogInfo}>
                   <div className={classes.dialogLabel}>ID</div>
-                  <div className={classes.dialogContent}>{expandedJob}</div>
+                  <div className={classes.dialogContent}>
+                    <span style={{ marginRight: '10px' }}>{expandedJob}</span>
+                    <CopyTextButton valueToCopy={expandedJob} nameOfValue="Job ID" />
+                  </div>
                 </div>
 
                 <div className={classes.dialogInfo}>

--- a/src/components/table/JobTable.tsx
+++ b/src/components/table/JobTable.tsx
@@ -11,6 +11,7 @@ import { RouterRootState } from 'connected-react-router';
 import { connect } from 'react-redux';
 import { push } from 'modules/hist';
 import { urlEncodeParams } from 'libs/utilsTs';
+import CopyTextButton from '../common/CopyTextButton';
 import LightTable from './LightTable';
 
 const styles = (theme: CustomTheme) => ({
@@ -35,7 +36,7 @@ const styles = (theme: CustomTheme) => ({
     border: 'none',
     backgroundColor: 'transparent',
     color: theme.palette.primary.main,
-    width: '100%',
+    width: '80%',
     ...theme.mixins.ellipsis,
     '&:hover': {
       color: theme.palette.primary.hover,
@@ -86,13 +87,16 @@ const JobTable = withStyles(styles)(
         allowSort: false,
         width: '20%',
         render: (row: any) => (
-          <button
-            type="button"
-            onClick={() => handleSeeMoreOpen(row.id)}
-            className={classes.seeMoreLink}
-          >
-            <span>{`${row.id || 'See More'}`}</span>
-          </button>
+          <div>
+            <button
+              type="button"
+              onClick={() => handleSeeMoreOpen(row.id)}
+              className={classes.seeMoreLink}
+            >
+              <span>{`${row.id || 'See More'}`}</span>
+            </button>
+            <CopyTextButton valueToCopy={row.id} nameOfValue="Job ID" />
+          </div>
         ),
       },
       {


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DCJ-392

## Summary

- This PR adds two copy buttons that allow users to copy a job id. 
- This PR does **NOT** fix the existing broken copy button in the job modal - that is using a different component to do the copying and is described in https://broadworkbench.atlassian.net/browse/DCJ-447 

### Job Table Views
Minimized view:
![Screenshot 2024-06-20 at 9 31 56 AM](https://github.com/DataBiosphere/jade-data-repo-ui/assets/116679/e48b8213-f5f8-4aeb-8d7f-f9f1f1282381)

Expanded view:
![Screenshot 2024-06-20 at 9 32 04 AM](https://github.com/DataBiosphere/jade-data-repo-ui/assets/116679/2d27c758-4019-45f5-8fc6-995ebbbef38e)

### Job Modal View
![Screenshot 2024-06-20 at 9 32 17 AM](https://github.com/DataBiosphere/jade-data-repo-ui/assets/116679/4a2eb54a-72b0-474c-957f-41eb53c256d2)
