### PR TITLE
[DT-1115]Flaky TDR UI integration test

### DIFF
--- a/cypress/integration/datasetSharing.spec.js
+++ b/cypress/integration/datasetSharing.spec.js
@@ -9,8 +9,7 @@ describe('test dataset sharing', () => {
     );
 
     cy.visit('/login/e2e');
-    cy.get('#tokenInput').type(Cypress.env('GOOGLE_TOKEN'), {
-      timeout: 30000,
+    cy.get('#tokenInput', { timeout: 60000 }).type(Cypress.env('GOOGLE_TOKEN'), {
       log: false,
       delay: 0,
     });

--- a/cypress/integration/datasetSharing.spec.js
+++ b/cypress/integration/datasetSharing.spec.js
@@ -1,6 +1,7 @@
 const newUser = 'voldemort.admin@test.firecloud.org';
 describe(
   'test dataset sharing',
+  // this is the first integration test suite run, and it occasionally fails on setup
   {
     retries: 2,
   },

--- a/cypress/integration/datasetSharing.spec.js
+++ b/cypress/integration/datasetSharing.spec.js
@@ -10,7 +10,7 @@ describe('test dataset sharing', () => {
 
     cy.visit('/login/e2e');
     cy.get('#tokenInput').type(Cypress.env('GOOGLE_TOKEN'), {
-      timeout: 10000,
+      timeout: 30000,
       log: false,
       delay: 0,
     });

--- a/cypress/integration/datasetSharing.spec.js
+++ b/cypress/integration/datasetSharing.spec.js
@@ -1,48 +1,54 @@
 const newUser = 'voldemort.admin@test.firecloud.org';
-describe('test dataset sharing', () => {
-  beforeEach(() => {
-    cy.intercept('GET', 'api/repository/v1/datasets/**').as('getDataset');
-    cy.intercept('GET', 'api/repository/v1/datasets/**/policies').as('getDatasetPolicies');
-    cy.intercept('GET', 'api/repository/v1/datasets/**/roles').as('getDatasetRoles');
-    cy.intercept({ method: 'GET', url: 'api/resources/v1/profiles/**' }).as(
-      'getBillingProfileById',
-    );
+describe(
+  'test dataset sharing',
+  {
+    retries: 2,
+  },
+  () => {
+    beforeEach(() => {
+      cy.intercept('GET', 'api/repository/v1/datasets/**').as('getDataset');
+      cy.intercept('GET', 'api/repository/v1/datasets/**/policies').as('getDatasetPolicies');
+      cy.intercept('GET', 'api/repository/v1/datasets/**/roles').as('getDatasetRoles');
+      cy.intercept({ method: 'GET', url: 'api/resources/v1/profiles/**' }).as(
+        'getBillingProfileById',
+      );
 
-    cy.visit('/login/e2e');
-    cy.get('#tokenInput').type(Cypress.env('GOOGLE_TOKEN'), {
-      log: false,
-      delay: 0,
+      cy.visit('/login/e2e');
+      cy.get('#tokenInput').type(Cypress.env('GOOGLE_TOKEN'), {
+        log: false,
+        delay: 0,
+      });
+      cy.get('#e2eLoginButton').click();
     });
-    cy.get('#e2eLoginButton').click();
-  });
 
-  it('does not have manage users buttons when the user is not a steward', () => {
-    cy.get('[placeholder="Search keyword or description"]').type('NonStewardDataset');
-    cy.contains(/NonStewardDataset/g).should('be.visible');
-    cy.contains(/NonStewardDataset/g).click();
-    cy.get('a > .MuiButtonBase-root').click();
+    it('does not have manage users buttons when the user is not a steward', () => {
+      cy.get('[placeholder="Search keyword or description"]').type('NonStewardDataset');
+      cy.contains(/NonStewardDataset/g).should('be.visible');
+      cy.contains(/NonStewardDataset/g).click();
+      cy.get('a > .MuiButtonBase-root').click();
 
-    cy.wait(['@getDataset', '@getDatasetPolicies', '@getBillingProfileById']);
-    cy.get('[data-cy="roles-tab"]').should('not.exist');
-  });
-  it('A steward can add and remove a user to a dataset', () => {
-    cy.get('[placeholder="Search keyword or description"]').type('V2F_GWAS');
-    cy.contains(/V2F_GWAS_Summary_Stats|V2F_GWAS_Summary_Statistics/g).should('be.visible');
-    cy.contains(/V2F_GWAS_Summary_Stats|V2F_GWAS_Summary_Statistics/g).click({ force: true });
+      cy.wait(['@getDataset', '@getDatasetPolicies', '@getBillingProfileById']);
+      cy.get('[data-cy="roles-tab"]').should('not.exist');
+    });
+    it('A steward can add and remove a user to a dataset', () => {
+      cy.get('[placeholder="Search keyword or description"]').type('V2F_GWAS');
+      cy.contains(/V2F_GWAS_Summary_Stats|V2F_GWAS_Summary_Statistics/g).should('be.visible');
+      cy.contains(/V2F_GWAS_Summary_Stats|V2F_GWAS_Summary_Statistics/g).click({ force: true });
 
-    cy.wait(['@getDataset', '@getDatasetPolicies', '@getBillingProfileById']);
-    cy.get('[data-cy="roles-tab"]').click();
-    // Add user as a custodian on the dataset
-    cy.get('[data-cy="enterEmailBox"]').type(newUser);
-    cy.get('[data-cy="roleSelect"]').click();
-    cy.get('[data-cy="roleOption-custodian"]').click();
-    cy.get('[data-cy="inviteButton"]').click();
-    // Confirm the user was added
-    cy.get('[data-cy="user-list-Custodians"]').click();
-    cy.get(`[data-cy="chip-${newUser}"]`).should('be.visible');
+      cy.wait(['@getDataset', '@getDatasetPolicies', '@getBillingProfileById']);
+      cy.get('[data-cy="roles-tab"]').click();
+      // Add user as a custodian on the dataset
+      cy.get('[data-cy="enterEmailBox"]').type(newUser);
+      cy.get('[data-cy="roleSelect"]').click();
+      cy.get('[data-cy="roleOption-custodian"]').click();
+      cy.get('[data-cy="inviteButton"]').click();
+      // Confirm the user was added
+      cy.get('[data-cy="user-list-Custodians"]').click();
+      cy.get(`[data-cy="chip-${newUser}"]`).should('be.visible');
 
-    // Now, let's remove this user
-    cy.get(`[data-cy="chip-${newUser}"]`).find('[data-testid="CancelIcon"]').click();
-    cy.get(`[data-cy="chip-${newUser}"]`).should('not.exist');
-  });
-});
+      // Now, let's remove this user
+      cy.get(`[data-cy="chip-${newUser}"]`).find('[data-testid="CancelIcon"]').click();
+      cy.get(`[data-cy="chip-${newUser}"]`).should('not.exist');
+    });
+  },
+);

--- a/cypress/integration/datasetSharing.spec.js
+++ b/cypress/integration/datasetSharing.spec.js
@@ -1,28 +1,28 @@
 const newUser = 'voldemort.admin@test.firecloud.org';
-describe(
-  'test dataset sharing',
-  // this is the first integration test suite run, and it occasionally fails on setup
-  {
-    retries: 2,
-  },
-  () => {
-    beforeEach(() => {
-      cy.intercept('GET', 'api/repository/v1/datasets/**').as('getDataset');
-      cy.intercept('GET', 'api/repository/v1/datasets/**/policies').as('getDatasetPolicies');
-      cy.intercept('GET', 'api/repository/v1/datasets/**/roles').as('getDatasetRoles');
-      cy.intercept({ method: 'GET', url: 'api/resources/v1/profiles/**' }).as(
-        'getBillingProfileById',
-      );
+describe('test dataset sharing', () => {
+  beforeEach(() => {
+    cy.intercept('GET', 'api/repository/v1/datasets/**').as('getDataset');
+    cy.intercept('GET', 'api/repository/v1/datasets/**/policies').as('getDatasetPolicies');
+    cy.intercept('GET', 'api/repository/v1/datasets/**/roles').as('getDatasetRoles');
+    cy.intercept({ method: 'GET', url: 'api/resources/v1/profiles/**' }).as(
+      'getBillingProfileById',
+    );
 
-      cy.visit('/login/e2e');
-      cy.get('#tokenInput').type(Cypress.env('GOOGLE_TOKEN'), {
-        log: false,
-        delay: 0,
-      });
-      cy.get('#e2eLoginButton').click();
+    cy.visit('/login/e2e');
+    cy.get('#tokenInput').type(Cypress.env('GOOGLE_TOKEN'), {
+      log: false,
+      delay: 0,
     });
+    cy.get('#e2eLoginButton').click();
+  });
 
-    it('does not have manage users buttons when the user is not a steward', () => {
+  it(
+    'does not have manage users buttons when the user is not a steward',
+    // this is the first integration test run, and it occasionally fails on setup
+    {
+      retries: 2,
+    },
+    () => {
       cy.get('[placeholder="Search keyword or description"]').type('NonStewardDataset');
       cy.contains(/NonStewardDataset/g).should('be.visible');
       cy.contains(/NonStewardDataset/g).click();
@@ -30,26 +30,26 @@ describe(
 
       cy.wait(['@getDataset', '@getDatasetPolicies', '@getBillingProfileById']);
       cy.get('[data-cy="roles-tab"]').should('not.exist');
-    });
-    it('A steward can add and remove a user to a dataset', () => {
-      cy.get('[placeholder="Search keyword or description"]').type('V2F_GWAS');
-      cy.contains(/V2F_GWAS_Summary_Stats|V2F_GWAS_Summary_Statistics/g).should('be.visible');
-      cy.contains(/V2F_GWAS_Summary_Stats|V2F_GWAS_Summary_Statistics/g).click({ force: true });
+    },
+  );
+  it('A steward can add and remove a user to a dataset', () => {
+    cy.get('[placeholder="Search keyword or description"]').type('V2F_GWAS');
+    cy.contains(/V2F_GWAS_Summary_Stats|V2F_GWAS_Summary_Statistics/g).should('be.visible');
+    cy.contains(/V2F_GWAS_Summary_Stats|V2F_GWAS_Summary_Statistics/g).click({ force: true });
 
-      cy.wait(['@getDataset', '@getDatasetPolicies', '@getBillingProfileById']);
-      cy.get('[data-cy="roles-tab"]').click();
-      // Add user as a custodian on the dataset
-      cy.get('[data-cy="enterEmailBox"]').type(newUser);
-      cy.get('[data-cy="roleSelect"]').click();
-      cy.get('[data-cy="roleOption-custodian"]').click();
-      cy.get('[data-cy="inviteButton"]').click();
-      // Confirm the user was added
-      cy.get('[data-cy="user-list-Custodians"]').click();
-      cy.get(`[data-cy="chip-${newUser}"]`).should('be.visible');
+    cy.wait(['@getDataset', '@getDatasetPolicies', '@getBillingProfileById']);
+    cy.get('[data-cy="roles-tab"]').click();
+    // Add user as a custodian on the dataset
+    cy.get('[data-cy="enterEmailBox"]').type(newUser);
+    cy.get('[data-cy="roleSelect"]').click();
+    cy.get('[data-cy="roleOption-custodian"]').click();
+    cy.get('[data-cy="inviteButton"]').click();
+    // Confirm the user was added
+    cy.get('[data-cy="user-list-Custodians"]').click();
+    cy.get(`[data-cy="chip-${newUser}"]`).should('be.visible');
 
-      // Now, let's remove this user
-      cy.get(`[data-cy="chip-${newUser}"]`).find('[data-testid="CancelIcon"]').click();
-      cy.get(`[data-cy="chip-${newUser}"]`).should('not.exist');
-    });
-  },
-);
+    // Now, let's remove this user
+    cy.get(`[data-cy="chip-${newUser}"]`).find('[data-testid="CancelIcon"]').click();
+    cy.get(`[data-cy="chip-${newUser}"]`).should('not.exist');
+  });
+});

--- a/cypress/integration/datasetSharing.spec.js
+++ b/cypress/integration/datasetSharing.spec.js
@@ -10,28 +10,22 @@ describe('test dataset sharing', () => {
 
     cy.visit('/login/e2e');
     cy.get('#tokenInput').type(Cypress.env('GOOGLE_TOKEN'), {
+      timeout: 10000,
       log: false,
       delay: 0,
     });
     cy.get('#e2eLoginButton').click();
   });
 
-  it(
-    'does not have manage users buttons when the user is not a steward',
-    // this is the first integration test run, and it occasionally fails on setup
-    {
-      retries: 2,
-    },
-    () => {
-      cy.get('[placeholder="Search keyword or description"]').type('NonStewardDataset');
-      cy.contains(/NonStewardDataset/g).should('be.visible');
-      cy.contains(/NonStewardDataset/g).click();
-      cy.get('a > .MuiButtonBase-root').click();
+  it('does not have manage users buttons when the user is not a steward', () => {
+    cy.get('[placeholder="Search keyword or description"]').type('NonStewardDataset');
+    cy.contains(/NonStewardDataset/g).should('be.visible');
+    cy.contains(/NonStewardDataset/g).click();
+    cy.get('a > .MuiButtonBase-root').click();
 
-      cy.wait(['@getDataset', '@getDatasetPolicies', '@getBillingProfileById']);
-      cy.get('[data-cy="roles-tab"]').should('not.exist');
-    },
-  );
+    cy.wait(['@getDataset', '@getDatasetPolicies', '@getBillingProfileById']);
+    cy.get('[data-cy="roles-tab"]').should('not.exist');
+  });
   it('A steward can add and remove a user to a dataset', () => {
     cy.get('[placeholder="Search keyword or description"]').type('V2F_GWAS');
     cy.contains(/V2F_GWAS_Summary_Stats|V2F_GWAS_Summary_Statistics/g).should('be.visible');


### PR DESCRIPTION
Summary:
Adds a thirty second timeout period to the before each of the first integration test suite because we occasionally see issues where the page is still loading for the first test.
Note: Another approach we could take is adding a rerun to the integration tests in github actions
Testing:
Rerunning test runs a few times to see if we see any failures.