### PR TITLE
[DCJ-572] Hide Activity tab

### DIFF
--- a/src/components/common/TabWrapper.tsx
+++ b/src/components/common/TabWrapper.tsx
@@ -71,7 +71,7 @@ function TabWrapper(props: TabWrapperProps) {
   const tabConfigs: Array<ITabConfig> = [
     { label: 'Datasets', path: '/datasets' },
     { label: 'Snapshots', path: '/snapshots' },
-    { label: 'Activity', path: '/activity' },
+    { label: 'Activity', path: '/activity', hidden: true },
     { label: 'Ingest Data', path: '/ingestdata' },
     {
       label: 'Requests',


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DCJ-572

## Addresses

Removes the Activity tab on TDR's top navigation bar.

For non-Admin users, it's currently timing out and driving up load balancer latency stats, which pages our On Call engineers.

This tab is clicked on only sporadically: this PR hides it so that users don't stumble upon it while we debug the underlying slowness.

<img width="895" alt="Screenshot 2024-08-01 at 4 47 16 PM" src="https://github.com/user-attachments/assets/cce8aa8e-f3cc-417f-aef4-57a07988fccf">


Users can if needed still navigate to the /activity URL to view all jobs, but only TDR Admins / debuggers are likely to actually do that.

<img width="899" alt="Screenshot 2024-08-01 at 4 47 30 PM" src="https://github.com/user-attachments/assets/41f42b49-f177-4be3-8087-cfd0fc02241a">

