### PR TITLE
DCJ-453: Pin cherry-pick action to the latest version that doesn't use vault

### DIFF
--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -92,7 +92,7 @@ jobs:
     secrets: inherit
   cherry_pick_image_to_production_gcr:
     needs: update_image
-    uses: DataBiosphere/jade-data-repo/.github/workflows/cherry-pick-image.yaml@1.536.0
+    uses: DataBiosphere/jade-data-repo/.github/workflows/cherry-pick-image.yaml@2.92.0
     secrets: inherit
     with:
       gcr_tag: ${{ needs.update_image.outputs.ui_image_tag }}


### PR DESCRIPTION
## Addresses
Follow-on PR to address https://broadworkbench.atlassian.net/browse/DCJ-453
This PR tags the UI's cherry-pick action to use the latest version of the action defined in https://github.com/DataBiosphere/jade-data-repo/pull/1716