### PR TITLE
DC-1048: Add aggregate reader role to UI

### DIFF
--- a/src/components/ManageUsersView.tsx
+++ b/src/components/ManageUsersView.tsx
@@ -28,7 +28,7 @@ function ManageUsersView({ classes, removeUser, users }: ManageUsersProps) {
           color="primary"
           label={user}
           key={user}
-          onDelete={() => removeUser?.(user)}
+          onDelete={removeUser ? () => removeUser?.(user) : undefined}
           variant="outlined"
           data-cy={`chip-${user}`}
         />

--- a/src/components/snapshot/SnapshotAccess.test.tsx
+++ b/src/components/snapshot/SnapshotAccess.test.tsx
@@ -28,8 +28,12 @@ const initialState = {
         name: 'discoverer',
         members: [],
       },
+      {
+        name: 'aggregate_data_reader',
+        members: ['datareader@gmail.com'],
+      },
     ],
-    userRoles: ['steward', 'reader'],
+    userRoles: ['steward', 'reader', 'discoverer', 'aggregate_data_reader'],
   },
 };
 
@@ -67,6 +71,13 @@ describe('Snapshot access info', () => {
       .within(() => {
         cy.get('[data-cy="user-email"]').then((user) => {
           cy.wrap(user[0]).should('contain.text', '(None)');
+        });
+      });
+    cy.get('[data-cy="snapshot-aggregate-data-readers"]')
+      .should('contain.text', 'Aggregate Data Readers')
+      .within(() => {
+        cy.get('[data-cy="user-email"]').then((user) => {
+          cy.wrap(user[0]).should('contain.text', 'datareader@gmail.com');
         });
       });
   });

--- a/src/components/snapshot/SnapshotAccess.tsx
+++ b/src/components/snapshot/SnapshotAccess.tsx
@@ -47,7 +47,12 @@ function SnapshotAccess({
 
       // needs this manual conversion because the permissions are different for
       // editing existing snapshot policies vs creating a new snapshot
-      if (role === 'steward' || role === 'reader' || role === 'discoverer') {
+      if (
+        role === 'steward' ||
+        role === 'reader' ||
+        role === 'discoverer' ||
+        role === 'aggregate_data_reader'
+      ) {
         dispatch(changePolicyUsersToSnapshotRequest(`${role}s`, uniqEmails));
       }
     } else {
@@ -81,12 +86,14 @@ function SnapshotAccess({
   const stewards = getUsers(SnapshotRoles.STEWARD);
   const readers = getUsers(SnapshotRoles.READER);
   const discoverers = getUsers(SnapshotRoles.DISCOVERER);
+  const aggregateDataReaders = getUsers(SnapshotRoles.AGGREGATE_DATA_READER);
 
   const canManageUsers = userRoles.includes(SnapshotRoles.STEWARD) || !!createMode;
   const permissions: AccessPermission[] = [
     { policy: 'steward', disabled: !canManageUsers },
     { policy: 'reader', disabled: !canManageUsers },
     { policy: 'discoverer', disabled: !canManageUsers },
+    { policy: 'aggregate_data_reader', disabled: !canManageUsers },
   ];
 
   return (
@@ -120,6 +127,15 @@ function SnapshotAccess({
           typeOfUsers="Discoverers"
           canManageUsers={canManageUsers}
           removeUser={removeUser(SnapshotRoles.DISCOVERER)}
+          defaultOpen={createMode}
+        />
+      </Grid>
+      <Grid item xs={12} data-cy="snapshot-aggregate-data-readers">
+        <UserList
+          users={aggregateDataReaders}
+          typeOfUsers="Aggregate Data Readers"
+          canManageUsers={canManageUsers}
+          removeUser={removeUser(SnapshotRoles.AGGREGATE_DATA_READER)}
           defaultOpen={createMode}
         />
       </Grid>

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -205,6 +205,7 @@ export enum SnapshotRoles {
   STEWARD = 'steward',
   READER = 'reader',
   DISCOVERER = 'discoverer',
+  AGGREGATE_DATA_READER = 'aggregate_data_reader',
 }
 
 export enum DatasetRoles {


### PR DESCRIPTION
### Summary
We now have a new role "aggregate data reader" on snapshots. We want to enable snapshot stewards to be able to give users this role in the TDR UI. Users can also add aggregate data readers on snapshot create. 


https://github.com/user-attachments/assets/601f0bf6-b107-4f07-b988-258d56769424



https://github.com/user-attachments/assets/32968ce0-945d-4529-baa3-e1973feb3b74




### Testing
- Added component test for this role
- Manual testing

### Super quick additional fix
We previously displayed the "x" button that would imply that you can remove a data access control (DAC) group. However, we do not support deleting DACs from a snapshot. So, I've remove it. 
**Before:**
<img width="942" alt="Screenshot 2024-07-29 at 11 40 54 AM" src="https://github.com/user-attachments/assets/ccbe99b5-2ce9-4cac-97ad-858f423d83ec">
**With Fix:**
<img width="928" alt="Screenshot 2024-07-29 at 11 40 32 AM" src="https://github.com/user-attachments/assets/e54e5d30-7afa-4395-9bda-137924d3abca">
