### PR TITLE
DT-1170 - Update App.jsx to handle auth library not yet loaded

### DIFF
--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -162,7 +162,13 @@ export function App(props) {
   const auth = useAuth();
   // This effect clause is needed to handle when the auth library loads the token on page refresh
   useEffect(() => {
-    if (auth.isAuthenticated && !auth.isLoading && !user.isAuthenticated && !auth.activeNavigator) {
+    if (
+      auth &&
+      auth.isAuthenticated &&
+      !auth.isLoading &&
+      !user.isAuthenticated &&
+      !auth.activeNavigator
+    ) {
       dispatch(logInSuccess(auth.user));
       dispatch(getUserStatus());
       auth.events.addUserLoaded((u) => dispatch(userRefresh(u)));
@@ -186,7 +192,7 @@ export function App(props) {
     }
   };
 
-  const loggingIn = status.tdrOperational && configuration.configObject.clientId && auth.isLoading;
+  const loggingIn = status.tdrOperational && configuration.configObject.clientId && auth?.isLoading;
 
   return (
     <div className={classes.root}>
@@ -243,7 +249,7 @@ export function App(props) {
       </AppBar>
       <div className={clsx(classes.content, { [classes.loggingIn]: loggingIn })}>
         {!status.tdrOperational && <ServerErrorView />}
-        {status.tdrOperational && configuration.configObject.clientId && !auth.isLoading && (
+        {status.tdrOperational && configuration.configObject.clientId && !auth?.isLoading && (
           <Switch>
             <Route path="/redirect-from-oauth" exact component={LoadingSpinner} />
             <RoutePublic
@@ -268,7 +274,7 @@ export function App(props) {
             )}
             {!user.isInitiallyLoaded && (
               <RoutePrivate
-                isAuthenticated={auth.isAuthenticated && !auth.isLoading && !user.isTest}
+                isAuthenticated={auth?.isAuthenticated && !auth?.isLoading && !user.isTest}
                 path="/"
                 component={LoadingSpinner}
               />


### PR DESCRIPTION
We're seeing intermittent failures in our e2e tests. The stacktrace suggests that it is an issue with the auth library not getting loaded before we try to access the "isLoading" field in App.jsx. This PR adds null checks to help the component more gracefully wait for the auth library to load. 

### Details
the error from cypress output:
> Cannot read properties of undefined (reading 'isLoading')

From the stacktrace:
`at App (http://localhost:3000/src/containers/App.jsx:195:90)`

The line numbers don't match up exactly, we we directly reference auth.isLoading in several places in App.jsx. I don't think it would hurt to handle this case that "auth" is undefined a little more gracefully.

Cypress run: [https://cloud.cypress.io/projects/e6ttjx/runs/3978/overview/b621a50d-ea83-43b5-ba96-4[…]-logs&roarHideRunsWithDiffGroupsAndTags=1&ts=1737432179725.8](https://cloud.cypress.io/projects/e6ttjx/runs/3978/overview/b621a50d-ea83-43b5-ba96-48419a77c3a9/replay?att=1&pc=log-http%3A%2F%2Flocalhost%3A3000-26__command-logs&roarHideRunsWithDiffGroupsAndTags=1&ts=1737432179725.8)

### Testing
One passing test run doesn't mean a whole lot. We'll see whether we continue to see this error out in the wild.