### PR TITLE
[DCJ-400] Ensure @emotion/react is a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@babel/runtime": "^7.25.0",
         "@codemirror/lang-javascript": "^6.2.2",
         "@emotion/cache": "^11.13.1",
+        "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.13.0",
         "@fortawesome/fontawesome-svg-core": "^6.6.0",
         "@fortawesome/free-solid-svg-icons": "^6.6.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@codemirror/lang-javascript": "^6.2.2",
     "@emotion/cache": "^11.13.1",
     "@emotion/styled": "^11.13.0",
+    "@emotion/react": "^11.11.1",
     "@fortawesome/fontawesome-svg-core": "^6.6.0",
     "@fortawesome/free-solid-svg-icons": "^6.6.0",
     "@fortawesome/react-fontawesome": "^0.2.2",


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DCJ-400

### Summary

`npm` is not strict and allows peer dependencies to be called from code even if they are not explicitly in `package.json`. `src/index.jsx` references `'@emotion/react';`, but this is not explicitly listed as a dependency. This can cause issues with `vite` when using stricter package managers like `pnpm`:

```
10:19:38 AM [vite] Internal server error: Failed to resolve import "@emotion/react" from "src/index.jsx". Does the file exist?
  Plugin: vite:import-analysis
  File: jade-data-repo-ui/src/index.jsx:20:30
  15 |  import momentDurationFormatSetup from "moment-duration-format";
  16 |  import createCache from "@emotion/cache";
  17 |  import { CacheProvider } from "@emotion/react";
     |                                 ^
  18 |  import App from "containers/App";
  19 |  import config from "./config";
  ```

We should avoid depending on this behavior, as it can cause unexpected behavior and bugs. This PR adds that dependency to make it explicit.

To make minimal compatible changes to the `package-lock.json` file, I did not include the latest version of `@emotion/react`, and instead relied on the one that was already referenced in the lockfile.