### PR TITLE
DT-1125: Migrate away from @mui/styles Part 2 - ThemeProvider to use @mui/system

### DIFF
--- a/src/components/AppBreadcrumbs/AppBreadcrumbs.test.tsx
+++ b/src/components/AppBreadcrumbs/AppBreadcrumbs.test.tsx
@@ -3,7 +3,7 @@ import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
 import history from 'modules/hist';
 import globalTheme from 'modules/theme';
-import { ThemeProvider } from '@mui/system';
+import { ThemeProvider } from '@mui/material/styles';
 import AppBreadcrumbs from './AppBreadcrumbs';
 import { BreadcrumbType } from '../../constants';
 

--- a/src/components/AppBreadcrumbs/AppBreadcrumbs.test.tsx
+++ b/src/components/AppBreadcrumbs/AppBreadcrumbs.test.tsx
@@ -3,7 +3,7 @@ import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
 import history from 'modules/hist';
 import globalTheme from 'modules/theme';
-import { ThemeProvider } from '@mui/styles';
+import { ThemeProvider } from '@mui/system';
 import AppBreadcrumbs from './AppBreadcrumbs';
 import { BreadcrumbType } from '../../constants';
 

--- a/src/components/EditableFieldView.test.tsx
+++ b/src/components/EditableFieldView.test.tsx
@@ -1,7 +1,7 @@
 import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
-import { ThemeProvider } from '@mui/system';
+import { ThemeProvider } from '@mui/material/styles';
 import createMockStore from 'redux-mock-store';
 import React from 'react';
 import EditableFieldView from './EditableFieldView';

--- a/src/components/EditableFieldView.test.tsx
+++ b/src/components/EditableFieldView.test.tsx
@@ -1,7 +1,7 @@
 import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
-import { ThemeProvider } from '@mui/styles';
+import { ThemeProvider } from '@mui/system';
 import createMockStore from 'redux-mock-store';
 import React from 'react';
 import EditableFieldView from './EditableFieldView';

--- a/src/components/JobView.test.tsx
+++ b/src/components/JobView.test.tsx
@@ -1,7 +1,7 @@
 import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
-import { ThemeProvider } from '@mui/system';
+import { ThemeProvider } from '@mui/material/styles';
 import createMockStore from 'redux-mock-store';
 import React from 'react';
 import _ from 'lodash';

--- a/src/components/JobView.test.tsx
+++ b/src/components/JobView.test.tsx
@@ -1,7 +1,7 @@
 import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
-import { ThemeProvider } from '@mui/styles';
+import { ThemeProvider } from '@mui/system';
 import createMockStore from 'redux-mock-store';
 import React from 'react';
 import _ from 'lodash';

--- a/src/components/ManageUsersView.test.tsx
+++ b/src/components/ManageUsersView.test.tsx
@@ -1,6 +1,6 @@
 import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
-import { ThemeProvider } from '@mui/system';
+import { ThemeProvider } from '@mui/material/styles';
 import { Provider } from 'react-redux';
 import React from 'react';
 import createMockStore from 'redux-mock-store';

--- a/src/components/ManageUsersView.test.tsx
+++ b/src/components/ManageUsersView.test.tsx
@@ -1,6 +1,6 @@
 import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
-import { ThemeProvider } from '@mui/styles';
+import { ThemeProvider } from '@mui/system';
 import { Provider } from 'react-redux';
 import React from 'react';
 import createMockStore from 'redux-mock-store';

--- a/src/components/SnapshotAccessRequestView.test.tsx
+++ b/src/components/SnapshotAccessRequestView.test.tsx
@@ -8,7 +8,7 @@ import { routerMiddleware } from 'connected-react-router';
 import history from 'modules/hist';
 import { Provider } from 'react-redux';
 import { Router } from 'react-router-dom';
-import { ThemeProvider } from '@mui/styles';
+import { ThemeProvider } from '@mui/system';
 import globalTheme from 'modules/theme';
 import React from 'react';
 

--- a/src/components/SnapshotAccessRequestView.test.tsx
+++ b/src/components/SnapshotAccessRequestView.test.tsx
@@ -8,7 +8,7 @@ import { routerMiddleware } from 'connected-react-router';
 import history from 'modules/hist';
 import { Provider } from 'react-redux';
 import { Router } from 'react-router-dom';
-import { ThemeProvider } from '@mui/system';
+import { ThemeProvider } from '@mui/material/styles';
 import globalTheme from 'modules/theme';
 import React from 'react';
 

--- a/src/components/UserList.test.tsx
+++ b/src/components/UserList.test.tsx
@@ -1,6 +1,6 @@
 import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
-import { ThemeProvider } from '@mui/system';
+import { ThemeProvider } from '@mui/material/styles';
 import { Provider } from 'react-redux';
 import React from 'react';
 import createMockStore from 'redux-mock-store';

--- a/src/components/UserList.test.tsx
+++ b/src/components/UserList.test.tsx
@@ -1,6 +1,6 @@
 import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
-import { ThemeProvider } from '@mui/styles';
+import { ThemeProvider } from '@mui/system';
 import { Provider } from 'react-redux';
 import React from 'react';
 import createMockStore from 'redux-mock-store';

--- a/src/components/common/TabWrapper.test.tsx
+++ b/src/components/common/TabWrapper.test.tsx
@@ -7,7 +7,7 @@ import { routerMiddleware } from 'connected-react-router';
 import history from 'modules/hist';
 import { Provider } from 'react-redux';
 import { Router } from 'react-router-dom';
-import { ThemeProvider } from '@mui/styles';
+import { ThemeProvider } from '@mui/system';
 import globalTheme from 'modules/theme';
 import React from 'react';
 import TabWrapper from 'components/common/TabWrapper';

--- a/src/components/common/TabWrapper.test.tsx
+++ b/src/components/common/TabWrapper.test.tsx
@@ -7,7 +7,7 @@ import { routerMiddleware } from 'connected-react-router';
 import history from 'modules/hist';
 import { Provider } from 'react-redux';
 import { Router } from 'react-router-dom';
-import { ThemeProvider } from '@mui/system';
+import { ThemeProvider } from '@mui/material/styles';
 import globalTheme from 'modules/theme';
 import React from 'react';
 import TabWrapper from 'components/common/TabWrapper';

--- a/src/components/common/TerraAvatar.test.tsx
+++ b/src/components/common/TerraAvatar.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
-import { ThemeProvider } from '@mui/styles';
+import { ThemeProvider } from '@mui/system';
 import { Provider } from 'react-redux';
 import createMockStore from 'redux-mock-store';
 

--- a/src/components/common/TerraAvatar.test.tsx
+++ b/src/components/common/TerraAvatar.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
-import { ThemeProvider } from '@mui/system';
+import { ThemeProvider } from '@mui/material/styles';
 import { Provider } from 'react-redux';
 import createMockStore from 'redux-mock-store';
 

--- a/src/components/common/TextContent.test.tsx
+++ b/src/components/common/TextContent.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
-import { ThemeProvider } from '@mui/styles';
+import { ThemeProvider } from '@mui/system';
 import { Provider } from 'react-redux';
 import createMockStore from 'redux-mock-store';
 

--- a/src/components/common/TextContent.test.tsx
+++ b/src/components/common/TextContent.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
-import { ThemeProvider } from '@mui/system';
+import { ThemeProvider } from '@mui/material/styles';
 import { Provider } from 'react-redux';
 import createMockStore from 'redux-mock-store';
 

--- a/src/components/common/WithoutStylesMarkdownContent.test.tsx
+++ b/src/components/common/WithoutStylesMarkdownContent.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
-import { ThemeProvider } from '@mui/styles';
+import { ThemeProvider } from '@mui/system';
 import { Provider } from 'react-redux';
 import createMockStore from 'redux-mock-store';
 

--- a/src/components/common/WithoutStylesMarkdownContent.test.tsx
+++ b/src/components/common/WithoutStylesMarkdownContent.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
-import { ThemeProvider } from '@mui/system';
+import { ThemeProvider } from '@mui/material/styles';
 import { Provider } from 'react-redux';
 import createMockStore from 'redux-mock-store';
 

--- a/src/components/common/overview/SchemaPanel.test.tsx
+++ b/src/components/common/overview/SchemaPanel.test.tsx
@@ -1,6 +1,6 @@
 import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
-import { ThemeProvider } from '@mui/system';
+import { ThemeProvider } from '@mui/material/styles';
 import React from 'react';
 import { TableDataType, TableModel } from 'generated/tdr';
 import history from '../../../modules/hist';

--- a/src/components/common/overview/SchemaPanel.test.tsx
+++ b/src/components/common/overview/SchemaPanel.test.tsx
@@ -1,6 +1,6 @@
 import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
-import { ThemeProvider } from '@mui/styles';
+import { ThemeProvider } from '@mui/system';
 import React from 'react';
 import { TableDataType, TableModel } from 'generated/tdr';
 import history from '../../../modules/hist';

--- a/src/components/dataset/data/sidebar/filter/CategoryWrapper.test.tsx
+++ b/src/components/dataset/data/sidebar/filter/CategoryWrapper.test.tsx
@@ -1,7 +1,7 @@
 import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
-import { ThemeProvider } from '@mui/system';
+import { ThemeProvider } from '@mui/material/styles';
 import { routerMiddleware } from 'connected-react-router';
 import createMockStore, { MockStoreEnhanced } from 'redux-mock-store';
 import React from 'react';

--- a/src/components/dataset/data/sidebar/filter/CategoryWrapper.test.tsx
+++ b/src/components/dataset/data/sidebar/filter/CategoryWrapper.test.tsx
@@ -1,7 +1,7 @@
 import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
-import { ThemeProvider } from '@mui/styles';
+import { ThemeProvider } from '@mui/system';
 import { routerMiddleware } from 'connected-react-router';
 import createMockStore, { MockStoreEnhanced } from 'redux-mock-store';
 import React from 'react';

--- a/src/components/dataset/data/sidebar/filter/FreetextFilter.test.tsx
+++ b/src/components/dataset/data/sidebar/filter/FreetextFilter.test.tsx
@@ -1,7 +1,7 @@
 import { Provider } from 'react-redux';
 import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
-import { ThemeProvider } from '@mui/system';
+import { ThemeProvider } from '@mui/material/styles';
 import { routerMiddleware } from 'connected-react-router';
 import createMockStore, { MockStoreEnhanced } from 'redux-mock-store';
 import React from 'react';

--- a/src/components/dataset/data/sidebar/filter/FreetextFilter.test.tsx
+++ b/src/components/dataset/data/sidebar/filter/FreetextFilter.test.tsx
@@ -1,7 +1,7 @@
 import { Provider } from 'react-redux';
 import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
-import { ThemeProvider } from '@mui/styles';
+import { ThemeProvider } from '@mui/system';
 import { routerMiddleware } from 'connected-react-router';
 import createMockStore, { MockStoreEnhanced } from 'redux-mock-store';
 import React from 'react';

--- a/src/components/dataset/data/sidebar/filter/RangeFilter.test.tsx
+++ b/src/components/dataset/data/sidebar/filter/RangeFilter.test.tsx
@@ -1,7 +1,7 @@
 import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
-import { ThemeProvider } from '@mui/system';
+import { ThemeProvider } from '@mui/material/styles';
 import { routerMiddleware } from 'connected-react-router';
 import createMockStore, { MockStoreEnhanced } from 'redux-mock-store';
 import React from 'react';

--- a/src/components/dataset/data/sidebar/filter/RangeFilter.test.tsx
+++ b/src/components/dataset/data/sidebar/filter/RangeFilter.test.tsx
@@ -1,7 +1,7 @@
 import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
-import { ThemeProvider } from '@mui/styles';
+import { ThemeProvider } from '@mui/system';
 import { routerMiddleware } from 'connected-react-router';
 import createMockStore, { MockStoreEnhanced } from 'redux-mock-store';
 import React from 'react';

--- a/src/components/dataset/schemaCreation/DatasetSchemaCreationView.test.tsx
+++ b/src/components/dataset/schemaCreation/DatasetSchemaCreationView.test.tsx
@@ -1,7 +1,7 @@
 import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
-import { ThemeProvider } from '@mui/system';
+import { ThemeProvider } from '@mui/material/styles';
 import createMockStore, { MockStoreEnhanced } from 'redux-mock-store';
 import React from 'react';
 import _ from 'lodash';

--- a/src/components/dataset/schemaCreation/DatasetSchemaCreationView.test.tsx
+++ b/src/components/dataset/schemaCreation/DatasetSchemaCreationView.test.tsx
@@ -1,7 +1,7 @@
 import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
-import { ThemeProvider } from '@mui/styles';
+import { ThemeProvider } from '@mui/system';
 import createMockStore, { MockStoreEnhanced } from 'redux-mock-store';
 import React from 'react';
 import _ from 'lodash';

--- a/src/components/snapshot/DataAccessControlGroup.test.tsx
+++ b/src/components/snapshot/DataAccessControlGroup.test.tsx
@@ -1,6 +1,6 @@
 import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
-import { ThemeProvider } from '@mui/system';
+import { ThemeProvider } from '@mui/material/styles';
 import { Provider } from 'react-redux';
 import React from 'react';
 import createMockStore from 'redux-mock-store';

--- a/src/components/snapshot/DataAccessControlGroup.test.tsx
+++ b/src/components/snapshot/DataAccessControlGroup.test.tsx
@@ -1,6 +1,6 @@
 import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
-import { ThemeProvider } from '@mui/styles';
+import { ThemeProvider } from '@mui/system';
 import { Provider } from 'react-redux';
 import React from 'react';
 import createMockStore from 'redux-mock-store';

--- a/src/components/snapshot/SnapshotAccess.test.tsx
+++ b/src/components/snapshot/SnapshotAccess.test.tsx
@@ -1,6 +1,6 @@
 import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
-import { ThemeProvider } from '@mui/system';
+import { ThemeProvider } from '@mui/material/styles';
 import { Provider } from 'react-redux';
 import React from 'react';
 import createMockStore from 'redux-mock-store';

--- a/src/components/snapshot/SnapshotAccess.test.tsx
+++ b/src/components/snapshot/SnapshotAccess.test.tsx
@@ -1,6 +1,6 @@
 import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
-import { ThemeProvider } from '@mui/styles';
+import { ThemeProvider } from '@mui/system';
 import { Provider } from 'react-redux';
 import React from 'react';
 import createMockStore from 'redux-mock-store';

--- a/src/components/snapshot/overview/SnapshotExport.test.tsx
+++ b/src/components/snapshot/overview/SnapshotExport.test.tsx
@@ -1,6 +1,6 @@
 import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
-import { ThemeProvider } from '@mui/system';
+import { ThemeProvider } from '@mui/material/styles';
 import { Provider } from 'react-redux';
 import React from 'react';
 import createMockStore from 'redux-mock-store';

--- a/src/components/snapshot/overview/SnapshotExport.test.tsx
+++ b/src/components/snapshot/overview/SnapshotExport.test.tsx
@@ -1,6 +1,6 @@
 import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
-import { ThemeProvider } from '@mui/styles';
+import { ThemeProvider } from '@mui/system';
 import { Provider } from 'react-redux';
 import React from 'react';
 import createMockStore from 'redux-mock-store';

--- a/src/components/snapshot/overview/SnapshotOverviewPanel.test.tsx
+++ b/src/components/snapshot/overview/SnapshotOverviewPanel.test.tsx
@@ -1,6 +1,6 @@
 import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
-import { ThemeProvider } from '@mui/system';
+import { ThemeProvider } from '@mui/material/styles';
 import { Provider } from 'react-redux';
 import React from 'react';
 import createMockStore from 'redux-mock-store';

--- a/src/components/snapshot/overview/SnapshotOverviewPanel.test.tsx
+++ b/src/components/snapshot/overview/SnapshotOverviewPanel.test.tsx
@@ -1,6 +1,6 @@
 import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
-import { ThemeProvider } from '@mui/styles';
+import { ThemeProvider } from '@mui/system';
 import { Provider } from 'react-redux';
 import React from 'react';
 import createMockStore from 'redux-mock-store';

--- a/src/components/snapshot/overview/SnapshotWorkspace.test.tsx
+++ b/src/components/snapshot/overview/SnapshotWorkspace.test.tsx
@@ -1,6 +1,6 @@
 import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
-import { ThemeProvider } from '@mui/system';
+import { ThemeProvider } from '@mui/material/styles';
 import { Provider } from 'react-redux';
 import React from 'react';
 import createMockStore from 'redux-mock-store';

--- a/src/components/snapshot/overview/SnapshotWorkspace.test.tsx
+++ b/src/components/snapshot/overview/SnapshotWorkspace.test.tsx
@@ -1,6 +1,6 @@
 import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
-import { ThemeProvider } from '@mui/styles';
+import { ThemeProvider } from '@mui/system';
 import { Provider } from 'react-redux';
 import React from 'react';
 import createMockStore from 'redux-mock-store';

--- a/src/components/table/LightTable.test.tsx
+++ b/src/components/table/LightTable.test.tsx
@@ -1,7 +1,7 @@
 import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
-import { ThemeProvider } from '@mui/system';
+import { ThemeProvider } from '@mui/material/styles';
 import { initialUserState } from 'reducers/user';
 import { initialQueryState } from 'reducers/query';
 import _ from 'lodash';

--- a/src/components/table/LightTable.test.tsx
+++ b/src/components/table/LightTable.test.tsx
@@ -1,7 +1,7 @@
 import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
-import { ThemeProvider } from '@mui/styles';
+import { ThemeProvider } from '@mui/system';
 import { initialUserState } from 'reducers/user';
 import { initialQueryState } from 'reducers/query';
 import _ from 'lodash';

--- a/src/components/table/ResourceName.test.tsx
+++ b/src/components/table/ResourceName.test.tsx
@@ -3,7 +3,7 @@ import createMockStore from 'redux-mock-store';
 import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
-import { ThemeProvider } from '@mui/system';
+import { ThemeProvider } from '@mui/material/styles';
 
 import history from '../../modules/hist';
 import globalTheme from '../../modules/theme';

--- a/src/components/table/ResourceName.test.tsx
+++ b/src/components/table/ResourceName.test.tsx
@@ -3,7 +3,7 @@ import createMockStore from 'redux-mock-store';
 import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
-import { ThemeProvider } from '@mui/styles';
+import { ThemeProvider } from '@mui/system';
 
 import history from '../../modules/hist';
 import globalTheme from '../../modules/theme';

--- a/src/components/table/SnapshotAccessRequestTable.test.tsx
+++ b/src/components/table/SnapshotAccessRequestTable.test.tsx
@@ -7,7 +7,7 @@ import { routerMiddleware } from 'connected-react-router';
 import history from 'modules/hist';
 import { Provider } from 'react-redux';
 import { Router } from 'react-router-dom';
-import { ThemeProvider } from '@mui/system';
+import { ThemeProvider } from '@mui/material/styles';
 import globalTheme from 'modules/theme';
 import React from 'react';
 import SnapshotAccessRequestTable from 'components/table/SnapshotAccessRequestTable';

--- a/src/components/table/SnapshotAccessRequestTable.test.tsx
+++ b/src/components/table/SnapshotAccessRequestTable.test.tsx
@@ -7,7 +7,7 @@ import { routerMiddleware } from 'connected-react-router';
 import history from 'modules/hist';
 import { Provider } from 'react-redux';
 import { Router } from 'react-router-dom';
-import { ThemeProvider } from '@mui/styles';
+import { ThemeProvider } from '@mui/system';
 import globalTheme from 'modules/theme';
 import React from 'react';
 import SnapshotAccessRequestTable from 'components/table/SnapshotAccessRequestTable';

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -7,7 +7,7 @@ import { Provider } from 'react-redux';
 import { Router } from 'react-router-dom';
 import history from 'modules/hist';
 import globalTheme from 'modules/theme';
-import { ThemeProvider } from '@mui/system';
+import { ThemeProvider } from '@mui/material/styles';
 import axios from 'axios';
 import { WebStorageStateStore, Log } from 'oidc-client-ts';
 import { AuthProvider } from 'react-oidc-context';

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -7,7 +7,7 @@ import { Provider } from 'react-redux';
 import { Router } from 'react-router-dom';
 import history from 'modules/hist';
 import globalTheme from 'modules/theme';
-import { ThemeProvider } from '@mui/material/styles';
+import { ThemeProvider } from '@mui/system';
 import axios from 'axios';
 import { WebStorageStateStore, Log } from 'oidc-client-ts';
 import { AuthProvider } from 'react-oidc-context';


### PR DESCRIPTION
### Background
More details about this migration here: https://github.com/DataBiosphere/jade-data-repo-ui/pull/1730

Breaking out this change to help simplify other PRs. 

### Included Changes
Switch references from `@mui/styles` to `@mui/material/styles`
______
From migration guide: https://mui.com/material-ui/migration/v5-style-changes/#update-themeprovider-import

<img width="828" alt="image" src="https://github.com/user-attachments/assets/ed329ce0-a6af-442a-814d-ea05bfed1351" />

______

### Note
I don't totally understand why this appears to still be working in combination with the sx components. We may need to eventually migrate away from this as well. But, I think that this ThemeProvider is providing the theme even in the changes in [this PR](https://github.com/DataBiosphere/jade-data-repo-ui/pull/1730/files) to use the sx prop because things break if the theme is not referenced correctly. 

But, I want to go ahead and remove all references directly to @mui/styles. 