### PR TITLE
Revert "DCJ-453: Pin cherry-pick action to the latest version that doesn't use vault"

### DIFF
--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -93,7 +93,6 @@ jobs:
   cherry_pick_image_to_production_gcr:
     needs: update_image
     uses: DataBiosphere/jade-data-repo/.github/workflows/cherry-pick-image.yaml@1.536.0
-
     secrets: inherit
     with:
       gcr_tag: ${{ needs.update_image.outputs.ui_image_tag }}

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -93,6 +93,7 @@ jobs:
   cherry_pick_image_to_production_gcr:
     needs: update_image
     uses: DataBiosphere/jade-data-repo/.github/workflows/cherry-pick-image.yaml@1.536.0
+
     secrets: inherit
     with:
       gcr_tag: ${{ needs.update_image.outputs.ui_image_tag }}

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -92,7 +92,7 @@ jobs:
     secrets: inherit
   cherry_pick_image_to_production_gcr:
     needs: update_image
-    uses: DataBiosphere/jade-data-repo/.github/workflows/cherry-pick-image.yaml@2.92.0
+    uses: DataBiosphere/jade-data-repo/.github/workflows/cherry-pick-image.yaml@1.536.0
     secrets: inherit
     with:
       gcr_tag: ${{ needs.update_image.outputs.ui_image_tag }}


### PR DESCRIPTION
Reverts DataBiosphere/jade-data-repo-ui#1669