### PR TITLE
[DT-1096] Update JIRA key to DT instead of DCJ

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   schedule:
     interval: weekly
   commit-message:
-    prefix: "[DCJ-400-npm]"
+    prefix: "[DT-400-npm]"
   groups:
     # We group minor and patch updates together because they are unexpected to break things.
     # Major updates will be PR-ed individually: they are more likely to need developer intervention.


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-1096

### Summary

Updates the JIRA key to `DT-` instead of `DCJ-`

