### PR TITLE
[DT-1137]After creating a snapshot - dataset tab appears selected even after selecting the snapshot tab

### DIFF
--- a/src/components/common/TabWrapper.tsx
+++ b/src/components/common/TabWrapper.tsx
@@ -1,10 +1,10 @@
 import { ClassNameMap, createStyles, withStyles } from '@mui/styles';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import Tabs from '@mui/material/Tabs';
 import { TabClasses } from '@mui/material/Tab/tabClasses';
 import Tab from '@mui/material/Tab';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import HelpContainer from 'components/help/HelpContainer';
 import history from 'modules/hist';
 import { CustomTheme } from '@mui/material/styles';
@@ -64,9 +64,13 @@ type TabWrapperProps = {
 
 function TabWrapper(props: TabWrapperProps) {
   const { classes, routes, snapshotAccessRequests } = props;
+  const [selectedTab, setSelectedTab] = React.useState<string>('datasets');
+  const location = useLocation();
 
-  const locationSplit = history.location.pathname.split('/');
-  const selectedTab = `/${locationSplit[1] || 'datasets'}`;
+  useEffect(() => {
+    const locationSplit = history.location.pathname.split('/');
+    setSelectedTab(`/${locationSplit[1] || 'datasets'}`);
+  }, [location]);
 
   const tabConfigs: Array<ITabConfig> = [
     { label: 'Datasets', path: '/datasets' },

--- a/src/components/common/TabWrapper.tsx
+++ b/src/components/common/TabWrapper.tsx
@@ -6,7 +6,6 @@ import { TabClasses } from '@mui/material/Tab/tabClasses';
 import Tab from '@mui/material/Tab';
 import { Link, useLocation } from 'react-router-dom';
 import HelpContainer from 'components/help/HelpContainer';
-import history from 'modules/hist';
 import { CustomTheme } from '@mui/material/styles';
 import { IRoute } from 'routes/Private';
 import { TdrState } from 'reducers';
@@ -68,7 +67,7 @@ function TabWrapper(props: TabWrapperProps) {
   const location = useLocation();
 
   useEffect(() => {
-    const locationSplit = history.location.pathname.split('/');
+    const locationSplit = location.pathname.split('/');
     setSelectedTab(`/${locationSplit[1] || 'datasets'}`);
   }, [location]);
 


### PR DESCRIPTION
Summary:
When changing tabs is routed through the SnapshotPopup the window goes to the correct location, but the incorrect tab is selected. This allows the selected tab to be updated whenever the window is changed. 

Changes:
add useEffect for selected tab dependent on current window location

Testing:
Just visually tested as in the video.

Before:
https://github.com/user-attachments/assets/c7d4dd5d-c0be-4d80-b803-cc5cfa2fe645

After:
https://github.com/user-attachments/assets/844fe0ae-4ca1-490c-a327-d53f27ad9122

