### PR TITLE
DT-1108: Manually bump cherry pick action version 

### DIFF
--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -90,7 +90,7 @@ jobs:
     secrets: inherit
   cherry_pick_image_to_production_gcr:
     needs: update_image
-    uses: DataBiosphere/jade-data-repo/.github/workflows/cherry-pick-image.yaml@2.98.0
+    uses: DataBiosphere/jade-data-repo/.github/workflows/cherry-pick-image.yaml@2.201.0
     secrets: inherit
     with:
       gcr_tag: ${{ needs.update_image.outputs.ui_image_tag }}


### PR DESCRIPTION
So that it picks up this change: https://github.com/DataBiosphere/jade-data-repo/pull/1874

We have seen that the action works in TDR. We'll see this in action on merge of this PR. 