### PR TITLE
[DC-1152] Remove client side name generation

### DIFF
--- a/src/libs/utilsTs.test.ts
+++ b/src/libs/utilsTs.test.ts
@@ -1,9 +1,5 @@
 import { CloudPlatform, DatasetModel } from 'generated/tdr';
-import {
-  generateSnapshotNameFromAccessRequestInformation,
-  getCloudPlatform,
-  urlEncodeParams,
-} from './utilsTs';
+import { getCloudPlatform, urlEncodeParams } from './utilsTs';
 
 describe('utilsTs', () => {
   it('should render a simple url parameter correctly', () => {
@@ -24,25 +20,5 @@ describe('utilsTs', () => {
       storage: [{ cloudPlatform: 'azure' }],
     } as DatasetModel;
     expect(getCloudPlatform(dataset)).to.equal(CloudPlatform.Azure);
-  });
-  describe('generateSnapshotNameFromAccessRequestInformation', () => {
-    it('joins id and name', () => {
-      const id = 'abc';
-      const name = 'name';
-      const expected = 'name_abc';
-      expect(generateSnapshotNameFromAccessRequestInformation(id, name)).to.equal(expected);
-    });
-    it('converts dashes and spaces to underscores', () => {
-      const id = 'a-b-c';
-      const name = 'na me';
-      const expected = 'na_me_a_b_c';
-      expect(generateSnapshotNameFromAccessRequestInformation(id, name)).to.equal(expected);
-    });
-    it('removes disallowed characters', () => {
-      const id = 'a&b;c';
-      const name = 'name';
-      const expected = 'name_abc';
-      expect(generateSnapshotNameFromAccessRequestInformation(id, name)).to.equal(expected);
-    });
   });
 });

--- a/src/libs/utilsTs.ts
+++ b/src/libs/utilsTs.ts
@@ -18,25 +18,3 @@ export const urlEncodeParams = (params: Record<string, string | number | boolean
  */
 export const getCloudPlatform = (dataset: DatasetModel): CloudPlatform | undefined =>
   _.first(dataset.storage?.map((s) => s.cloudPlatform));
-
-/**
- * @param id {string} the id of the snapshot access request
- * @param snapshotName {string} the user specified name of the snapshot access request
- *
- * @return {string} An underscore joined name and id with all dashes and spaces converted to
- * underscores and all non-alphanumeric or underscore character stripped out.
- * It also trims all leading underscores
- */
-export const generateSnapshotNameFromAccessRequestInformation = (
-  id: string,
-  snapshotName: string,
-): string => {
-  const dashesAndSpacesRegExp = /[- ]+/g;
-  const nonAlphaNumericRegExp = /\W/g;
-  return _.trim(
-    `${snapshotName}_${id}`
-      .replaceAll(dashesAndSpacesRegExp, '_')
-      .replaceAll(nonAlphaNumericRegExp, ''),
-    '_',
-  );
-};

--- a/src/sagas/repository.ts
+++ b/src/sagas/repository.ts
@@ -33,7 +33,6 @@ import {
   ColumnStatsRetrievalType,
 } from 'constants';
 import { TdrState } from 'reducers';
-import { generateSnapshotNameFromAccessRequestInformation } from 'libs/utilsTs';
 
 /**
  * Switch Menu
@@ -1033,7 +1032,7 @@ export function* approveSnapshotAccessRequest({ payload }: any): any {
     snapshotAccessRequestResponse: { id, snapshotName },
   } = payload;
   const snapshotRequest: SnapshotRequestModel = {
-    name: generateSnapshotNameFromAccessRequestInformation(id, snapshotName),
+    name: 'unused',
     description: `Snapshot created from ${snapshotName}`,
     contents: [
       {


### PR DESCRIPTION
We are now generating the name server-side for byRequestId snapshots, so we can remove that here.