### PR TITLE
DT-1110: Migrate away from @mui/styles Part 1

### DIFF
--- a/src/components/DatasetView.tsx
+++ b/src/components/DatasetView.tsx
@@ -2,13 +2,15 @@ import React, { Dispatch } from 'react';
 import { connect } from 'react-redux';
 import { Action } from 'redux';
 import { Box } from '@mui/material';
+import { styled } from '@mui/system';
 import { getDatasets, addDatasetPolicyMember } from 'actions/index';
 import { DatasetSummaryModel } from 'generated/tdr';
 import { TdrState } from 'reducers';
 import { OrderDirectionOptions } from 'reducers/query';
-import theme from 'modules/theme';
 import DatasetTable from './table/DatasetTable';
 import { DatasetRoles } from '../constants';
+
+const Container = styled('div')(({ theme }) => theme.mixins.containerWidth);
 
 interface IProps {
   datasets: Array<DatasetSummaryModel>;
@@ -55,7 +57,7 @@ function DatasetView({
         mt: '1em',
       }}
     >
-      <Box sx={{ ...theme.mixins.containerWidth }}>
+      <Container>
         <Box>
           {datasets && (
             <DatasetTable
@@ -71,7 +73,7 @@ function DatasetView({
             />
           )}
         </Box>
-      </Box>
+      </Container>
     </Box>
   );
 }

--- a/src/components/DatasetView.tsx
+++ b/src/components/DatasetView.tsx
@@ -1,11 +1,12 @@
 import React, { Dispatch } from 'react';
 import { connect } from 'react-redux';
 import { Action } from 'redux';
-import { Box, Typography } from '@mui/material';
+import { Box } from '@mui/material';
 import { getDatasets, addDatasetPolicyMember } from 'actions/index';
 import { DatasetSummaryModel } from 'generated/tdr';
 import { TdrState } from 'reducers';
 import { OrderDirectionOptions } from 'reducers/query';
+import theme from 'modules/theme';
 import DatasetTable from './table/DatasetTable';
 
 import { DatasetRoles } from '../constants';
@@ -49,7 +50,7 @@ function DatasetView({
 
   return (
     <Box sx={{ display: 'flex', justifyContent: 'center', marginTop: '1em' }}>
-      <Box sx={{ width: '100%', maxWidth: '1200px' }}>
+      <Box sx={{ ...theme.mixins.containerWidth }}>
         {datasets && (
           <DatasetTable
             datasets={datasets}

--- a/src/components/DatasetView.tsx
+++ b/src/components/DatasetView.tsx
@@ -8,7 +8,6 @@ import { TdrState } from 'reducers';
 import { OrderDirectionOptions } from 'reducers/query';
 import DatasetTable from './table/DatasetTable';
 import { DatasetRoles } from '../constants';
-import Container from './common/Container';
 
 interface IProps {
   datasets: Array<DatasetSummaryModel>;
@@ -55,7 +54,7 @@ function DatasetView({
         mt: '1em',
       }}
     >
-      <Container>
+      <Box sx={{ width: '100%' }}>
         <Box>
           {datasets && (
             <DatasetTable
@@ -71,7 +70,7 @@ function DatasetView({
             />
           )}
         </Box>
-      </Container>
+      </Box>
     </Box>
   );
 }

--- a/src/components/DatasetView.tsx
+++ b/src/components/DatasetView.tsx
@@ -2,7 +2,7 @@ import React, { Dispatch } from 'react';
 import { connect } from 'react-redux';
 import { Action } from 'redux';
 import { Box } from '@mui/material';
-import { styled } from '@mui/system';
+import { CustomTheme, styled } from '@mui/material/styles';
 import { getDatasets, addDatasetPolicyMember } from 'actions/index';
 import { DatasetSummaryModel } from 'generated/tdr';
 import { TdrState } from 'reducers';
@@ -10,7 +10,7 @@ import { OrderDirectionOptions } from 'reducers/query';
 import DatasetTable from './table/DatasetTable';
 import { DatasetRoles } from '../constants';
 
-const Container = styled('div')(({ theme }) => theme.mixins.containerWidth);
+const Container = styled('div')(({ theme }: { theme: CustomTheme }) => theme.mixins.containerWidth);
 
 interface IProps {
   datasets: Array<DatasetSummaryModel>;

--- a/src/components/DatasetView.tsx
+++ b/src/components/DatasetView.tsx
@@ -2,15 +2,13 @@ import React, { Dispatch } from 'react';
 import { connect } from 'react-redux';
 import { Action } from 'redux';
 import { Box } from '@mui/material';
-import { CustomTheme, styled } from '@mui/material/styles';
 import { getDatasets, addDatasetPolicyMember } from 'actions/index';
 import { DatasetSummaryModel } from 'generated/tdr';
 import { TdrState } from 'reducers';
 import { OrderDirectionOptions } from 'reducers/query';
 import DatasetTable from './table/DatasetTable';
 import { DatasetRoles } from '../constants';
-
-const Container = styled('div')(({ theme }: { theme: CustomTheme }) => theme.mixins.containerWidth);
+import Container from './common/Container';
 
 interface IProps {
   datasets: Array<DatasetSummaryModel>;

--- a/src/components/DatasetView.tsx
+++ b/src/components/DatasetView.tsx
@@ -50,16 +50,6 @@ function DatasetView({
   return (
     <Box sx={{ display: 'flex', justifyContent: 'center', marginTop: '1em' }}>
       <Box sx={{ width: '100%', maxWidth: '1200px' }}>
-        <Typography
-          sx={{
-            color: 'primary.main',
-            fontSize: '54px',
-            lineHeight: '66px',
-            paddingBottom: '64px',
-          }}
-        >
-          Datasets
-        </Typography>
         {datasets && (
           <DatasetTable
             datasets={datasets}

--- a/src/components/DatasetView.tsx
+++ b/src/components/DatasetView.tsx
@@ -8,7 +8,6 @@ import { TdrState } from 'reducers';
 import { OrderDirectionOptions } from 'reducers/query';
 import theme from 'modules/theme';
 import DatasetTable from './table/DatasetTable';
-
 import { DatasetRoles } from '../constants';
 
 interface IProps {
@@ -49,21 +48,29 @@ function DatasetView({
   };
 
   return (
-    <Box sx={{ display: 'flex', justifyContent: 'center', marginTop: '1em' }}>
+    <Box
+      sx={{
+        display: 'flex',
+        justifyContent: 'center',
+        mt: '1em',
+      }}
+    >
       <Box sx={{ ...theme.mixins.containerWidth }}>
-        {datasets && (
-          <DatasetTable
-            datasets={datasets}
-            datasetRoleMaps={datasetRoleMaps}
-            datasetsCount={datasetsCount}
-            handleFilterDatasets={handleFilterDatasets}
-            handleMakeSteward={handleMakeSteward}
-            filteredDatasetsCount={filteredDatasetsCount}
-            searchString={searchString}
-            loading={loading}
-            refreshCnt={refreshCnt}
-          />
-        )}
+        <Box>
+          {datasets && (
+            <DatasetTable
+              datasets={datasets}
+              datasetRoleMaps={datasetRoleMaps}
+              datasetsCount={datasetsCount}
+              handleFilterDatasets={handleFilterDatasets}
+              handleMakeSteward={handleMakeSteward}
+              filteredDatasetsCount={filteredDatasetsCount}
+              searchString={searchString}
+              loading={loading}
+              refreshCnt={refreshCnt}
+            />
+          )}
+        </Box>
       </Box>
     </Box>
   );

--- a/src/components/DatasetView.tsx
+++ b/src/components/DatasetView.tsx
@@ -51,7 +51,7 @@ function DatasetView({
       sx={{
         display: 'flex',
         justifyContent: 'center',
-        mt: '1em',
+        marginTop: '1em',
       }}
     >
       <Box sx={{ width: '100%' }}>

--- a/src/components/DatasetView.tsx
+++ b/src/components/DatasetView.tsx
@@ -1,34 +1,16 @@
 import React, { Dispatch } from 'react';
 import { connect } from 'react-redux';
 import { Action } from 'redux';
-import { WithStyles, withStyles } from '@mui/styles';
+import { Box, Typography } from '@mui/material';
 import { getDatasets, addDatasetPolicyMember } from 'actions/index';
 import { DatasetSummaryModel } from 'generated/tdr';
-import { CustomTheme } from '@mui/material';
 import { TdrState } from 'reducers';
 import { OrderDirectionOptions } from 'reducers/query';
 import DatasetTable from './table/DatasetTable';
 
 import { DatasetRoles } from '../constants';
 
-const styles = (theme: CustomTheme) => ({
-  wrapper: {
-    display: 'flex',
-    justifyContent: 'center',
-    marginTop: '1em',
-  },
-  width: {
-    ...theme.mixins.containerWidth,
-  },
-  title: {
-    color: theme.palette.primary.main,
-    fontSize: '54px',
-    lineHeight: '66px',
-    paddingBottom: theme.spacing(8),
-  },
-});
-
-interface IProps extends WithStyles<typeof styles> {
+interface IProps {
   datasets: Array<DatasetSummaryModel>;
   datasetRoleMaps: { [key: string]: Array<string> };
   datasetsCount: number;
@@ -40,56 +22,61 @@ interface IProps extends WithStyles<typeof styles> {
   userEmail: string;
 }
 
-const DatasetView = withStyles(styles)(
-  ({
-    classes,
-    datasets,
-    datasetRoleMaps,
-    datasetsCount,
-    dispatch,
-    filteredDatasetsCount,
-    loading,
-    searchString,
-    refreshCnt,
-    userEmail,
-  }: IProps) => {
-    const handleFilterDatasets = (
-      limit: number,
-      offset: number,
-      sort: string,
-      sortDirection: OrderDirectionOptions,
-      search: string,
-    ) => {
-      dispatch(getDatasets(limit, offset, sort, sortDirection, search));
-    };
+function DatasetView({
+  datasets,
+  datasetRoleMaps,
+  datasetsCount,
+  dispatch,
+  filteredDatasetsCount,
+  loading,
+  searchString,
+  refreshCnt,
+  userEmail,
+}: IProps) {
+  const handleFilterDatasets = (
+    limit: number,
+    offset: number,
+    sort: string,
+    sortDirection: OrderDirectionOptions,
+    search: string,
+  ) => {
+    dispatch(getDatasets(limit, offset, sort, sortDirection, search));
+  };
 
-    const handleMakeSteward = (datasetId: string) => {
-      dispatch(addDatasetPolicyMember(datasetId, userEmail, DatasetRoles.STEWARD));
-    };
+  const handleMakeSteward = (datasetId: string) => {
+    dispatch(addDatasetPolicyMember(datasetId, userEmail, DatasetRoles.STEWARD));
+  };
 
-    return (
-      <div className={classes.wrapper}>
-        <div className={classes.width}>
-          <div>
-            {datasets && (
-              <DatasetTable
-                datasets={datasets}
-                datasetRoleMaps={datasetRoleMaps}
-                datasetsCount={datasetsCount}
-                handleFilterDatasets={handleFilterDatasets}
-                handleMakeSteward={handleMakeSteward}
-                filteredDatasetsCount={filteredDatasetsCount}
-                searchString={searchString}
-                loading={loading}
-                refreshCnt={refreshCnt}
-              />
-            )}
-          </div>
-        </div>
-      </div>
-    );
-  },
-);
+  return (
+    <Box sx={{ display: 'flex', justifyContent: 'center', marginTop: '1em' }}>
+      <Box sx={{ width: '100%', maxWidth: '1200px' }}>
+        <Typography
+          sx={{
+            color: 'primary.main',
+            fontSize: '54px',
+            lineHeight: '66px',
+            paddingBottom: '64px',
+          }}
+        >
+          Datasets
+        </Typography>
+        {datasets && (
+          <DatasetTable
+            datasets={datasets}
+            datasetRoleMaps={datasetRoleMaps}
+            datasetsCount={datasetsCount}
+            handleFilterDatasets={handleFilterDatasets}
+            handleMakeSteward={handleMakeSteward}
+            filteredDatasetsCount={filteredDatasetsCount}
+            searchString={searchString}
+            loading={loading}
+            refreshCnt={refreshCnt}
+          />
+        )}
+      </Box>
+    </Box>
+  );
+}
 
 function mapStateToProps(state: TdrState) {
   return {

--- a/src/components/HomeView.tsx
+++ b/src/components/HomeView.tsx
@@ -2,12 +2,10 @@ import React, { Dispatch, useState } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { Action } from 'redux';
-
 import { Button, Box } from '@mui/material';
+import { styled } from '@mui/material/styles';
 import { AddCircle, Refresh } from '@mui/icons-material';
-import { CustomTheme } from '@mui/material/styles';
 import { RouterLocation, RouterRootState } from 'connected-react-router';
-import { LocationState } from 'history';
 import {
   getSnapshotAccessRequests,
   refreshDatasets,
@@ -17,11 +15,35 @@ import {
 } from 'src/actions';
 import { TdrState } from 'reducers';
 import { useOnMount } from 'libs/utils';
+import { LocationState } from 'history';
 import DatasetView from './DatasetView';
 import SnapshotView from './SnapshotView';
 import JobView from './JobView';
 import SearchTable from './table/SearchTable';
 import SnapshotAccessRequestView from './SnapshotAccessRequestView';
+
+const RootContainer = styled(Box)({
+  padding: '16px 24px',
+  display: 'flex',
+  flexDirection: 'column',
+  height: '100%',
+});
+
+const TitleContainer = styled(Box)(({ theme }) => ({
+  color: theme.palette.secondary.dark,
+  fontSize: '1.5rem',
+  fontWeight: 700,
+  flex: '1 1 0',
+  paddingRight: '2em',
+  display: 'flex',
+}));
+
+const HeaderButton = styled(Button)({
+  padding: '10px',
+  marginLeft: '16px',
+  height: '45px',
+  textTransform: 'none',
+});
 
 interface IProps {
   dispatch: Dispatch<Action>;
@@ -35,7 +57,7 @@ function HomeView({ dispatch, location }: IProps) {
 
   let pageTitle = 'Terra Data Repository';
   let searchable = true;
-  let tableValue = <Box />;
+  let tableValue = <div />;
   let refresh;
   if (tabValue === '/datasets') {
     pageTitle = 'Datasets';
@@ -56,57 +78,32 @@ function HomeView({ dispatch, location }: IProps) {
     refresh = () => dispatch(refreshSnapshotAccessRequests());
   }
   const refreshButton = (
-    <Button
+    <HeaderButton
       aria-label="refresh page"
       size="medium"
-      sx={{ padding: '10px', marginLeft: '16px', height: '45px', textTransform: 'none' }}
       onClick={refresh}
       variant="outlined"
       startIcon={<Refresh />}
     >
       Refresh
-    </Button>
+    </HeaderButton>
   );
   const pageHeader =
     tabValue === '/datasets' ? (
-      <Box
-        sx={{
-          display: 'flex',
-          color: 'secondary.dark',
-          fontSize: '1.5rem',
-          fontWeight: 700,
-          flex: '1 1 0',
-          paddingRight: '2em',
-        }}
-      >
+      <TitleContainer>
         <Box sx={{ width: '150px' }}>{pageTitle}</Box>
         {refreshButton}
         <Link to="datasets/new" data-cy="create-dataset-link">
-          <Button
-            sx={{ padding: '10px', marginLeft: '16px', height: '45px', textTransform: 'none' }}
-            color="primary"
-            variant="outlined"
-            disableElevation
-            size="medium"
-          >
+          <HeaderButton color="primary" variant="outlined" disableElevation size="medium">
             <AddCircle sx={{ marginRight: '6px', fontSize: '1.5rem' }} /> Create Dataset
-          </Button>
+          </HeaderButton>
         </Link>
-      </Box>
+      </TitleContainer>
     ) : (
-      <Box
-        sx={{
-          display: 'flex',
-          color: 'secondary.dark',
-          fontSize: '1.5rem',
-          fontWeight: 700,
-          flex: '1 1 0',
-          paddingRight: '2em',
-        }}
-      >
+      <TitleContainer>
         <Box sx={{ width: '150px' }}>{pageTitle}</Box>
         {refreshButton}
-      </Box>
+      </TitleContainer>
     );
 
   useOnMount(() => {
@@ -114,8 +111,8 @@ function HomeView({ dispatch, location }: IProps) {
   });
 
   return (
-    <Box sx={{ padding: '16px 24px', display: 'flex', flexDirection: 'column', height: '100%' }}>
-      <Box sx={{ display: 'flex', marginTop: '1.25em', marginBottom: '1.25em' }}>
+    <RootContainer>
+      <Box sx={{ display: 'flex', mt: '1.25em', mb: '1.25em' }}>
         {pageHeader}
         {searchable && (
           <SearchTable
@@ -126,7 +123,7 @@ function HomeView({ dispatch, location }: IProps) {
         )}
       </Box>
       {tableValue}
-    </Box>
+    </RootContainer>
   );
 }
 

--- a/src/components/HomeView.tsx
+++ b/src/components/HomeView.tsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { Action } from 'redux';
 import { Button, Box } from '@mui/material';
-import { styled } from '@mui/system';
+import { styled } from '@mui/material/styles';
 import { AddCircle, Refresh } from '@mui/icons-material';
 import { RouterLocation, RouterRootState } from 'connected-react-router';
 import {

--- a/src/components/HomeView.tsx
+++ b/src/components/HomeView.tsx
@@ -112,7 +112,7 @@ function HomeView({ dispatch, location }: IProps) {
 
   return (
     <RootContainer>
-      <Box sx={{ display: 'flex', mt: '1.25em', mb: '1.25em' }}>
+      <Box sx={{ display: 'flex', marginTop: '1.25em', marginBottom: '1.25em' }}>
         {pageHeader}
         {searchable && (
           <SearchTable

--- a/src/components/HomeView.tsx
+++ b/src/components/HomeView.tsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { Action } from 'redux';
 import { Button, Box } from '@mui/material';
-import { styled } from '@mui/material/styles';
+import { styled } from '@mui/system';
 import { AddCircle, Refresh } from '@mui/icons-material';
 import { RouterLocation, RouterRootState } from 'connected-react-router';
 import {

--- a/src/components/HomeView.tsx
+++ b/src/components/HomeView.tsx
@@ -3,9 +3,8 @@ import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { Action } from 'redux';
 
-import { Button } from '@mui/material';
+import { Button, Box } from '@mui/material';
 import { AddCircle, Refresh } from '@mui/icons-material';
-import { createStyles, WithStyles, withStyles } from '@mui/styles';
 import { CustomTheme } from '@mui/material/styles';
 import { RouterLocation, RouterRootState } from 'connected-react-router';
 import { LocationState } from 'history';
@@ -24,77 +23,19 @@ import JobView from './JobView';
 import SearchTable from './table/SearchTable';
 import SnapshotAccessRequestView from './SnapshotAccessRequestView';
 
-const styles = (theme: CustomTheme) =>
-  createStyles({
-    pageRoot: {
-      padding: '16px 24px',
-      display: 'flex',
-      flexDirection: 'column',
-      height: '100%',
-    },
-    header: {
-      alignItems: 'center',
-      color: theme.typography.color,
-      display: 'flex',
-      fontWeight: 500,
-      fontSize: 16,
-      height: 21,
-      letterSpacing: 1,
-    },
-    jadeTableSpacer: {
-      paddingBottom: theme.spacing(12),
-    },
-    jadeLink: {
-      ...theme.mixins.jadeLink,
-      float: 'right',
-      fontSize: 16,
-      fontWeight: 500,
-      height: 20,
-      letterSpacing: 0.3,
-      paddingLeft: theme.spacing(4),
-      paddingTop: theme.spacing(4),
-    },
-    title: {
-      color: theme.palette.secondary.dark,
-      fontSize: '1.5rem',
-      fontWeight: 700,
-      flex: '1 1 0',
-      'padding-right': '2em',
-      display: 'flex',
-    },
-    titleText: {
-      width: '150px',
-    },
-    titleAndSearch: {
-      display: 'flex',
-      'margin-top': '1.25em',
-      'margin-bottom': '1.25em',
-    },
-    headerButton: {
-      padding: 10,
-      marginLeft: theme.spacing(2),
-      height: '45px',
-      textTransform: 'none',
-    },
-    buttonIcon: {
-      marginRight: 6,
-      fontSize: '1.5rem',
-    },
-  });
-
-interface IProps extends WithStyles<typeof styles> {
+interface IProps {
   dispatch: Dispatch<Action>;
   location: RouterLocation<LocationState>;
 }
 
-function HomeView({ classes, dispatch, location }: IProps) {
+function HomeView({ dispatch, location }: IProps) {
   const [searchString, setSearchString] = useState('');
   const prefixMatcher = /\/[^/]*/;
   const tabValue = prefixMatcher.exec(location.pathname)?.[0];
 
   let pageTitle = 'Terra Data Repository';
   let searchable = true;
-  let tableValue = <div />;
+  let tableValue = <Box />;
   let refresh;
   if (tabValue === '/datasets') {
     pageTitle = 'Datasets';
@@ -118,7 +59,7 @@ function HomeView({ classes, dispatch, location }: IProps) {
     <Button
       aria-label="refresh page"
       size="medium"
-      className={classes.headerButton}
+      sx={{ padding: '10px', marginLeft: '16px', height: '45px', textTransform: 'none' }}
       onClick={refresh}
       variant="outlined"
       startIcon={<Refresh />}
@@ -128,26 +69,44 @@ function HomeView({ classes, dispatch, location }: IProps) {
   );
   const pageHeader =
     tabValue === '/datasets' ? (
-      <div className={classes.title}>
-        <span className={classes.titleText}>{pageTitle}</span>
+      <Box
+        sx={{
+          display: 'flex',
+          color: 'secondary.dark',
+          fontSize: '1.5rem',
+          fontWeight: 700,
+          flex: '1 1 0',
+          paddingRight: '2em',
+        }}
+      >
+        <Box sx={{ width: '150px' }}>{pageTitle}</Box>
         {refreshButton}
         <Link to="datasets/new" data-cy="create-dataset-link">
           <Button
-            className={classes.headerButton}
+            sx={{ padding: '10px', marginLeft: '16px', height: '45px', textTransform: 'none' }}
             color="primary"
             variant="outlined"
             disableElevation
             size="medium"
           >
-            <AddCircle className={classes.buttonIcon} /> Create Dataset
+            <AddCircle sx={{ marginRight: '6px', fontSize: '1.5rem' }} /> Create Dataset
           </Button>
         </Link>
-      </div>
+      </Box>
     ) : (
-      <div className={classes.title}>
-        <span className={classes.titleText}>{pageTitle}</span>
+      <Box
+        sx={{
+          display: 'flex',
+          color: 'secondary.dark',
+          fontSize: '1.5rem',
+          fontWeight: 700,
+          flex: '1 1 0',
+          paddingRight: '2em',
+        }}
+      >
+        <Box sx={{ width: '150px' }}>{pageTitle}</Box>
         {refreshButton}
-      </div>
+      </Box>
     );
 
   useOnMount(() => {
@@ -155,8 +114,8 @@ function HomeView({ classes, dispatch, location }: IProps) {
   });
 
   return (
-    <div className={classes.pageRoot}>
-      <div className={classes.titleAndSearch}>
+    <Box sx={{ padding: '16px 24px', display: 'flex', flexDirection: 'column', height: '100%' }}>
+      <Box sx={{ display: 'flex', marginTop: '1.25em', marginBottom: '1.25em' }}>
         {pageHeader}
         {searchable && (
           <SearchTable
@@ -165,9 +124,9 @@ function HomeView({ classes, dispatch, location }: IProps) {
             clearSearchString={() => setSearchString('')}
           />
         )}
-      </div>
+      </Box>
       {tableValue}
-    </div>
+    </Box>
   );
 }
 
@@ -177,4 +136,4 @@ function mapStateToProps(state: TdrState & RouterRootState) {
   };
 }
 
-export default connect(mapStateToProps)(withStyles(styles)(HomeView));
+export default connect(mapStateToProps)(HomeView);

--- a/src/components/JobView.tsx
+++ b/src/components/JobView.tsx
@@ -41,7 +41,7 @@ function JobView({ jobs, dispatch, loading, searchString, refreshCnt }: IProps) 
       sx={{
         display: 'flex',
         justifyContent: 'center',
-        mt: '1em',
+        marginTop: '1em',
       }}
     >
       <Box sx={{ width: '100%' }}>

--- a/src/components/JobView.tsx
+++ b/src/components/JobView.tsx
@@ -5,6 +5,7 @@ import { getJobs } from 'actions/index';
 import { JobModel } from 'generated/tdr';
 import { TdrState } from 'reducers';
 import { OrderDirectionOptions } from 'reducers/query';
+import theme from 'modules/theme';
 import JobTable from './table/JobTable';
 
 interface IProps {
@@ -13,7 +14,6 @@ interface IProps {
   loading: boolean;
   searchString: string;
   refreshCnt: number;
-  userEmail: string;
 }
 
 function JobView({ jobs, dispatch, loading, searchString, refreshCnt }: IProps) {
@@ -38,7 +38,7 @@ function JobView({ jobs, dispatch, loading, searchString, refreshCnt }: IProps) 
 
   return (
     <Box sx={{ display: 'flex', justifyContent: 'center', marginTop: '1em' }}>
-      <Box sx={{ width: '100%', maxWidth: '1200px' }}>
+      <Box sx={{ ...theme.mixins.containerWidth }}>
         <Box>
           {jobs && (
             <JobTable
@@ -59,7 +59,6 @@ function mapStateToProps(state: TdrState) {
   return {
     jobs: state.jobs.jobs,
     loading: state.jobs.loading,
-    userEmail: state.user.email,
     refreshCnt: state.jobs.refreshCnt,
   };
 }

--- a/src/components/JobView.tsx
+++ b/src/components/JobView.tsx
@@ -1,74 +1,59 @@
 import React, { Dispatch } from 'react';
 import { connect } from 'react-redux';
-import { Action } from 'redux';
-import { WithStyles, withStyles } from '@mui/styles';
+import { Box } from '@mui/material';
 import { getJobs } from 'actions/index';
 import { JobModel } from 'generated/tdr';
-import { CustomTheme } from '@mui/material';
 import { TdrState } from 'reducers';
 import { OrderDirectionOptions } from 'reducers/query';
 import JobTable from './table/JobTable';
 
-const styles = (theme: CustomTheme) => ({
-  wrapper: {
-    display: 'flex',
-    justifyContent: 'center',
-    marginTop: '1em',
-  },
-  width: {
-    ...theme.mixins.containerWidth,
-  },
-});
-
-interface IProps extends WithStyles<typeof styles> {
+interface IProps {
   jobs: Array<JobModel>;
-  dispatch: Dispatch<Action>;
+  dispatch: Dispatch<any>;
   loading: boolean;
   searchString: string;
   refreshCnt: number;
   userEmail: string;
 }
 
-const JobView = withStyles(styles)(
-  ({ classes, jobs, dispatch, loading, searchString, refreshCnt }: IProps) => {
-    const handleFilterJobs = (
-      limit: number,
-      offset: number,
-      sort: string,
-      sortDirection: OrderDirectionOptions,
-      search: string,
-    ) => {
-      dispatch(
-        getJobs({
-          limit,
-          offset,
-          sort,
-          direction: sortDirection,
-          search,
-          errMessage: 'An error occured loading jobs. Please reload the page to try again.',
-        }),
-      );
-    };
-
-    return (
-      <div className={classes.wrapper}>
-        <div className={classes.width}>
-          <div>
-            {jobs && (
-              <JobTable
-                jobs={jobs}
-                handleFilterJobs={handleFilterJobs}
-                searchString={searchString}
-                loading={loading}
-                refreshCnt={refreshCnt}
-              />
-            )}
-          </div>
-        </div>
-      </div>
+function JobView({ jobs, dispatch, loading, searchString, refreshCnt }: IProps) {
+  const handleFilterJobs = (
+    limit: number,
+    offset: number,
+    sort: string,
+    sortDirection: OrderDirectionOptions,
+    search: string,
+  ) => {
+    dispatch(
+      getJobs({
+        limit,
+        offset,
+        sort,
+        direction: sortDirection,
+        search,
+        errMessage: 'An error occurred loading jobs. Please reload the page to try again.',
+      }),
     );
-  },
-);
+  };
+
+  return (
+    <Box sx={{ display: 'flex', justifyContent: 'center', marginTop: '1em' }}>
+      <Box sx={{ width: '100%', maxWidth: '1200px' }}>
+        <Box>
+          {jobs && (
+            <JobTable
+              jobs={jobs}
+              handleFilterJobs={handleFilterJobs}
+              searchString={searchString}
+              loading={loading}
+              refreshCnt={refreshCnt}
+            />
+          )}
+        </Box>
+      </Box>
+    </Box>
+  );
+}
 
 function mapStateToProps(state: TdrState) {
   return {

--- a/src/components/JobView.tsx
+++ b/src/components/JobView.tsx
@@ -7,7 +7,6 @@ import { JobModel } from 'generated/tdr';
 import { TdrState } from 'reducers';
 import { OrderDirectionOptions } from 'reducers/query';
 import JobTable from './table/JobTable';
-import Container from './common/Container';
 
 interface IProps {
   jobs: Array<JobModel>;
@@ -45,7 +44,7 @@ function JobView({ jobs, dispatch, loading, searchString, refreshCnt }: IProps) 
         mt: '1em',
       }}
     >
-      <Container>
+      <Box sx={{ width: '100%' }}>
         <Box>
           {jobs && (
             <JobTable
@@ -57,7 +56,7 @@ function JobView({ jobs, dispatch, loading, searchString, refreshCnt }: IProps) 
             />
           )}
         </Box>
-      </Container>
+      </Box>
     </Box>
   );
 }

--- a/src/components/JobView.tsx
+++ b/src/components/JobView.tsx
@@ -6,10 +6,10 @@ import { getJobs } from 'actions/index';
 import { JobModel } from 'generated/tdr';
 import { TdrState } from 'reducers';
 import { OrderDirectionOptions } from 'reducers/query';
-import { styled } from '@mui/system';
+import { CustomTheme, styled } from '@mui/material/styles';
 import JobTable from './table/JobTable';
 
-const Container = styled('div')(({ theme }) => theme.mixins.containerWidth);
+const Container = styled('div')(({ theme }: { theme: CustomTheme }) => theme.mixins.containerWidth);
 
 interface IProps {
   jobs: Array<JobModel>;

--- a/src/components/JobView.tsx
+++ b/src/components/JobView.tsx
@@ -6,8 +6,10 @@ import { getJobs } from 'actions/index';
 import { JobModel } from 'generated/tdr';
 import { TdrState } from 'reducers';
 import { OrderDirectionOptions } from 'reducers/query';
-import theme from 'modules/theme';
+import { styled } from '@mui/system';
 import JobTable from './table/JobTable';
+
+const Container = styled('div')(({ theme }) => theme.mixins.containerWidth);
 
 interface IProps {
   jobs: Array<JobModel>;
@@ -15,7 +17,6 @@ interface IProps {
   loading: boolean;
   searchString: string;
   refreshCnt: number;
-  userEmail: string;
 }
 
 function JobView({ jobs, dispatch, loading, searchString, refreshCnt }: IProps) {
@@ -46,7 +47,7 @@ function JobView({ jobs, dispatch, loading, searchString, refreshCnt }: IProps) 
         mt: '1em',
       }}
     >
-      <Box sx={{ ...theme.mixins.containerWidth }}>
+      <Container>
         <Box>
           {jobs && (
             <JobTable
@@ -58,7 +59,7 @@ function JobView({ jobs, dispatch, loading, searchString, refreshCnt }: IProps) 
             />
           )}
         </Box>
-      </Box>
+      </Container>
     </Box>
   );
 }
@@ -67,7 +68,6 @@ function mapStateToProps(state: TdrState) {
   return {
     jobs: state.jobs.jobs,
     loading: state.jobs.loading,
-    userEmail: state.user.email,
     refreshCnt: state.jobs.refreshCnt,
   };
 }

--- a/src/components/JobView.tsx
+++ b/src/components/JobView.tsx
@@ -6,11 +6,12 @@ import { JobModel } from 'generated/tdr';
 import { TdrState } from 'reducers';
 import { OrderDirectionOptions } from 'reducers/query';
 import theme from 'modules/theme';
+import { Action } from 'redux';
 import JobTable from './table/JobTable';
 
 interface IProps {
   jobs: Array<JobModel>;
-  dispatch: Dispatch<any>;
+  dispatch: Dispatch<Action>;
   loading: boolean;
   searchString: string;
   refreshCnt: number;

--- a/src/components/JobView.tsx
+++ b/src/components/JobView.tsx
@@ -6,10 +6,8 @@ import { getJobs } from 'actions/index';
 import { JobModel } from 'generated/tdr';
 import { TdrState } from 'reducers';
 import { OrderDirectionOptions } from 'reducers/query';
-import { CustomTheme, styled } from '@mui/material/styles';
 import JobTable from './table/JobTable';
-
-const Container = styled('div')(({ theme }: { theme: CustomTheme }) => theme.mixins.containerWidth);
+import Container from './common/Container';
 
 interface IProps {
   jobs: Array<JobModel>;

--- a/src/components/JobView.tsx
+++ b/src/components/JobView.tsx
@@ -18,12 +18,6 @@ const styles = (theme: CustomTheme) => ({
   width: {
     ...theme.mixins.containerWidth,
   },
-  title: {
-    color: theme.palette.primary.main,
-    fontSize: '54px',
-    lineHeight: '66px',
-    paddingBottom: theme.spacing(8),
-  },
 });
 
 interface IProps extends WithStyles<typeof styles> {

--- a/src/components/JobView.tsx
+++ b/src/components/JobView.tsx
@@ -1,12 +1,12 @@
 import React, { Dispatch } from 'react';
 import { connect } from 'react-redux';
+import { Action } from 'redux';
 import { Box } from '@mui/material';
 import { getJobs } from 'actions/index';
 import { JobModel } from 'generated/tdr';
 import { TdrState } from 'reducers';
 import { OrderDirectionOptions } from 'reducers/query';
 import theme from 'modules/theme';
-import { Action } from 'redux';
 import JobTable from './table/JobTable';
 
 interface IProps {
@@ -15,6 +15,7 @@ interface IProps {
   loading: boolean;
   searchString: string;
   refreshCnt: number;
+  userEmail: string;
 }
 
 function JobView({ jobs, dispatch, loading, searchString, refreshCnt }: IProps) {
@@ -32,13 +33,19 @@ function JobView({ jobs, dispatch, loading, searchString, refreshCnt }: IProps) 
         sort,
         direction: sortDirection,
         search,
-        errMessage: 'An error occurred loading jobs. Please reload the page to try again.',
+        errMessage: 'An error occured loading jobs. Please reload the page to try again.',
       }),
     );
   };
 
   return (
-    <Box sx={{ display: 'flex', justifyContent: 'center', marginTop: '1em' }}>
+    <Box
+      sx={{
+        display: 'flex',
+        justifyContent: 'center',
+        mt: '1em',
+      }}
+    >
       <Box sx={{ ...theme.mixins.containerWidth }}>
         <Box>
           {jobs && (
@@ -60,6 +67,7 @@ function mapStateToProps(state: TdrState) {
   return {
     jobs: state.jobs.jobs,
     loading: state.jobs.loading,
+    userEmail: state.user.email,
     refreshCnt: state.jobs.refreshCnt,
   };
 }

--- a/src/components/SnapshotView.tsx
+++ b/src/components/SnapshotView.tsx
@@ -6,8 +6,8 @@ import { SnapshotSummaryModel } from 'generated/tdr';
 import { Action } from 'redux';
 import { TdrState } from 'reducers';
 import { OrderDirectionOptions } from 'reducers/query';
-
 import theme from 'modules/theme';
+
 import SnapshotTable from './table/SnapshotTable';
 import SnapshotPopup from './snapshot/SnapshotPopup';
 import { SnapshotRoles } from '../constants';
@@ -42,6 +42,7 @@ function SnapshotView({
     sortDirection: OrderDirectionOptions,
     search: string,
   ) => {
+    // TODO: should we allow filtering on dataset id here?
     const datasetIds: string[] = [];
     dispatch(getSnapshots(limit, offset, sort, sortDirection, search, datasetIds));
   };
@@ -51,8 +52,19 @@ function SnapshotView({
   };
 
   return (
-    <Box id="snapshots" sx={{ display: 'flex', justifyContent: 'center', marginTop: '1em' }}>
-      <Box sx={{ ...theme.mixins.containerWidth }}>
+    <Box
+      id="snapshots"
+      sx={{
+        display: 'flex',
+        justifyContent: 'center',
+        marginTop: '1em',
+      }}
+    >
+      <Box
+        sx={{
+          ...theme.mixins.containerWidth,
+        }}
+      >
         <div>
           <SnapshotTable
             snapshotCount={snapshotCount}
@@ -66,8 +78,8 @@ function SnapshotView({
             refreshCnt={refreshCnt}
           />
         </div>
-        <SnapshotPopup />
       </Box>
+      <SnapshotPopup />
     </Box>
   );
 }

--- a/src/components/SnapshotView.tsx
+++ b/src/components/SnapshotView.tsx
@@ -7,6 +7,7 @@ import { Action } from 'redux';
 import { TdrState } from 'reducers';
 import { OrderDirectionOptions } from 'reducers/query';
 
+import theme from 'modules/theme';
 import SnapshotTable from './table/SnapshotTable';
 import SnapshotPopup from './snapshot/SnapshotPopup';
 import { SnapshotRoles } from '../constants';
@@ -51,8 +52,8 @@ function SnapshotView({
 
   return (
     <Box id="snapshots" sx={{ display: 'flex', justifyContent: 'center', marginTop: '1em' }}>
-      <Box sx={{ width: '100%', maxWidth: '1200px' }}>
-        <Box>
+      <Box sx={{ ...theme.mixins.containerWidth }}>
+        <div>
           <SnapshotTable
             snapshotCount={snapshotCount}
             snapshotRoleMaps={snapshotRoleMaps}
@@ -64,7 +65,7 @@ function SnapshotView({
             loading={loading}
             refreshCnt={refreshCnt}
           />
-        </Box>
+        </div>
         <SnapshotPopup />
       </Box>
     </Box>

--- a/src/components/SnapshotView.tsx
+++ b/src/components/SnapshotView.tsx
@@ -9,7 +9,6 @@ import { OrderDirectionOptions } from 'reducers/query';
 import SnapshotTable from './table/SnapshotTable';
 import SnapshotPopup from './snapshot/SnapshotPopup';
 import { SnapshotRoles } from '../constants';
-import Container from './common/Container';
 
 interface IProps {
   snapshots: Array<SnapshotSummaryModel>;
@@ -59,7 +58,7 @@ function SnapshotView({
         marginTop: '1em',
       }}
     >
-      <Container>
+      <Box sx={{ width: '100%' }}>
         <div>
           <SnapshotTable
             snapshotCount={snapshotCount}
@@ -73,7 +72,7 @@ function SnapshotView({
             refreshCnt={refreshCnt}
           />
         </div>
-      </Container>
+      </Box>
       <SnapshotPopup />
     </Box>
   );

--- a/src/components/SnapshotView.tsx
+++ b/src/components/SnapshotView.tsx
@@ -1,7 +1,6 @@
 import React, { Dispatch } from 'react';
 import { connect } from 'react-redux';
-import { WithStyles, withStyles } from '@mui/styles';
-import { CustomTheme } from '@mui/material';
+import { Box } from '@mui/material';
 import { addSnapshotPolicyMember, getSnapshots } from 'actions/index';
 import { SnapshotSummaryModel } from 'generated/tdr';
 import { Action } from 'redux';
@@ -12,18 +11,7 @@ import SnapshotTable from './table/SnapshotTable';
 import SnapshotPopup from './snapshot/SnapshotPopup';
 import { SnapshotRoles } from '../constants';
 
-const styles = (theme: CustomTheme) => ({
-  wrapper: {
-    display: 'flex',
-    justifyContent: 'center',
-    marginTop: '1em',
-  },
-  width: {
-    ...theme.mixins.containerWidth,
-  },
-});
-
-interface IProps extends WithStyles<typeof styles> {
+interface IProps {
   snapshots: Array<SnapshotSummaryModel>;
   snapshotRoleMaps: { [key: string]: Array<string> };
   snapshotCount: number;
@@ -35,57 +23,53 @@ interface IProps extends WithStyles<typeof styles> {
   userEmail: string;
 }
 
-const SnapshotView = withStyles(styles)(
-  ({
-    classes,
-    snapshots,
-    snapshotRoleMaps,
-    snapshotCount,
-    dispatch,
-    filteredSnapshotCount,
-    loading,
-    searchString,
-    refreshCnt,
-    userEmail,
-  }: IProps) => {
-    const handleFilterSnapshots = (
-      limit: number,
-      offset: number,
-      sort: string,
-      sortDirection: OrderDirectionOptions,
-      search: string,
-    ) => {
-      // TODO: should we allow filtering on dataset id here?
-      const datasetIds: string[] = [];
-      dispatch(getSnapshots(limit, offset, sort, sortDirection, search, datasetIds));
-    };
+function SnapshotView({
+  snapshots,
+  snapshotRoleMaps,
+  snapshotCount,
+  dispatch,
+  filteredSnapshotCount,
+  loading,
+  searchString,
+  refreshCnt,
+  userEmail,
+}: IProps) {
+  const handleFilterSnapshots = (
+    limit: number,
+    offset: number,
+    sort: string,
+    sortDirection: OrderDirectionOptions,
+    search: string,
+  ) => {
+    const datasetIds: string[] = [];
+    dispatch(getSnapshots(limit, offset, sort, sortDirection, search, datasetIds));
+  };
 
-    const handleMakeSteward = (snapshotID: string) => {
-      dispatch(addSnapshotPolicyMember(snapshotID, userEmail, SnapshotRoles.STEWARD));
-    };
+  const handleMakeSteward = (snapshotID: string) => {
+    dispatch(addSnapshotPolicyMember(snapshotID, userEmail, SnapshotRoles.STEWARD));
+  };
 
-    return (
-      <div id="snapshots" className={classes.wrapper}>
-        <div className={classes.width}>
-          <div>
-            <SnapshotTable
-              snapshotCount={snapshotCount}
-              snapshotRoleMaps={snapshotRoleMaps}
-              filteredSnapshotCount={filteredSnapshotCount}
-              snapshots={snapshots}
-              handleFilterSnapshots={handleFilterSnapshots}
-              handleMakeSteward={handleMakeSteward}
-              searchString={searchString}
-              loading={loading}
-              refreshCnt={refreshCnt}
-            />
-          </div>
-        </div>
+  return (
+    <Box id="snapshots" sx={{ display: 'flex', justifyContent: 'center', marginTop: '1em' }}>
+      <Box sx={{ width: '100%', maxWidth: '1200px' }}>
+        <Box>
+          <SnapshotTable
+            snapshotCount={snapshotCount}
+            snapshotRoleMaps={snapshotRoleMaps}
+            filteredSnapshotCount={filteredSnapshotCount}
+            snapshots={snapshots}
+            handleFilterSnapshots={handleFilterSnapshots}
+            handleMakeSteward={handleMakeSteward}
+            searchString={searchString}
+            loading={loading}
+            refreshCnt={refreshCnt}
+          />
+        </Box>
         <SnapshotPopup />
-      </div>
-    );
-  },
-);
+      </Box>
+    </Box>
+  );
+}
 
 function mapStateToProps(state: TdrState) {
   return {

--- a/src/components/SnapshotView.tsx
+++ b/src/components/SnapshotView.tsx
@@ -6,11 +6,12 @@ import { SnapshotSummaryModel } from 'generated/tdr';
 import { Action } from 'redux';
 import { TdrState } from 'reducers';
 import { OrderDirectionOptions } from 'reducers/query';
-import theme from 'modules/theme';
-
+import { styled } from '@mui/system';
 import SnapshotTable from './table/SnapshotTable';
 import SnapshotPopup from './snapshot/SnapshotPopup';
 import { SnapshotRoles } from '../constants';
+
+const Container = styled('div')(({ theme }) => theme.mixins.containerWidth);
 
 interface IProps {
   snapshots: Array<SnapshotSummaryModel>;
@@ -60,11 +61,7 @@ function SnapshotView({
         marginTop: '1em',
       }}
     >
-      <Box
-        sx={{
-          ...theme.mixins.containerWidth,
-        }}
-      >
+      <Container>
         <div>
           <SnapshotTable
             snapshotCount={snapshotCount}
@@ -78,7 +75,7 @@ function SnapshotView({
             refreshCnt={refreshCnt}
           />
         </div>
-      </Box>
+      </Container>
       <SnapshotPopup />
     </Box>
   );

--- a/src/components/SnapshotView.tsx
+++ b/src/components/SnapshotView.tsx
@@ -6,12 +6,10 @@ import { SnapshotSummaryModel } from 'generated/tdr';
 import { Action } from 'redux';
 import { TdrState } from 'reducers';
 import { OrderDirectionOptions } from 'reducers/query';
-import { CustomTheme, styled } from '@mui/material/styles';
 import SnapshotTable from './table/SnapshotTable';
 import SnapshotPopup from './snapshot/SnapshotPopup';
 import { SnapshotRoles } from '../constants';
-
-const Container = styled('div')(({ theme }: { theme: CustomTheme }) => theme.mixins.containerWidth);
+import Container from './common/Container';
 
 interface IProps {
   snapshots: Array<SnapshotSummaryModel>;

--- a/src/components/SnapshotView.tsx
+++ b/src/components/SnapshotView.tsx
@@ -21,12 +21,6 @@ const styles = (theme: CustomTheme) => ({
   width: {
     ...theme.mixins.containerWidth,
   },
-  title: {
-    color: theme.palette.primary.main,
-    fontSize: 54,
-    lineHeight: '66px',
-    paddingBottom: theme.spacing(8),
-  },
 });
 
 interface IProps extends WithStyles<typeof styles> {

--- a/src/components/SnapshotView.tsx
+++ b/src/components/SnapshotView.tsx
@@ -6,12 +6,12 @@ import { SnapshotSummaryModel } from 'generated/tdr';
 import { Action } from 'redux';
 import { TdrState } from 'reducers';
 import { OrderDirectionOptions } from 'reducers/query';
-import { styled } from '@mui/system';
+import { CustomTheme, styled } from '@mui/material/styles';
 import SnapshotTable from './table/SnapshotTable';
 import SnapshotPopup from './snapshot/SnapshotPopup';
 import { SnapshotRoles } from '../constants';
 
-const Container = styled('div')(({ theme }) => theme.mixins.containerWidth);
+const Container = styled('div')(({ theme }: { theme: CustomTheme }) => theme.mixins.containerWidth);
 
 interface IProps {
   snapshots: Array<SnapshotSummaryModel>;

--- a/src/components/UserList.tsx
+++ b/src/components/UserList.tsx
@@ -27,14 +27,14 @@ function UserList({ canManageUsers, defaultOpen, removeUser, typeOfUsers, users 
       >
         {typeOfUsers}
       </AccordionSummary>
-      <AccordionDetails data-cy="user-email" sx={canManageUsers ? { pt: 0 } : undefined}>
+      <AccordionDetails data-cy="user-email" sx={canManageUsers ? { paddingTop: 0 } : undefined}>
         <ManageUsersView removeUser={canManageUsers ? removeUser : undefined} users={users} />
         {users.length === 0 && (
           <Typography
             sx={{
               fontStyle: 'italic',
               color: 'error.contrastText',
-              pb: '8px',
+              paddingBottom: '8px',
             }}
           >
             (None)

--- a/src/components/UserList.tsx
+++ b/src/components/UserList.tsx
@@ -1,34 +1,10 @@
 import React from 'react';
 import clsx from 'clsx';
-import { createStyles, WithStyles, withStyles } from '@mui/styles';
-import { Accordion, AccordionDetails, AccordionSummary, CustomTheme } from '@mui/material';
+import { Box, Accordion, AccordionDetails, AccordionSummary, Typography } from '@mui/material';
 import { ExpandMore } from '@mui/icons-material';
-import Typography from '@mui/material/Typography';
 import ManageUsersView from './ManageUsersView';
 
-const styles = (theme: CustomTheme) =>
-  createStyles({
-    header: {
-      fontSize: '14px',
-      lineHeight: '22px',
-      fontWeight: '600',
-      color: theme.palette.primary.main,
-    },
-    expandIcon: {
-      color: theme.palette.primary.main,
-    },
-    canManageUsers: {
-      paddingTop: 0,
-    },
-    noUsers: {
-      fontStyle: 'italic',
-      colorPrimary: theme.palette.error.contrastText,
-      color: theme.palette.error.contrastText,
-      paddingBottom: theme.spacing(1),
-    },
-  });
-
-interface UserListProps extends WithStyles<typeof styles> {
+interface UserListProps {
   canManageUsers: boolean;
   defaultOpen?: boolean;
   removeUser?: (removableEmail: string) => void;
@@ -36,34 +12,42 @@ interface UserListProps extends WithStyles<typeof styles> {
   users: Array<string>;
 }
 
-function UserList({
-  classes,
-  canManageUsers,
-  defaultOpen,
-  removeUser,
-  typeOfUsers,
-  users,
-}: UserListProps) {
+function UserList({ canManageUsers, defaultOpen, removeUser, typeOfUsers, users }: UserListProps) {
   return (
     <Accordion defaultExpanded={defaultOpen}>
       <AccordionSummary
-        expandIcon={<ExpandMore className={classes.expandIcon} />}
-        className={classes.header}
+        expandIcon={<ExpandMore sx={{ color: 'primary.main' }} />}
+        sx={{
+          fontSize: '14px',
+          lineHeight: '22px',
+          fontWeight: '600',
+          color: 'primary.main',
+        }}
         data-cy={`user-list-${typeOfUsers}`}
       >
         {typeOfUsers}
       </AccordionSummary>
       <AccordionDetails
         data-cy="user-email"
-        className={clsx({
-          [classes.canManageUsers]: canManageUsers,
-        })}
+        sx={{
+          paddingTop: canManageUsers ? 0 : undefined,
+        }}
       >
         <ManageUsersView removeUser={canManageUsers ? removeUser : undefined} users={users} />
-        {users.length === 0 && <Typography className={classes.noUsers}>(None)</Typography>}
+        {users.length === 0 && (
+          <Typography
+            sx={{
+              fontStyle: 'italic',
+              color: 'error.contrastText',
+              paddingBottom: '8px',
+            }}
+          >
+            (None)
+          </Typography>
+        )}
       </AccordionDetails>
     </Accordion>
   );
 }
 
-export default withStyles(styles)(UserList);
+export default UserList;

--- a/src/components/UserList.tsx
+++ b/src/components/UserList.tsx
@@ -20,12 +20,6 @@ const styles = (theme: CustomTheme) =>
     canManageUsers: {
       paddingTop: 0,
     },
-    values: {
-      paddingBottom: theme.spacing(1),
-    },
-    root: {
-      marginTop: theme.spacing(3),
-    },
     noUsers: {
       fontStyle: 'italic',
       colorPrimary: theme.palette.error.contrastText,

--- a/src/components/UserList.tsx
+++ b/src/components/UserList.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import clsx from 'clsx';
-import { Box, Accordion, AccordionDetails, AccordionSummary, Typography } from '@mui/material';
+import { Accordion, AccordionDetails, AccordionSummary, Box } from '@mui/material';
 import { ExpandMore } from '@mui/icons-material';
+import Typography from '@mui/material/Typography';
 import ManageUsersView from './ManageUsersView';
 
 interface UserListProps {
@@ -27,19 +27,14 @@ function UserList({ canManageUsers, defaultOpen, removeUser, typeOfUsers, users 
       >
         {typeOfUsers}
       </AccordionSummary>
-      <AccordionDetails
-        data-cy="user-email"
-        sx={{
-          paddingTop: canManageUsers ? 0 : undefined,
-        }}
-      >
+      <AccordionDetails data-cy="user-email" sx={canManageUsers ? { pt: 0 } : undefined}>
         <ManageUsersView removeUser={canManageUsers ? removeUser : undefined} users={users} />
         {users.length === 0 && (
           <Typography
             sx={{
               fontStyle: 'italic',
               color: 'error.contrastText',
-              paddingBottom: '8px',
+              pb: '8px',
             }}
           >
             (None)

--- a/src/components/common/Container.tsx
+++ b/src/components/common/Container.tsx
@@ -1,4 +1,0 @@
-import { styled, CustomTheme } from '@mui/material/styles';
-
-const Container = styled('div')(({ theme }: { theme: CustomTheme }) => theme.mixins.containerWidth);
-export default Container;

--- a/src/components/common/Container.tsx
+++ b/src/components/common/Container.tsx
@@ -1,0 +1,4 @@
+import { styled, CustomTheme } from '@mui/material/styles';
+
+const Container = styled('div')(({ theme }: { theme: CustomTheme }) => theme.mixins.containerWidth);
+export default Container;

--- a/src/components/dataset/DatasetAccess.tsx
+++ b/src/components/dataset/DatasetAccess.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { CustomTheme, Grid } from '@mui/material';
-import { createStyles, WithStyles, withStyles } from '@mui/styles';
+import { Grid } from '@mui/material';
 import { TdrState } from 'reducers';
 import { DatasetModel, PolicyModel } from 'generated/tdr';
 import { Action, Dispatch } from 'redux';
@@ -11,18 +10,7 @@ import { getRoleMembersFromPolicies } from '../../libs/utils';
 import { addDatasetPolicyMember, removeDatasetPolicyMember } from '../../actions';
 import AddUserAccess, { AccessPermission } from '../common/AddUserAccess';
 
-const styles = (theme: CustomTheme) =>
-  createStyles({
-    helpContainer: {
-      padding: '30px 0 10px',
-    },
-    genericLink: {
-      color: theme.palette.primary.main,
-      textDecoration: 'underline',
-    },
-  });
-
-interface DatasetAccessProps extends WithStyles<typeof styles> {
+interface DatasetAccessProps {
   dataset: DatasetModel;
   dispatch: Dispatch<Action>;
   policies: Array<PolicyModel>;
@@ -101,4 +89,4 @@ function mapStateToProps(state: TdrState) {
   };
 }
 
-export default connect(mapStateToProps)(withStyles(styles)(DatasetAccess));
+export default connect(mapStateToProps)(DatasetAccess);

--- a/src/components/dataset/overview/DatasetOverview.jsx
+++ b/src/components/dataset/overview/DatasetOverview.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Box, Typography } from '@mui/material';
-import { styled } from '@mui/material/styles';
+import { styled } from '@mui/system';
 import { getDatasetById, getDatasetPolicy, getUserDatasetRoles } from 'actions';
 import SnapshotPopup from 'components/snapshot/SnapshotPopup';
 import DatasetRelationshipsPanel from '../../common/overview/SchemaPanel';
@@ -31,12 +31,6 @@ const MainColumn = styled(Box)({
   display: 'flex',
   flexDirection: 'column',
   marginLeft: 40,
-});
-
-const SnapshotGrid = styled(Box)({
-  display: 'grid',
-  gridTemplateColumns: 'repeat(auto-fill, minmax(360px, 32%))',
-  gridGap: '1rem',
 });
 
 function DatasetOverview(props) {
@@ -91,7 +85,6 @@ function DatasetOverview(props) {
 }
 
 DatasetOverview.propTypes = {
-  classes: PropTypes.object,
   dataset: PropTypes.object,
   datasetByIdLoading: PropTypes.bool,
   datasetPolicies: PropTypes.array,

--- a/src/components/dataset/overview/DatasetOverview.jsx
+++ b/src/components/dataset/overview/DatasetOverview.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { withStyles } from '@mui/styles';
+import { Box, Typography } from '@mui/material';
 import { getDatasetById, getDatasetPolicy, getUserDatasetRoles } from 'actions';
-import { Typography } from '@mui/material';
 import SnapshotPopup from 'components/snapshot/SnapshotPopup';
+import theme from 'modules/theme';
 import DatasetRelationshipsPanel from '../../common/overview/SchemaPanel';
 import { useOnMount } from '../../../libs/utils';
 import { BreadcrumbType, DatasetIncludeOptions } from '../../../constants';
@@ -12,32 +12,8 @@ import LoadingSpinner from '../../common/LoadingSpinner';
 import DatasetOverviewPanel from './DatasetOverviewPanel';
 import AppBreadcrumbs from '../../AppBreadcrumbs/AppBreadcrumbs';
 
-const styles = (theme) => ({
-  pageRoot: { ...theme.mixins.pageRoot },
-  pageTitle: { ...theme.mixins.pageTitle },
-  root: {
-    // TODO: expect this to change as more components are added
-    height: '100%',
-    display: 'grid',
-    gridTemplateColumns: '1fr 3fr',
-    flex: 1,
-  },
-  infoColumn: {
-    display: 'flex',
-    flexDirection: 'column',
-  },
-  infoColumnPanel: {
-    flexGrow: 1,
-  },
-  mainColumn: {
-    display: 'flex',
-    flexDirection: 'column',
-    marginLeft: 40,
-  },
-});
-
 function DatasetOverview(props) {
-  const { classes, dataset, datasetPolicies, datasetByIdLoading, dispatch, match } = props;
+  const { dataset, datasetPolicies, datasetByIdLoading, dispatch, match } = props;
   const datasetId = match.params.uuid;
   useOnMount(() => {
     dispatch(
@@ -60,37 +36,36 @@ function DatasetOverview(props) {
     return <LoadingSpinner />;
   }
   return datasetPolicies && dataset && dataset.schema && dataset.id === datasetId ? (
-    <div className={classes.pageRoot}>
+    <Box sx={{ ...theme.mixins.pageRoot }}>
       <AppBreadcrumbs
         context={{ type: BreadcrumbType.DATASET, id: datasetId, name: dataset.name }}
         childBreadcrumbs={[]}
       />
-      <Typography variant="h3" className={classes.pageTitle}>
+      <Typography variant="h3" sx={{ ...theme.mixins.pageTitle }}>
         {dataset.name}
       </Typography>
-      <div className={classes.root}>
-        <div className={classes.infoColumn}>
-          <div className={classes.infoColumnPanel}>
+      <Box sx={{ height: '100%', display: 'grid', gridTemplateColumns: '1fr 3fr', flex: 1 }}>
+        <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+          <Box sx={{ flexGrow: 1 }}>
             <DatasetRelationshipsPanel
               tables={dataset.schema.tables}
               resourceType="Dataset"
               resourceId={dataset.id}
             />
-          </div>
-        </div>
-        <div className={classes.mainColumn}>
+          </Box>
+        </Box>
+        <Box sx={{ display: 'flex', flexDirection: 'column', marginLeft: '40px' }}>
           <DatasetOverviewPanel dataset={dataset} />
-        </div>
-      </div>
+        </Box>
+      </Box>
       <SnapshotPopup />
-    </div>
+    </Box>
   ) : (
-    <div />
+    <Box />
   );
 }
 
 DatasetOverview.propTypes = {
-  classes: PropTypes.object,
   dataset: PropTypes.object,
   datasetByIdLoading: PropTypes.bool,
   datasetPolicies: PropTypes.array,
@@ -108,4 +83,4 @@ const mapStateToProps = ({
   dispatch,
 });
 
-export default connect(mapStateToProps)(withStyles(styles)(DatasetOverview));
+export default connect(mapStateToProps)(DatasetOverview);

--- a/src/components/dataset/overview/DatasetOverview.jsx
+++ b/src/components/dataset/overview/DatasetOverview.jsx
@@ -22,10 +22,6 @@ const styles = (theme) => ({
     gridTemplateColumns: '1fr 3fr',
     flex: 1,
   },
-  headerText: {
-    textTransform: 'uppercase',
-    marginBottom: '0.5rem',
-  },
   infoColumn: {
     display: 'flex',
     flexDirection: 'column',
@@ -37,18 +33,6 @@ const styles = (theme) => ({
     display: 'flex',
     flexDirection: 'column',
     marginLeft: 40,
-  },
-  snapshotsArea: {
-    flexGrow: 1,
-    marginTop: '1.5rem',
-  },
-  spacer: {
-    height: '4rem',
-  },
-  snapshotCardsContainer: {
-    display: 'grid',
-    gridTemplateColumns: 'repeat(auto-fill, minmax(360px, 32%))',
-    gridGap: '1rem',
   },
 });
 

--- a/src/components/dataset/overview/DatasetOverview.jsx
+++ b/src/components/dataset/overview/DatasetOverview.jsx
@@ -2,15 +2,42 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Box, Typography } from '@mui/material';
+import { styled } from '@mui/material/styles';
 import { getDatasetById, getDatasetPolicy, getUserDatasetRoles } from 'actions';
 import SnapshotPopup from 'components/snapshot/SnapshotPopup';
-import theme from 'modules/theme';
 import DatasetRelationshipsPanel from '../../common/overview/SchemaPanel';
 import { useOnMount } from '../../../libs/utils';
 import { BreadcrumbType, DatasetIncludeOptions } from '../../../constants';
 import LoadingSpinner from '../../common/LoadingSpinner';
 import DatasetOverviewPanel from './DatasetOverviewPanel';
 import AppBreadcrumbs from '../../AppBreadcrumbs/AppBreadcrumbs';
+
+const Root = styled(Box)(({ theme }) => ({
+  ...theme.mixins.pageRoot,
+}));
+
+const PageTitle = styled(Typography)(({ theme }) => ({
+  ...theme.mixins.pageTitle,
+}));
+
+const ContentContainer = styled(Box)({
+  height: '100%',
+  display: 'grid',
+  gridTemplateColumns: '1fr 3fr',
+  flex: 1,
+});
+
+const MainColumn = styled(Box)({
+  display: 'flex',
+  flexDirection: 'column',
+  marginLeft: 40,
+});
+
+const SnapshotGrid = styled(Box)({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fill, minmax(360px, 32%))',
+  gridGap: '1rem',
+});
 
 function DatasetOverview(props) {
   const { dataset, datasetPolicies, datasetByIdLoading, dispatch, match } = props;
@@ -36,15 +63,13 @@ function DatasetOverview(props) {
     return <LoadingSpinner />;
   }
   return datasetPolicies && dataset && dataset.schema && dataset.id === datasetId ? (
-    <Box sx={{ ...theme.mixins.pageRoot }}>
+    <Root>
       <AppBreadcrumbs
         context={{ type: BreadcrumbType.DATASET, id: datasetId, name: dataset.name }}
         childBreadcrumbs={[]}
       />
-      <Typography variant="h3" sx={{ ...theme.mixins.pageTitle }}>
-        {dataset.name}
-      </Typography>
-      <Box sx={{ height: '100%', display: 'grid', gridTemplateColumns: '1fr 3fr', flex: 1 }}>
+      <PageTitle variant="h3">{dataset.name}</PageTitle>
+      <ContentContainer>
         <Box sx={{ display: 'flex', flexDirection: 'column' }}>
           <Box sx={{ flexGrow: 1 }}>
             <DatasetRelationshipsPanel
@@ -54,18 +79,19 @@ function DatasetOverview(props) {
             />
           </Box>
         </Box>
-        <Box sx={{ display: 'flex', flexDirection: 'column', marginLeft: '40px' }}>
+        <MainColumn>
           <DatasetOverviewPanel dataset={dataset} />
-        </Box>
-      </Box>
+        </MainColumn>
+      </ContentContainer>
       <SnapshotPopup />
-    </Box>
+    </Root>
   ) : (
     <Box />
   );
 }
 
 DatasetOverview.propTypes = {
+  classes: PropTypes.object,
   dataset: PropTypes.object,
   datasetByIdLoading: PropTypes.bool,
   datasetPolicies: PropTypes.array,

--- a/src/components/dataset/overview/DatasetOverview.jsx
+++ b/src/components/dataset/overview/DatasetOverview.jsx
@@ -34,7 +34,7 @@ const ContentContainer = styled(Box)({
 const MainColumn = styled(Box)({
   display: 'flex',
   flexDirection: 'column',
-  marginLeft: 40,
+  marginLeft: '40px',
 });
 
 function DatasetOverview(props) {

--- a/src/components/dataset/overview/DatasetOverview.jsx
+++ b/src/components/dataset/overview/DatasetOverview.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Box, Typography } from '@mui/material';
-import { styled } from '@mui/system';
+import { styled } from '@mui/material/styles';
 import { getDatasetById, getDatasetPolicy, getUserDatasetRoles } from 'actions';
 import SnapshotPopup from 'components/snapshot/SnapshotPopup';
 import DatasetRelationshipsPanel from '../../common/overview/SchemaPanel';
@@ -12,6 +12,10 @@ import LoadingSpinner from '../../common/LoadingSpinner';
 import DatasetOverviewPanel from './DatasetOverviewPanel';
 import AppBreadcrumbs from '../../AppBreadcrumbs/AppBreadcrumbs';
 
+// When we switch to Typescript, we can use the following type definition to
+// fix the unresolved variable warning
+// import { CustomTheme, styled } from '@mui/material/styles';
+// const Root = styled(Box)(({ theme }: { theme: CustomTheme }) => ({
 const Root = styled(Box)(({ theme }) => ({
   ...theme.mixins.pageRoot,
 }));

--- a/src/components/dataset/overview/DatasetOverviewPanel.jsx
+++ b/src/components/dataset/overview/DatasetOverviewPanel.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import {
+  Box,
+  Typography,
   Accordion,
   AccordionDetails,
   AccordionSummary,
@@ -9,14 +12,11 @@ import {
   Grid,
   Tab,
   Tabs,
-  Typography,
+  IconButton,
 } from '@mui/material';
-import { withStyles } from '@mui/styles';
 import { ExpandMore, Close } from '@mui/icons-material';
-import IconButton from '@mui/material/IconButton';
-import { connect } from 'react-redux';
+import theme from 'modules/theme';
 import moment from 'moment';
-import clsx from 'clsx';
 import { patchDataset } from 'actions';
 import GoogleSheetExport from 'components/common/overview/GoogleSheetExport';
 import { IamResourceTypeEnum, CloudPlatform } from 'generated/tdr';
@@ -33,74 +33,6 @@ import TabPanel from '../../common/TabPanel';
 import { DatasetRoles } from '../../../constants';
 import JournalEntriesView from '../../JournalEntriesView';
 import { getCloudPlatform } from '../../../libs/utilsTs';
-
-const styles = (theme) => ({
-  root: {
-    flexGrow: 1,
-  },
-  helpOverlayCloseButton: {
-    color: theme.palette.common.link,
-  },
-  drawer: {
-    top: '112px',
-    bottom: '0px',
-    flexShrink: 0,
-    height: 'initial',
-    zIndex: 10,
-    minWidth: 300,
-    width: '40%',
-  },
-  helpText: {
-    padding: 30,
-  },
-  drawerPosition: {
-    position: 'absolute',
-  },
-  drawerOpen: (props) => ({
-    width: props.width,
-    transition: theme.transitions.create('width', {
-      easing: theme.transitions.easing.sharp,
-      duration: theme.transitions.duration.enteringScreen,
-    }),
-  }),
-  drawerClose: {
-    transition: theme.transitions.create('width', {
-      easing: theme.transitions.easing.sharp,
-      duration: theme.transitions.duration.leavingScreen,
-    }),
-    overflowX: 'hidden',
-    width: 0,
-    minWidth: 0,
-    [theme.breakpoints.up('sm')]: {
-      width: 0,
-    },
-  },
-  header: {
-    fontSize: '14px',
-    lineHeight: '22px',
-    fontWeight: '600',
-    color: theme.palette.primary.main,
-  },
-  expandIcon: {
-    color: theme.palette.primary.main,
-  },
-  noRelationships: {
-    fontStyle: 'italic',
-    colorPrimary: theme.palette.error.contrastText,
-    color: theme.palette.error.contrastText,
-  },
-  divider: {
-    marginTop: '14px',
-    marginBottom: '14px',
-  },
-  fullViewButton: {
-    marginLeft: theme.spacing(2),
-  },
-  fullViewText: {
-    paddingBottom: '14px',
-  },
-});
-
 function a11yProps(index) {
   return {
     id: `simple-tab-${index}`,
@@ -113,7 +45,7 @@ function DatasetOverviewPanel(props) {
   const [isHelpVisible, setIsHelpVisible] = React.useState(false);
   const [helpTitle, setHelpTitle] = React.useState();
   const [helpContent, setHelpContent] = React.useState();
-  const { classes, dataset, dispatch, pendingSave, userRoles } = props;
+  const { dataset, dispatch, pendingSave, userRoles } = props;
   const linkToBq = dataset.accessInformation?.bigQuery !== undefined;
 
   const isSteward = userRoles.includes(DatasetRoles.STEWARD);
@@ -136,7 +68,7 @@ function DatasetOverviewPanel(props) {
   };
 
   return (
-    <div className={classes.root}>
+    <Box sx={{ flexGrow: 1 }}>
       <Tabs value={value} onChange={handleChange}>
         <Tab label="Dataset Summary" disableFocusRipple disableRipple {...a11yProps(0)} />
         <Tab label="Snapshots" disableFocusRipple disableRipple {...a11yProps(1)} />
@@ -231,17 +163,24 @@ function DatasetOverviewPanel(props) {
             <Grid item xs={8}>
               <Accordion defaultExpanded={false}>
                 <AccordionSummary
-                  expandIcon={<ExpandMore className={classes.expandIcon} />}
-                  className={classes.header}
+                  expandIcon={<ExpandMore sx={{ color: 'primary.main' }} />}
+                  sx={{
+                    fontSize: '14px',
+                    lineHeight: '22px',
+                    fontWeight: '600',
+                    color: 'primary.main',
+                  }}
                 >
                   Relationships ({dataset.schema.relationships.length ?? 0})
                 </AccordionSummary>
                 <AccordionDetails data-cy="relationship">
                   {dataset.schema.relationships.length === 0 && (
-                    <Typography className={classes.noRelationships}>(None)</Typography>
+                    <Typography sx={{ fontStyle: 'italic', color: 'error.contrastText' }}>
+                      (None)
+                    </Typography>
                   )}
                   {dataset.schema.relationships.map((rel, i) => (
-                    <div key={rel.name}>
+                    <Box key={rel.name}>
                       <Typography variant="h6">{rel.name}</Typography>
                       <dl>
                         <dt>
@@ -259,9 +198,9 @@ function DatasetOverviewPanel(props) {
                         </dt>
                       </dl>
                       {i < dataset.schema.relationships.length - 1 && (
-                        <Divider className={classes.divider} />
+                        <Divider sx={{ marginTop: '14px', marginBottom: '14px' }} />
                       )}
-                    </div>
+                    </Box>
                   ))}
                 </AccordionDetails>
               </Accordion>
@@ -309,24 +248,43 @@ function DatasetOverviewPanel(props) {
       <Drawer
         variant="permanent"
         anchor="right"
-        className={clsx(classes.drawer, {
-          [classes.drawerOpen]: isHelpVisible,
-          [classes.drawerClose]: !isHelpVisible,
-        })}
-        classes={{
-          paper: clsx(classes.drawer, classes.drawerPosition, {
-            [classes.drawerOpen]: isHelpVisible,
-            [classes.drawerClose]: !isHelpVisible,
-          }),
+        className={isHelpVisible ? 'drawerOpen' : 'drawerClose'}
+        sx={{
+          top: '112px',
+          bottom: '0px',
+          flexShrink: 0,
+          height: 'initial',
+          zIndex: 10,
+          minWidth: 300,
+          width: '40%',
+          position: 'absolute',
+          transition: () =>
+            theme.transitions.create('width', {
+              easing: theme.transitions.easing.sharp,
+              duration: theme.transitions.duration.enteringScreen,
+            }),
+          '&.drawerClose': {
+            transition: () =>
+              theme.transitions.create('width', {
+                easing: theme.transitions.easing.sharp,
+                duration: theme.transitions.duration.leavingScreen,
+              }),
+            overflowX: 'hidden',
+            width: '0px',
+            minWidth: '0px',
+            [theme.breakpoints.up('sm')]: {
+              width: '0px',
+            },
+          },
         }}
         open={isHelpVisible}
       >
-        <Grid key="help-drawer" container spacing={1} className={classes.helpText}>
+        <Grid key="help-drawer" container spacing={1} sx={{ padding: '30px' }}>
           <Grid item xs={11}>
             {helpTitle}
           </Grid>
           <Grid item xs={1}>
-            <IconButton className={classes.helpOverlayCloseButton} onClick={closeHelpOverlay}>
+            <IconButton sx={{ color: 'common.link' }} onClick={closeHelpOverlay}>
               <Close />
             </IconButton>
           </Grid>
@@ -335,12 +293,11 @@ function DatasetOverviewPanel(props) {
           </Grid>
         </Grid>
       </Drawer>
-    </div>
+    </Box>
   );
 }
 
 DatasetOverviewPanel.propTypes = {
-  classes: PropTypes.object,
   dataset: PropTypes.object,
   dispatch: PropTypes.func.isRequired,
   pendingSave: PropTypes.object,
@@ -356,4 +313,4 @@ function mapStateToProps(state) {
   };
 }
 
-export default connect(mapStateToProps)(withStyles(styles)(DatasetOverviewPanel));
+export default connect(mapStateToProps)(DatasetOverviewPanel);

--- a/src/components/dataset/overview/DatasetOverviewPanel.jsx
+++ b/src/components/dataset/overview/DatasetOverviewPanel.jsx
@@ -236,7 +236,7 @@ function DatasetOverviewPanel(props) {
                         </dt>
                       </dl>
                       {i < dataset.schema.relationships.length - 1 && (
-                        <Divider sx={{ mt: '14px', mb: '14px' }} />
+                        <Divider sx={{ marginTop: '14px', marginBottom: '14px' }} />
                       )}
                     </div>
                   ))}
@@ -247,9 +247,9 @@ function DatasetOverviewPanel(props) {
         </Grid>
       </TabPanel>
       <TabPanel value={value} index={1}>
-        <Grid sx={{ pb: '14px' }}>
+        <Grid sx={{ paddingBottom: '14px' }}>
           Use the dataset as is to create a full view snapshot
-          <Box component="span" sx={{ ml: 2 }}>
+          <Box component="span" sx={{ marginLeft: 2 }}>
             <FullViewSnapshotButton dataset={dataset} dispatch={dispatch} />
           </Box>
         </Grid>
@@ -289,7 +289,7 @@ function DatasetOverviewPanel(props) {
         open={isHelpVisible}
         isVisible={isHelpVisible}
       >
-        <Grid container spacing={1} sx={{ p: '30px' }}>
+        <Grid container spacing={1} sx={{ padding: '30px' }}>
           <Grid item xs={11}>
             {helpTitle}
           </Grid>

--- a/src/components/dataset/overview/DatasetOverviewPanel.jsx
+++ b/src/components/dataset/overview/DatasetOverviewPanel.jsx
@@ -247,9 +247,9 @@ function DatasetOverviewPanel(props) {
         </Grid>
       </TabPanel>
       <TabPanel value={value} index={1}>
-        <Grid sx={{ paddingBottom: '14px' }}>
+        <Grid sx={{ pb: '14px' }}>
           Use the dataset as is to create a full view snapshot
-          <Box sx={{ marginLeft: 2 }}>
+          <Box component="span" sx={{ ml: 2 }}>
             <FullViewSnapshotButton dataset={dataset} dispatch={dispatch} />
           </Box>
         </Grid>

--- a/src/components/dataset/overview/DatasetOverviewPanel.jsx
+++ b/src/components/dataset/overview/DatasetOverviewPanel.jsx
@@ -33,6 +33,7 @@ import TabPanel from '../../common/TabPanel';
 import { DatasetRoles } from '../../../constants';
 import JournalEntriesView from '../../JournalEntriesView';
 import { getCloudPlatform } from '../../../libs/utilsTs';
+
 function a11yProps(index) {
   return {
     id: `simple-tab-${index}`,
@@ -209,11 +210,11 @@ function DatasetOverviewPanel(props) {
         </Grid>
       </TabPanel>
       <TabPanel value={value} index={1}>
-        <Grid className={classes.fullViewText}>
+        <Grid sx={{ paddingBottom: '14px' }}>
           Use the dataset as is to create a full view snapshot
-          <span className={classes.fullViewButton}>
+          <Box sx={{ marginLeft: theme.spacing(2) }}>
             <FullViewSnapshotButton dataset={dataset} dispatch={dispatch} />
-          </span>
+          </Box>
         </Grid>
         <DatasetSnapshotsTable />
       </TabPanel>

--- a/src/components/dataset/overview/DatasetOverviewPanel.jsx
+++ b/src/components/dataset/overview/DatasetOverviewPanel.jsx
@@ -12,7 +12,7 @@ import {
   Tabs,
   Typography,
 } from '@mui/material';
-import { styled } from '@mui/system';
+import { styled } from '@mui/material/styles';
 import { ExpandMore, Close } from '@mui/icons-material';
 import IconButton from '@mui/material/IconButton';
 import { connect } from 'react-redux';

--- a/src/components/dataset/overview/DatasetOverviewPanel.jsx
+++ b/src/components/dataset/overview/DatasetOverviewPanel.jsx
@@ -42,7 +42,7 @@ const StyledDrawer = styled(Drawer, {
   flexShrink: 0,
   height: 'initial',
   zIndex: 10,
-  minWidth: 300,
+  minWidth: '300px',
   position: 'absolute',
   width: isVisible ? '40%' : 0,
   transition: theme.transitions.create('width', {
@@ -56,7 +56,7 @@ const StyledDrawer = styled(Drawer, {
     flexShrink: 0,
     height: 'initial',
     zIndex: 10,
-    minWidth: isVisible ? 300 : 0,
+    minWidth: isVisible ? '300px' : '0px',
     width: isVisible ? '40%' : 0,
     position: 'absolute',
     transition: theme.transitions.create('width', {

--- a/src/components/dataset/overview/DatasetOverviewPanel.jsx
+++ b/src/components/dataset/overview/DatasetOverviewPanel.jsx
@@ -12,7 +12,7 @@ import {
   Tabs,
   Typography,
 } from '@mui/material';
-import { styled } from '@mui/material/styles';
+import { styled } from '@mui/system';
 import { ExpandMore, Close } from '@mui/icons-material';
 import IconButton from '@mui/material/IconButton';
 import { connect } from 'react-redux';

--- a/src/components/dataset/overview/DatasetOverviewPanel.jsx
+++ b/src/components/dataset/overview/DatasetOverviewPanel.jsx
@@ -246,7 +246,7 @@ function DatasetOverviewPanel(props) {
         </Grid>
       </TabPanel>
       <Drawer
-        variant="permanent"
+        variant="temporary"
         anchor="right"
         className={isHelpVisible ? 'drawerOpen' : 'drawerClose'}
         sx={{

--- a/src/components/dataset/overview/DatasetOverviewPanel.jsx
+++ b/src/components/dataset/overview/DatasetOverviewPanel.jsx
@@ -284,7 +284,7 @@ function DatasetOverviewPanel(props) {
         </Grid>
       </TabPanel>
       <StyledDrawer
-        variant="permanent"
+        variant="temporary"
         anchor="right"
         open={isHelpVisible}
         isVisible={isHelpVisible}

--- a/src/components/dataset/overview/DatasetOverviewPanel.jsx
+++ b/src/components/dataset/overview/DatasetOverviewPanel.jsx
@@ -1,21 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import {
-  Box,
-  Typography,
   Accordion,
   AccordionDetails,
   AccordionSummary,
+  Box,
   Divider,
   Drawer,
   Grid,
   Tab,
   Tabs,
-  IconButton,
+  Typography,
 } from '@mui/material';
+import { styled } from '@mui/material/styles';
 import { ExpandMore, Close } from '@mui/icons-material';
-import theme from 'modules/theme';
+import IconButton from '@mui/material/IconButton';
+import { connect } from 'react-redux';
 import moment from 'moment';
 import { patchDataset } from 'actions';
 import GoogleSheetExport from 'components/common/overview/GoogleSheetExport';
@@ -33,6 +33,38 @@ import TabPanel from '../../common/TabPanel';
 import { DatasetRoles } from '../../../constants';
 import JournalEntriesView from '../../JournalEntriesView';
 import { getCloudPlatform } from '../../../libs/utilsTs';
+
+const StyledDrawer = styled(Drawer, {
+  shouldForwardProp: (prop) => !['isVisible'].includes(prop),
+})(({ theme, isVisible }) => ({
+  top: '112px',
+  bottom: '0px',
+  flexShrink: 0,
+  height: 'initial',
+  zIndex: 10,
+  minWidth: 300,
+  position: 'absolute',
+  width: isVisible ? '40%' : 0,
+  transition: theme.transitions.create('width', {
+    easing: theme.transitions.easing.sharp,
+    duration: theme.transitions.duration[isVisible ? 'enteringScreen' : 'leavingScreen'],
+  }),
+  overflowX: 'hidden',
+  '& .MuiDrawer-paper': {
+    top: '112px',
+    bottom: '0px',
+    flexShrink: 0,
+    height: 'initial',
+    zIndex: 10,
+    minWidth: isVisible ? 300 : 0,
+    width: isVisible ? '40%' : 0,
+    position: 'absolute',
+    transition: theme.transitions.create('width', {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration[isVisible ? 'enteringScreen' : 'leavingScreen'],
+    }),
+  },
+}));
 
 function a11yProps(index) {
   return {
@@ -176,12 +208,17 @@ function DatasetOverviewPanel(props) {
                 </AccordionSummary>
                 <AccordionDetails data-cy="relationship">
                   {dataset.schema.relationships.length === 0 && (
-                    <Typography sx={{ fontStyle: 'italic', color: 'error.contrastText' }}>
+                    <Typography
+                      sx={{
+                        fontStyle: 'italic',
+                        color: 'error.contrastText',
+                      }}
+                    >
                       (None)
                     </Typography>
                   )}
                   {dataset.schema.relationships.map((rel, i) => (
-                    <Box key={rel.name}>
+                    <div key={rel.name}>
                       <Typography variant="h6">{rel.name}</Typography>
                       <dl>
                         <dt>
@@ -199,9 +236,9 @@ function DatasetOverviewPanel(props) {
                         </dt>
                       </dl>
                       {i < dataset.schema.relationships.length - 1 && (
-                        <Divider sx={{ marginTop: '14px', marginBottom: '14px' }} />
+                        <Divider sx={{ mt: '14px', mb: '14px' }} />
                       )}
-                    </Box>
+                    </div>
                   ))}
                 </AccordionDetails>
               </Accordion>
@@ -212,7 +249,7 @@ function DatasetOverviewPanel(props) {
       <TabPanel value={value} index={1}>
         <Grid sx={{ paddingBottom: '14px' }}>
           Use the dataset as is to create a full view snapshot
-          <Box sx={{ marginLeft: theme.spacing(2) }}>
+          <Box sx={{ marginLeft: 2 }}>
             <FullViewSnapshotButton dataset={dataset} dispatch={dispatch} />
           </Box>
         </Grid>
@@ -246,46 +283,18 @@ function DatasetOverviewPanel(props) {
           </Grid>
         </Grid>
       </TabPanel>
-      <Drawer
-        variant="temporary"
+      <StyledDrawer
+        variant="permanent"
         anchor="right"
-        className={isHelpVisible ? 'drawerOpen' : 'drawerClose'}
-        sx={{
-          top: '112px',
-          bottom: '0px',
-          flexShrink: 0,
-          height: 'initial',
-          zIndex: 10,
-          minWidth: 300,
-          width: '40%',
-          position: 'absolute',
-          transition: () =>
-            theme.transitions.create('width', {
-              easing: theme.transitions.easing.sharp,
-              duration: theme.transitions.duration.enteringScreen,
-            }),
-          '&.drawerClose': {
-            transition: () =>
-              theme.transitions.create('width', {
-                easing: theme.transitions.easing.sharp,
-                duration: theme.transitions.duration.leavingScreen,
-              }),
-            overflowX: 'hidden',
-            width: '0px',
-            minWidth: '0px',
-            [theme.breakpoints.up('sm')]: {
-              width: '0px',
-            },
-          },
-        }}
         open={isHelpVisible}
+        isVisible={isHelpVisible}
       >
-        <Grid key="help-drawer" container spacing={1} sx={{ padding: '30px' }}>
+        <Grid container spacing={1} sx={{ p: '30px' }}>
           <Grid item xs={11}>
             {helpTitle}
           </Grid>
           <Grid item xs={1}>
-            <IconButton sx={{ color: 'common.link' }} onClick={closeHelpOverlay}>
+            <IconButton onClick={closeHelpOverlay} sx={{ color: 'common.link' }}>
               <Close />
             </IconButton>
           </Grid>
@@ -293,7 +302,7 @@ function DatasetOverviewPanel(props) {
             {helpContent}
           </Grid>
         </Grid>
-      </Drawer>
+      </StyledDrawer>
     </Box>
   );
 }

--- a/src/components/dataset/overview/DatasetOverviewPanel.test.tsx
+++ b/src/components/dataset/overview/DatasetOverviewPanel.test.tsx
@@ -3,7 +3,7 @@ import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
 import history from 'modules/hist';
 import { Provider } from 'react-redux';
-import { ThemeProvider } from '@mui/styles';
+import { ThemeProvider } from '@mui/material/styles';
 import globalTheme from 'modules/theme';
 import React from 'react';
 import DatasetOverviewPanel from 'components/dataset/overview/DatasetOverviewPanel';

--- a/src/components/dataset/schemaCreation/DatasetSchemaCreationView.tsx
+++ b/src/components/dataset/schemaCreation/DatasetSchemaCreationView.tsx
@@ -18,7 +18,7 @@ import DatasetCreationModal from './DatasetCreationModal';
 const styles = (theme: CustomTheme) => ({
   pageRoot: { ...theme.mixins.pageRoot },
   pageTitle: { ...theme.mixins.pageTitle },
-  width: { ...theme.mixins.containerWidth },
+  width: { width: '100%' },
   jadeLink: {
     ...theme.mixins.jadeLink,
     'text-decoration': 'underline',

--- a/src/components/table/SnapshotAccessRequestTable.tsx
+++ b/src/components/table/SnapshotAccessRequestTable.tsx
@@ -3,7 +3,7 @@ import { SnapshotAccessRequestResponse, SnapshotAccessRequestDetailsResponse } f
 import { TableColumnType } from 'reducers/query';
 import LightTable from 'components/table/LightTable';
 import moment from 'moment/moment';
-import { Button } from '@mui/material';
+import { Button, Box } from '@mui/material';
 import _ from 'lodash';
 import {
   approveSnapshotAccessRequest,
@@ -12,43 +12,10 @@ import {
 } from 'actions';
 import { Action } from 'redux';
 import { Link } from 'react-router-dom';
-import { ClassNameMap, createStyles, withStyles } from '@mui/styles';
-import { CustomTheme } from '@mui/material/styles';
 import TextWithModalDetails from 'components/common/InfoModal';
 import LoadingSpinner from 'components/common/LoadingSpinner';
 
-const styles = (theme: CustomTheme) =>
-  createStyles({
-    jadeLink: {
-      ...theme.mixins.jadeLink,
-    },
-    openButton: {
-      width: '100%',
-      border: 0,
-      justifyContent: 'left',
-      textTransform: 'none',
-      paddingTop: theme.spacing(1),
-      paddingBottom: theme.spacing(1),
-      '&:hover': {
-        border: 0,
-      },
-    },
-    overlaySpinner: {
-      opacity: 0.9,
-      position: 'absolute',
-      right: 0,
-      bottom: 0,
-      left: 0,
-      width: '100vw',
-      height: '100vh',
-      overflow: 'clip',
-      backgroundColor: theme.palette.common.white,
-      zIndex: 100,
-    },
-  });
-
 interface IProps {
-  classes: ClassNameMap;
   dispatch: Dispatch<Action>;
   snapshotAccessRequests: Array<SnapshotAccessRequestResponse>;
   snapshotAccessRequestDetails?: SnapshotAccessRequestDetailsResponse;
@@ -59,7 +26,6 @@ interface IProps {
 }
 
 function SnapshotAccessRequestTable({
-  classes,
   dispatch,
   snapshotAccessRequests,
   snapshotAccessRequestDetails,
@@ -107,7 +73,15 @@ function SnapshotAccessRequestTable({
       name: 'snapshotName',
       render: (row: SnapshotAccessRequestResponse) => (
         <Button
-          className={classes.openButton}
+          sx={{
+            width: '100%',
+            border: 0,
+            justifyContent: 'left',
+            textTransform: 'none',
+            paddingTop: '8px',
+            paddingBottom: '8px',
+            '&:hover': { border: 0 },
+          }}
           aria-label={row.snapshotName}
           onClick={() => openDetailsModal(row)}
           disableFocusRipple={true}
@@ -135,7 +109,9 @@ function SnapshotAccessRequestTable({
       name: 'createdSnapshotId',
       render: (row: SnapshotAccessRequestResponse) => (
         <Link to={`/snapshots/${row.createdSnapshotId}`}>
-          <span className={classes.jadeLink}>{row.createdSnapshotId}</span>
+          <Box sx={{ color: 'primary.main', textDecoration: 'underline' }}>
+            {row.createdSnapshotId}
+          </Box>
         </Link>
       ),
       width: '12%',
@@ -162,7 +138,7 @@ function SnapshotAccessRequestTable({
       label: '',
       name: 'Actions',
       render: (row: SnapshotAccessRequestResponse) => (
-        <div>
+        <Box>
           <Button
             color="primary"
             onClick={() => row.id && dispatch(rejectSnapshotAccessRequest(row.id))}
@@ -175,14 +151,14 @@ function SnapshotAccessRequestTable({
           >
             Approve
           </Button>
-        </div>
+        </Box>
       ),
       width: '15%',
     },
   ];
   return (
     <>
-      <div>
+      <Box>
         <LightTable
           columns={columns}
           noRowsMessage="No requests are pending review"
@@ -192,9 +168,22 @@ function SnapshotAccessRequestTable({
           refreshCnt={refreshCnt}
           totalCount={snapshotAccessRequests.length}
         />
-      </div>
+      </Box>
       {loadingSnapshotAccessRequestDetails ? (
-        <LoadingSpinner className={classes.overlaySpinner} />
+        <LoadingSpinner
+          sx={{
+            opacity: 0.9,
+            position: 'absolute',
+            right: 0,
+            bottom: 0,
+            left: 0,
+            width: '100vw',
+            height: '100vh',
+            overflow: 'clip',
+            backgroundColor: 'common.white',
+            zIndex: 100,
+          }}
+        />
       ) : (
         selectedAccessRequest &&
         snapshotAccessRequestDetails && (
@@ -209,4 +198,4 @@ function SnapshotAccessRequestTable({
   );
 }
 
-export default withStyles(styles)(SnapshotAccessRequestTable);
+export default SnapshotAccessRequestTable;

--- a/src/components/table/SnapshotAccessRequestTable.tsx
+++ b/src/components/table/SnapshotAccessRequestTable.tsx
@@ -12,11 +12,11 @@ import {
 } from 'actions';
 import { Action } from 'redux';
 import { Link } from 'react-router-dom';
-import { styled } from '@mui/system';
+import { CustomTheme, styled } from '@mui/material/styles';
 import TextWithModalDetails from 'components/common/InfoModal';
 import LoadingSpinner from 'components/common/LoadingSpinner';
 
-const OverlaySpinner = styled(Box)(({ theme }) => ({
+const OverlaySpinner = styled(Box)(({ theme }: { theme: CustomTheme }) => ({
   opacity: 0.9,
   position: 'absolute',
   right: 0,
@@ -29,7 +29,7 @@ const OverlaySpinner = styled(Box)(({ theme }) => ({
   zIndex: 100,
 }));
 
-const RequestButton = styled(Button)(({ theme }) => ({
+const RequestButton = styled(Button)(({ theme }: { theme: CustomTheme }) => ({
   width: '100%',
   border: 0,
   justifyContent: 'left',

--- a/src/components/table/SnapshotAccessRequestTable.tsx
+++ b/src/components/table/SnapshotAccessRequestTable.tsx
@@ -12,8 +12,36 @@ import {
 } from 'actions';
 import { Action } from 'redux';
 import { Link } from 'react-router-dom';
+import { styled } from '@mui/system';
 import TextWithModalDetails from 'components/common/InfoModal';
 import LoadingSpinner from 'components/common/LoadingSpinner';
+
+const OverlaySpinner = styled(Box)(({ theme }) => ({
+  opacity: 0.9,
+  position: 'absolute',
+  right: 0,
+  bottom: 0,
+  left: 0,
+  width: '100vw',
+  height: '100vh',
+  overflow: 'clip',
+  backgroundColor: theme.palette.common.white,
+  zIndex: 100,
+}));
+
+const RequestButton = styled(Button)(({ theme }) => ({
+  width: '100%',
+  border: 0,
+  justifyContent: 'left',
+  textTransform: 'none',
+  paddingTop: theme.spacing(1),
+  paddingBottom: theme.spacing(1),
+  '&:hover': {
+    border: 0,
+  },
+}));
+
+const SnapshotIdLinkLabel = styled('span')(({ theme }) => theme.mixins.jadeLink);
 
 interface IProps {
   dispatch: Dispatch<Action>;
@@ -72,23 +100,14 @@ function SnapshotAccessRequestTable({
       label: 'Request Name',
       name: 'snapshotName',
       render: (row: SnapshotAccessRequestResponse) => (
-        <Button
-          sx={{
-            width: '100%',
-            border: 0,
-            justifyContent: 'left',
-            textTransform: 'none',
-            paddingTop: '8px',
-            paddingBottom: '8px',
-            '&:hover': { border: 0 },
-          }}
+        <RequestButton
           aria-label={row.snapshotName}
           onClick={() => openDetailsModal(row)}
           disableFocusRipple={true}
           disableRipple={true}
         >
           {row.snapshotName}
-        </Button>
+        </RequestButton>
       ),
       width: '16%',
     },
@@ -109,9 +128,7 @@ function SnapshotAccessRequestTable({
       name: 'createdSnapshotId',
       render: (row: SnapshotAccessRequestResponse) => (
         <Link to={`/snapshots/${row.createdSnapshotId}`}>
-          <Box sx={{ color: 'primary.main', textDecoration: 'underline' }}>
-            {row.createdSnapshotId}
-          </Box>
+          <SnapshotIdLinkLabel>{row.createdSnapshotId}</SnapshotIdLinkLabel>
         </Link>
       ),
       width: '12%',
@@ -138,7 +155,7 @@ function SnapshotAccessRequestTable({
       label: '',
       name: 'Actions',
       render: (row: SnapshotAccessRequestResponse) => (
-        <Box>
+        <div>
           <Button
             color="primary"
             onClick={() => row.id && dispatch(rejectSnapshotAccessRequest(row.id))}
@@ -151,14 +168,14 @@ function SnapshotAccessRequestTable({
           >
             Approve
           </Button>
-        </Box>
+        </div>
       ),
       width: '15%',
     },
   ];
   return (
     <>
-      <Box>
+      <div>
         <LightTable
           columns={columns}
           noRowsMessage="No requests are pending review"
@@ -168,22 +185,9 @@ function SnapshotAccessRequestTable({
           refreshCnt={refreshCnt}
           totalCount={snapshotAccessRequests.length}
         />
-      </Box>
+      </div>
       {loadingSnapshotAccessRequestDetails ? (
-        <LoadingSpinner
-          sx={{
-            opacity: 0.9,
-            position: 'absolute',
-            right: 0,
-            bottom: 0,
-            left: 0,
-            width: '100vw',
-            height: '100vh',
-            overflow: 'clip',
-            backgroundColor: 'common.white',
-            zIndex: 100,
-          }}
-        />
+        <LoadingSpinner component={OverlaySpinner} />
       ) : (
         selectedAccessRequest &&
         snapshotAccessRequestDetails && (

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -6,7 +6,7 @@ import Helmet from 'react-helmet';
 import { Provider } from 'react-redux';
 import { Router } from 'react-router-dom';
 import history from 'modules/hist';
-import globalTheme from 'modules/theme';
+import theme from 'modules/theme';
 import { ThemeProvider } from '@mui/material/styles';
 import axios from 'axios';
 import { WebStorageStateStore, Log } from 'oidc-client-ts';
@@ -159,7 +159,7 @@ function render(Component) {
         <Router history={history}>
           {/* CachingProvider is a way to control how css is rendered in the DOM */}
           <CacheProvider value={cache}>
-            <ThemeProvider theme={globalTheme}>
+            <ThemeProvider theme={theme}>
               <AuthProvider {...oidcConfig}>
                 <Component />
               </AuthProvider>

--- a/src/modules/theme.ts
+++ b/src/modules/theme.ts
@@ -269,9 +269,6 @@ const theme = createTheme({
         color: LINK_HOVER,
       },
     },
-    containerWidth: {
-      width: '100%',
-    },
     pageRoot: {
       padding: '16px 24px',
       display: 'flex',

--- a/src/types/theme.d.ts
+++ b/src/types/theme.d.ts
@@ -6,7 +6,6 @@ import {
   PaletteOptions,
 } from '@mui/material/styles/createPalette';
 import { Typography, TypographyOptions } from '@mui/material/styles/createTypography';
-import { Overrides } from '@mui/styles/overrides';
 import { CSSProperties, Mixins, MixinsOptions } from '@mui/material/styles/createMixins';
 
 declare module '@mui/material/styles' {
@@ -41,7 +40,6 @@ declare module '@mui/material/styles' {
     lightTable?: Partial<CustomPaletteColors>;
     panel?: Partial<CustomPaletteColors>;
     terra?: Partial<CustomPaletteColors>;
-    primary?: Partial<CustomPaletteColors>;
   }
 
   interface CustomPalette extends Palette {
@@ -97,7 +95,6 @@ declare module '@mui/material/styles' {
   interface CustomTheme extends Theme {
     typography: CustomTypography;
     palette: CustomPalette;
-    overrides: Overrides;
     mixins: CustomMixins;
     constants: CustomConstants;
   }
@@ -106,7 +103,6 @@ declare module '@mui/material/styles' {
   interface CustomThemeOptions extends ThemeOptions {
     typography?: CustomTypographyOptions;
     palette?: CustomPaletteOptions;
-    overrides?: Overrides;
     mixins?: CustomMixinsOptions;
     constants?: CustomConstantsOptions;
   }

--- a/src/types/theme.d.ts
+++ b/src/types/theme.d.ts
@@ -66,7 +66,6 @@ declare module '@mui/material/styles' {
 
   interface CustomMixins extends Mixins {
     jadeLink: JadeLink;
-    containerWidth: CSSProperties;
     pageRoot: CSSProperties;
     pageTitle: CSSProperties;
     ellipsis: CSSProperties;
@@ -78,7 +77,6 @@ declare module '@mui/material/styles' {
 
   interface CustomMixinsOptions extends MixinsOptions {
     jadeLink?: JadeLink;
-    containerWidth?: CSSProperties;
     pageRoot?: CSSProperties;
     pageTitle?: CSSProperties;
     ellipsis?: CSSProperties;


### PR DESCRIPTION
## Background
We must discontinue use of @mui/styles in order to migrate from React 17 to 18. ([source](https://mui.com/system/styles/api/))

>  @mui/styles was deprecated with the release of MUI Core v5 in late 2021. It is not compatible with [React.StrictMode](https://react.dev/reference/react/StrictMode) or React 18+, and it will not be updated. Please use [@mui/system](https://mui.com/system/getting-started/) instead.

There is guide for this migration here: https://mui.com/material-ui/migration/migrating-from-jss

Options considered:
- [`sx` prop](https://mui.com/system/getting-started/the-sx-prop/)  + styled components from `@mui/matertial/styles`  -  From migration guide - "We recommend sx API over styled for creating responsive styles or overriding minor CSS". We can use styled components for components with a lot of styles (4+) and for styling that is reused. 
- tss-react - Easiest change, but still would require using copilot per component. It would be more of a lateral step.

This PR uses the first option and uses the `sx` prop alongside styled components. Given that we have to touch every file manually and I think we can utilize copilot for the bulk of the work, I would prefer to do the harder change rather than the lateral change. 

## Steps for Upgrades
**Pre-checks:**
- Review the styles listed at the beginning of the file. Are they all referenced in the component? (Apparently if there are styles that don't match up to a component, it will try to infer where the component with those styles should go and add it) 

1) Run copilot command, specifically in VSCode with Claude 3.5 Sonnet.

>Can you migrate this component away from using JSS and references to '@mui/styles'? We want to instead use a combination of inline styling with the "sx" prop on Material UI components and styled components from @mui/material/styles.

>Let me explain something about how our code is set up: In the existing code, all of the styles currently live in a "styles" object. It contains a list of classes each with their own styles.

>Consider the following example:
```
const styles = (theme: CustomTheme) =>
  createStyles({
    pageRoot: {
      padding: '16px 24px',
      display: 'flex',
      flexDirection: 'column',
      height: '100%',
    },
    jadeTableSpacer: {
      paddingBottom: theme.spacing(12),
    }
});
```

>pageRoot and jadeTableSpacer are classes that we reference in the component. pageRoot has 4 styles and jadeTableSpacer has 1 style. We don't want to use inline styling with the sx for classes that have more than 3 styles, so we want to handle these two classes in different manners. Since pageRoot has 4 styles, we want to use a styled component. Since jadeTableSpacer only has 1 style, we want to use the inline styling with an "sx" prop. We can evaluate other style classes with this same rule: if there are 3 or fewer styles, use the "sx" prop. If there are more than 3 styles, then convert to a styled component.

>When using the "sx" prop, then we must use the material UI version of the component (e.g. Box instead of div and add an import statement at the beginning of the file). We must also switch any css references of direct numbers to include px (e.g. '10px' instead of 10)

2) Apply prettier
3) Review UI and code generated
4) Compare UI/styling between local UI and dev


### Common Issues
- It doesn't handle theme changes well - https://github.com/DataBiosphere/jade-data-repo-ui/commit/30ca7c2d2a6c15a6f8f8c6690781714a04c17cf2

## What step is the copilot upgrade taking? (example output from copilot)
I'll help migrate the SnapshotAccessRequestTable from JSS to use styled components and sx props. 

Let's analyze the styles:
1) More than 3 styles:
-  overlaySpinner (6 styles)
-  openButton (7 styles)
2) Convert to sx props:
- jadeLink (1 style with theme mixin)

Key changes made:
- Removed withStyles HOC and styles object
- Added styled import from @mui/material/styles
- Created styled components for complex styles: OverlaySpinner for loading overlay, RequestButton for the request name button, Converted jadeLink to use sx prop with theme mixin
- Removed classes prop and ClassNameMap interface
- Added Box component for styled span
- Simplified component exports
- Maintained all functionality while modernizing the styling approach

The component maintains the same styling and behavior while using modern MUI patterns.


**Example**
**Before with @mui/styles**
```
const styles = (theme: CustomTheme) => ({
  wrapper: {
    display: 'flex',
    justifyContent: 'center',
    marginTop: '1em',
  }
);
....
 <div className={classes.wrapper}>
...
</div>
```
**With sx prop**
```
 <Box sx={{ display: 'flex', justifyContent: 'center', marginTop: '1em' }}>
...
</Box>
```

##TODO - add example for styled component

## TODO - add more notes about nuances of  the changes from mui



## Components Impacted in this PR
**Updated screenshots as of 01-11-2024**
1) HomeView and 2) DatasetView
<img width="1352" alt="image" src="https://github.com/user-attachments/assets/a386d4ab-d373-4f5b-83dc-f3c4573bc52b" />


3) JobView
<img width="1341" alt="image" src="https://github.com/user-attachments/assets/40948704-9895-49ab-8934-81862af0270a" />


4) SnapshotView
<img width="1345" alt="image" src="https://github.com/user-attachments/assets/c40410c0-fb1d-48bc-96df-b8c3b3a85bb8" />



5) DatasetOverview and 6) DatasetOverviewPanel
<img width="1342" alt="image" src="https://github.com/user-attachments/assets/290978e1-30f4-4da4-977f-7b9797f9b2d7" />
<img width="1342" alt="image" src="https://github.com/user-attachments/assets/1dc37842-404c-4a50-9015-59496228584d" />


7) DatasetAccess and 8) UserList
<img width="1342" alt="image" src="https://github.com/user-attachments/assets/c2554df4-f415-476d-ade8-a99f6b79e51d" />

9) SnapshotAccessRequestTable
<img width="1339" alt="image" src="https://github.com/user-attachments/assets/ca49f54f-929c-44b3-902a-efea57b96290" />

