### PR TITLE
DT-454: Add GAR specific build action

### DIFF
--- a/.github/workflows/bump-tag-push.yaml
+++ b/.github/workflows/bump-tag-push.yaml
@@ -76,27 +76,29 @@ jobs:
         shell: bash
         run: |
           NAME="${GOOGLE_DOCKER_REPOSITORY}/${GOOGLE_PROJECT}/${REPOSITORY_NAME}/${IMAGE_NAME}"
-          TAGGED="${NAME}:$DOCKER_TAG"
+          TAGGED="${NAME}:$BUMP_TAG"
           HASHED="${NAME}:$(git rev-parse --short HEAD)"
           echo "NAME: ${NAME}"
-          echo "DOCKER_TAG: $DOCKER_TAG"
-          echo "DOCKER_TAG: ${DOCKER_TAG}"
+          echo "BUMP_TAG: $BUMP_TAG"
+          echo "BUMP_TAG: ${BUMP_TAG}"
           echo "TAGGED: ${TAGGED}"
           echo "HASHED: ${HASHED}"
           echo "NAME=${NAME}" >> "$GITHUB_ENV"
-          echo "DOCKER_TAG=$DOCKER_TAG" >> "$GITHUB_ENV"
+          echo "BUMP_TAG=$BUMP_TAG" >> "$GITHUB_ENV"
           echo "TAGGED=${TAGGED}" >> "$GITHUB_ENV"
           echo "HASHED=${HASHED}" >> "$GITHUB_ENV"
+        env:
+          BUMP_TAG: ${{ steps.tag.outputs.tag }}
       - name: Build image
         run: |
-          docker build -t $DOCKER_TAG .
-        env:
-          DOCKER_TAG: ${{ steps.tag.outputs.tag }}
+          docker build -t $BUMP_TAG .
+#        env:
+#          BUMP_TAG: ${{ steps.tag.outputs.tag }}
 
       # Publish images
       - name: Push image
         run: |
-          echo "DOCKER_TAG: $DOCKER_TAG"
+          echo "BUMP_TAG: $BUMP_TAG"
           echo "TAGGED: $TAGGED"
           echo "HASHED: $HASHED"
           docker push $TAGGED
@@ -104,7 +106,7 @@ jobs:
         if: github.event_name != 'pull_request'
         shell: bash
         run: |
-          echo "DOCKER_TAG: $DOCKER_TAG"
+          echo "BUMP_TAG: $BUMP_TAG"
           echo "TAGGED: $TAGGED"
           echo "HASHED: $HASHED"
           gcloud artifacts docker tags add \

--- a/.github/workflows/bump-tag-push.yaml
+++ b/.github/workflows/bump-tag-push.yaml
@@ -76,29 +76,29 @@ jobs:
         shell: bash
         run: |
           NAME="${GOOGLE_DOCKER_REPOSITORY}/${GOOGLE_PROJECT}/${REPOSITORY_NAME}/${IMAGE_NAME}"
-          DOCKER_TAG="${{ steps.tag.outputs.tag }}"
           TAGGED="${NAME}:${DOCKER_TAG}"
           HASHED="${NAME}:$(git rev-parse --short HEAD)"
           echo "NAME: ${NAME}"
           echo "TAGGED: ${TAGGED}"
           echo "HASHED: ${HASHED}"
-          echo "name=${NAME}" >> $GITHUB_OUTPUT
-          echo "tagged=${TAGGED}" >> $GITHUB_OUTPUT
-          echo "hashed=${HASHED}" >> $GITHUB_OUTPUT
+          echo "NAME=${NAME}" >> "$GITHUB_ENV"
+          echo "TAGGED=${TAGGED}" >> "$GITHUB_ENV"
+          echo "HASHED=${HASHED}" >> "$GITHUB_ENV"
       - name: Build image
         run: |
-          docker build -t ${{ steps.image-name.outputs.tagged }} .
+          docker build -t ${DOCKER_TAG} .
+        env:
+          DOCKER_TAG: ${{ steps.tag.outputs.tag }}
 
       # Publish images
       - name: Push image
         run: |
-          docker push ${{ steps.image-name.outputs.tagged }}
-      - name: Add latest tags to Docker image
+          docker push ${TAGGED}
+      - name: Add hashed, develop, and latest tags to Docker image
         if: github.event_name != 'pull_request'
         shell: bash
         run: |
           gcloud artifacts docker tags add \
-            "${{ steps.image-name.outputs.tagged }}" \
-            "${{ steps.image-name.outputs.hashed }}" \
-            "${{ steps.image-name.outputs.hashed }}-develop" \
-            "${{ steps.image-name.outputs.name }}:latest"
+            "${HASHED}" \
+            "${HASHED}-develop" \
+            "${NAME}:latest"

--- a/.github/workflows/bump-tag-push.yaml
+++ b/.github/workflows/bump-tag-push.yaml
@@ -80,6 +80,7 @@ jobs:
           HASHED="${NAME}:$(git rev-parse --short HEAD)"
           echo "NAME: ${NAME}"
           echo "DOCKER_TAG: $DOCKER_TAG"
+          echo "DOCKER_TAG: ${DOCKER_TAG}"
           echo "TAGGED: ${TAGGED}"
           echo "HASHED: ${HASHED}"
           echo "NAME=${NAME}" >> "$GITHUB_ENV"

--- a/.github/workflows/bump-tag-push.yaml
+++ b/.github/workflows/bump-tag-push.yaml
@@ -1,0 +1,108 @@
+name: Bump, Tag, and Publish
+# The purpose of the workflow is to:
+#  1. Bump the version number and tag the release if not a PR
+#  2. Build docker image and publish to GAR
+#
+# When run on merge to main, it tags and bumps the minor version by default. You can
+# bump other parts of the version by putting #major, #minor, or #patch in your commit
+# message.
+#
+# When run on a PR, it simulates bumping the tag and appends a hash to the pushed image.
+on:
+  workflow_dispatch: {}
+  push:
+    branches:
+      - develop
+  pull_request:
+    branches:
+      - develop
+    paths-ignore:
+      - "README.md"
+env:
+  # The project we'll be pushing artifacts to.
+  GOOGLE_PROJECT: dsp-artifact-registry
+  # Name of the app-specific Docker repository configured in GOOGLE_PROJECT.
+  # This is typically equal to the GitHub repository name.
+  REPOSITORY_NAME: ${{ github.event.repository.name }}
+  # Name of the image we'll be uploading into the Docker repository.
+  # This is often equal to the GitHub repository name, but it might also be the
+  # name of the Helm Chart if that's different.
+  IMAGE_NAME: ${{ github.event.repository.name }}
+  # This is the region-specific top-level Google-managed domain where our
+  # GOOGLE_PROJECT/REPOSITORY_NAME can be found.
+  GOOGLE_DOCKER_REPOSITORY: us-central1-docker.pkg.dev
+jobs:
+  tag-build-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: "read"
+      id-token: "write"
+    steps:
+      # Git config
+      - name: Checkout current code
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.BROADBOT_TOKEN }}
+      - name: Set up Git
+        shell: bash
+        run: |
+          git config --global user.name 'broadbot'
+          git config --global user.email 'broadbot@broadinstitute.org'
+          git fetch --all --tags
+      - name: Bump the tag to a new version
+        uses: databiosphere/github-actions/actions/bumper@bumper-0.0.6
+        id: tag
+        env:
+          DEFAULT_BUMP: minor
+          GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
+          RELEASE_BRANCHES: ${{ github.event.repository.default_branch }}
+          WITH_V: true
+
+      # GCP config
+      - name: Auth to GCP
+        id: "auth"
+        uses: google-github-actions/auth@v0
+        with:
+          workload_identity_provider: "projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider"
+          service_account: "dsp-artifact-registry-push@dsp-artifact-registry.iam.gserviceaccount.com"
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v0
+      - name: Explicitly auth Docker for Artifact Registry
+        run: gcloud auth configure-docker $GOOGLE_DOCKER_REPOSITORY --quiet
+
+      # Build images
+      - name: Construct docker image name and tags
+        id: image-name
+        shell: bash
+        run: |
+          NAME="${GOOGLE_DOCKER_REPOSITORY}/${GOOGLE_PROJECT}/${REPOSITORY_NAME}/${IMAGE_NAME}"
+          DOCKER_TAG="${{ steps.tag.outputs.tag }}"
+          TAGGED="${NAME}:${DOCKER_TAG}"
+          HASH=$(git rev-parse --short HEAD)
+          echo "NAME: ${NAME}"
+          echo "TAGGED: ${TAGGED}"
+          echo "name=${NAME}" >> $GITHUB_OUTPUT
+          echo "tagged=${TAGGED}" >> $GITHUB_OUTPUT
+          echo "hash=${HASH}" >> $GITHUB_OUTPUT
+      - name: Build image
+        run: |
+          docker build -t ${{ steps.image-name.outputs.tagged }} .
+
+      # Publish images
+      - name: Run Trivy vulnerability scanner
+        # From https://github.com/broadinstitute/dsp-appsec-trivy-action
+        uses: broadinstitute/dsp-appsec-trivy-action@v1
+        with:
+          image: ${{ steps.image-name.outputs.tagged }}
+      - name: Push image
+        run: |
+          docker push ${{ steps.image-name.outputs.tagged }}
+      - name: Add latest tags to Docker image
+        if: github.event_name != 'pull_request'
+        shell: bash
+        run: |
+          gcloud artifacts docker tags add \
+            "${{ steps.image-name.outputs.tagged }}" \
+            "${{ steps.image-name.outputs.hash }}" \
+            "${{ steps.image-name.outputs.hash }}-develop" \
+            "${{ steps.image-name.outputs.name }}:latest"

--- a/.github/workflows/bump-tag-push.yaml
+++ b/.github/workflows/bump-tag-push.yaml
@@ -78,13 +78,13 @@ jobs:
           NAME="${GOOGLE_DOCKER_REPOSITORY}/${GOOGLE_PROJECT}/${REPOSITORY_NAME}/${IMAGE_NAME}"
           DOCKER_TAG="${{ steps.tag.outputs.tag }}"
           TAGGED="${NAME}:${DOCKER_TAG}"
-          HASH=$(git rev-parse --short HEAD)
+          HASHED="${NAME}:$(git rev-parse --short HEAD)"
           echo "NAME: ${NAME}"
           echo "TAGGED: ${TAGGED}"
-          echo "HASH: ${HASH}"
+          echo "HASHED: ${HASHED}"
           echo "name=${NAME}" >> $GITHUB_OUTPUT
           echo "tagged=${TAGGED}" >> $GITHUB_OUTPUT
-          echo "hash=${HASH}" >> $GITHUB_OUTPUT
+          echo "hashed=${HASHED}" >> $GITHUB_OUTPUT
       - name: Build image
         run: |
           docker build -t ${{ steps.image-name.outputs.tagged }} .
@@ -104,6 +104,6 @@ jobs:
         run: |
           gcloud artifacts docker tags add \
             "${{ steps.image-name.outputs.tagged }}" \
-            "${{ steps.image-name.outputs.hash }}" \
-            "${{ steps.image-name.outputs.hash }}-develop" \
+            "${{ steps.image-name.outputs.hashed }}" \
+            "${{ steps.image-name.outputs.hashed }}-develop" \
             "${{ steps.image-name.outputs.name }}:latest"

--- a/.github/workflows/bump-tag-push.yaml
+++ b/.github/workflows/bump-tag-push.yaml
@@ -82,6 +82,7 @@ jobs:
           echo "TAGGED: ${TAGGED}"
           echo "HASHED: ${HASHED}"
           echo "NAME=${NAME}" >> "$GITHUB_ENV"
+          echo "DOCKER_TAG=${DOCKER_TAG}" >> "$GITHUB_ENV"
           echo "TAGGED=${TAGGED}" >> "$GITHUB_ENV"
           echo "HASHED=${HASHED}" >> "$GITHUB_ENV"
       - name: Build image

--- a/.github/workflows/bump-tag-push.yaml
+++ b/.github/workflows/bump-tag-push.yaml
@@ -92,15 +92,12 @@ jobs:
       - name: Build image
         run: |
           docker build -t $BUMP_TAG .
-#        env:
-#          BUMP_TAG: ${{ steps.tag.outputs.tag }}
+        env:
+          BUMP_TAG: ${{ steps.tag.outputs.tag }}
 
       # Publish images
       - name: Push image
         run: |
-          echo "BUMP_TAG: $BUMP_TAG"
-          echo "TAGGED: $TAGGED"
-          echo "HASHED: $HASHED"
           docker push $TAGGED
       - name: Add hashed, develop, and latest tags to Docker image
         if: github.event_name != 'pull_request'

--- a/.github/workflows/bump-tag-push.yaml
+++ b/.github/workflows/bump-tag-push.yaml
@@ -81,6 +81,7 @@ jobs:
           HASH=$(git rev-parse --short HEAD)
           echo "NAME: ${NAME}"
           echo "TAGGED: ${TAGGED}"
+          echo "HASH: ${HASH}"
           echo "name=${NAME}" >> $GITHUB_OUTPUT
           echo "tagged=${TAGGED}" >> $GITHUB_OUTPUT
           echo "hash=${HASH}" >> $GITHUB_OUTPUT

--- a/.github/workflows/bump-tag-push.yaml
+++ b/.github/workflows/bump-tag-push.yaml
@@ -79,8 +79,6 @@ jobs:
           TAGGED="${NAME}:$BUMP_TAG"
           HASHED="${NAME}:$(git rev-parse --short HEAD)"
           echo "NAME: ${NAME}"
-          echo "BUMP_TAG: $BUMP_TAG"
-          echo "BUMP_TAG: ${BUMP_TAG}"
           echo "TAGGED: ${TAGGED}"
           echo "HASHED: ${HASHED}"
           echo "NAME=${NAME}" >> "$GITHUB_ENV"
@@ -91,9 +89,7 @@ jobs:
           BUMP_TAG: ${{ steps.tag.outputs.tag }}
       - name: Build image
         run: |
-          docker build -t $BUMP_TAG .
-        env:
-          BUMP_TAG: ${{ steps.tag.outputs.tag }}
+          docker build -t $TAGGED .
 
       # Publish images
       - name: Push image
@@ -103,9 +99,6 @@ jobs:
         if: github.event_name != 'pull_request'
         shell: bash
         run: |
-          echo "BUMP_TAG: $BUMP_TAG"
-          echo "TAGGED: $TAGGED"
-          echo "HASHED: $HASHED"
           gcloud artifacts docker tags add \
             "$HASHED" \
             "$HASHED-develop" \

--- a/.github/workflows/bump-tag-push.yaml
+++ b/.github/workflows/bump-tag-push.yaml
@@ -90,11 +90,6 @@ jobs:
           docker build -t ${{ steps.image-name.outputs.tagged }} .
 
       # Publish images
-      - name: Run Trivy vulnerability scanner
-        # From https://github.com/broadinstitute/dsp-appsec-trivy-action
-        uses: broadinstitute/dsp-appsec-trivy-action@v1
-        with:
-          image: ${{ steps.image-name.outputs.tagged }}
       - name: Push image
         run: |
           docker push ${{ steps.image-name.outputs.tagged }}

--- a/.github/workflows/bump-tag-push.yaml
+++ b/.github/workflows/bump-tag-push.yaml
@@ -79,6 +79,7 @@ jobs:
           TAGGED="${NAME}:${DOCKER_TAG}"
           HASHED="${NAME}:$(git rev-parse --short HEAD)"
           echo "NAME: ${NAME}"
+          echo "DOCKER_TAG: ${DOCKER_TAG}"
           echo "TAGGED: ${TAGGED}"
           echo "HASHED: ${HASHED}"
           echo "NAME=${NAME}" >> "$GITHUB_ENV"
@@ -94,7 +95,7 @@ jobs:
       # Publish images
       - name: Push image
         run: |
-          docker push ${TAGGED}
+          docker push "${TAGGED}"
       - name: Add hashed, develop, and latest tags to Docker image
         if: github.event_name != 'pull_request'
         shell: bash

--- a/.github/workflows/bump-tag-push.yaml
+++ b/.github/workflows/bump-tag-push.yaml
@@ -61,7 +61,7 @@ jobs:
       # GCP config
       - name: Auth to GCP
         id: "auth"
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: "projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider"
           service_account: "dsp-artifact-registry-push@dsp-artifact-registry.iam.gserviceaccount.com"

--- a/.github/workflows/bump-tag-push.yaml
+++ b/.github/workflows/bump-tag-push.yaml
@@ -76,31 +76,37 @@ jobs:
         shell: bash
         run: |
           NAME="${GOOGLE_DOCKER_REPOSITORY}/${GOOGLE_PROJECT}/${REPOSITORY_NAME}/${IMAGE_NAME}"
-          TAGGED="${NAME}:${DOCKER_TAG}"
+          TAGGED="${NAME}:$DOCKER_TAG"
           HASHED="${NAME}:$(git rev-parse --short HEAD)"
           echo "NAME: ${NAME}"
-          echo "DOCKER_TAG: ${DOCKER_TAG}"
+          echo "DOCKER_TAG: $DOCKER_TAG"
           echo "TAGGED: ${TAGGED}"
           echo "HASHED: ${HASHED}"
           echo "NAME=${NAME}" >> "$GITHUB_ENV"
-          echo "DOCKER_TAG=${DOCKER_TAG}" >> "$GITHUB_ENV"
+          echo "DOCKER_TAG=$DOCKER_TAG" >> "$GITHUB_ENV"
           echo "TAGGED=${TAGGED}" >> "$GITHUB_ENV"
           echo "HASHED=${HASHED}" >> "$GITHUB_ENV"
       - name: Build image
         run: |
-          docker build -t ${DOCKER_TAG} .
+          docker build -t $DOCKER_TAG .
         env:
           DOCKER_TAG: ${{ steps.tag.outputs.tag }}
 
       # Publish images
       - name: Push image
         run: |
-          docker push "${TAGGED}"
+          echo "DOCKER_TAG: $DOCKER_TAG"
+          echo "TAGGED: $TAGGED"
+          echo "HASHED: $HASHED"
+          docker push $TAGGED
       - name: Add hashed, develop, and latest tags to Docker image
         if: github.event_name != 'pull_request'
         shell: bash
         run: |
+          echo "DOCKER_TAG: $DOCKER_TAG"
+          echo "TAGGED: $TAGGED"
+          echo "HASHED: $HASHED"
           gcloud artifacts docker tags add \
-            "${HASHED}" \
-            "${HASHED}-develop" \
-            "${NAME}:latest"
+            "$HASHED" \
+            "$HASHED-develop" \
+            "$NAME:latest"

--- a/.github/workflows/bump-tag-push.yaml
+++ b/.github/workflows/bump-tag-push.yaml
@@ -66,7 +66,7 @@ jobs:
           workload_identity_provider: "projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider"
           service_account: "dsp-artifact-registry-push@dsp-artifact-registry.iam.gserviceaccount.com"
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v2
       - name: Explicitly auth Docker for Artifact Registry
         run: gcloud auth configure-docker $GOOGLE_DOCKER_REPOSITORY --quiet
 


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-454

## Summary
We take inspiration from the [existing build job](https://github.com/DataBiosphere/jade-data-repo-ui/blob/develop/.github/workflows/dev-image-update.yaml#L25) and from an [existing Terra build process](https://github.com/DataBiosphere/biocore-data-model/blob/87e13b09b7a4050c22d63b672031b1e4d209901f/.github/workflows/build.yaml#L23). We have an [existing Trivy action](https://github.com/DataBiosphere/jade-data-repo-ui/blob/develop/.github/workflows/trivy.yml), so that is not included in this PR. We pull in the Terra bumper action which provides semantic versioning. This will supercede/replace the existing TDR `helm_tag_bump` functionality.

Images can be accessed via a suitable `firecloud.org` account:
<img width="1310" alt="Screenshot 2025-01-30 at 11 17 21 AM" src="https://github.com/user-attachments/assets/a26314f0-825c-4655-91e6-3b13dfd52411" />

## Future work
When this is complete and pushing images to GAR, we will need to:
1. Update the deployments to look for the GAR image
2. Retire image publishing to GCR
4. Retire the existing version bump process, i.e. [helmtagbump.yaml](https://github.com/DataBiosphere/jade-data-repo-ui/blob/develop/.github/workflows/helmtagbump.yaml)
5. Retire the [cherry-pick](DataBiosphere/jade-data-repo/.github/workflows/cherry-pick-image.yaml) process.