### PR TITLE
[DC-1269] Remove limit on dependabot and integration references

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,6 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
-  # See workflows/test-e2e.yml for the current list of k8s namespaces available for integration testing.
-  # Presently, there are only 2.
-  # Keeping the open PR limit low at 4 so that when automatically rebasing, 4 concurrent Dependabot PR integration test
-  # runs all stand a chance at success rather than some being guaranteed to time out waiting for an available namespace.
-  open-pull-requests-limit: 4
   commit-message:
     prefix: "[DCJ-400-npm]"
   groups:

--- a/.github/workflows/helmtagbump.yaml
+++ b/.github/workflows/helmtagbump.yaml
@@ -4,57 +4,6 @@ on:
   workflow_call: {}
 
 jobs:
-  # new integration image updater
-  integration_helm_tag_update:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          ref: develop
-      - name: 'Get Previous tag'
-        id: uiprevioustag
-        run: |
-          TAG=$(git for-each-ref --sort=-creatordate --count 1 --format="%(refname:short)" "refs/tags/")
-          echo "tag=${TAG}" >> $GITHUB_OUTPUT
-      - name: 'Checkout datarepo-helm-definitions repo'
-        uses: actions/checkout@v3
-        with:
-          repository: 'broadinstitute/datarepo-helm-definitions'
-          token: ${{ secrets.BROADBOT_TOKEN}}
-          path: datarepo-helm-definitions
-      - name: 'integration-1 find and replace'
-        uses: docker://mikefarah/yq:3
-        with:
-          args: yq w -i datarepo-helm-definitions/integration/integration-1/datarepo-ui.yaml image.tag ${{ steps.uiprevioustag.outputs.tag }}"
-      - name: 'integration-2 find and replace'
-        uses: docker://mikefarah/yq:3
-        with:
-          args: yq w -i datarepo-helm-definitions/integration/integration-2/datarepo-ui.yaml image.tag ${{ steps.uiprevioustag.outputs.tag }}"
-      - name: 'integration-3 find and replace'
-        uses: docker://mikefarah/yq:3
-        with:
-          args: yq w -i datarepo-helm-definitions/integration/integration-3/datarepo-ui.yaml image.tag ${{ steps.uiprevioustag.outputs.tag }}"
-      - name: 'integration-4 find and replace'
-        uses: docker://mikefarah/yq:3
-        with:
-          args: yq w -i datarepo-helm-definitions/integration/integration-4/datarepo-ui.yaml image.tag ${{ steps.uiprevioustag.outputs.tag }}"
-      - name: 'integration-5 find and replace'
-        uses: docker://mikefarah/yq:3
-        with:
-          args: yq w -i datarepo-helm-definitions/integration/integration-5/datarepo-ui.yaml image.tag ${{ steps.uiprevioustag.outputs.tag }}"
-      - name: 'integration-6 find and replace'
-        uses: docker://mikefarah/yq:3
-        with:
-          args: yq w -i datarepo-helm-definitions/integration/integration-6/datarepo-ui.yaml image.tag ${{ steps.uiprevioustag.outputs.tag }}"
-      - name: '[datarepo-helm-definitions] Merge chart version update'
-        uses: broadinstitute/datarepo-actions/actions/merger@0.74.0
-        env:
-          COMMIT_MESSAGE: 'Datarepo ui tag version update: ${{ steps.uiprevioustag.outputs.tag }}'
-          GITHUB_REPO: datarepo-helm-definitions
-          SWITCH_DIRECTORIES: true
-          MERGE_BRANCH: master
   ui_helm_default_chart_tag:
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
I believe these should all get removed with the move to point at dev, rather than integration for the tests