### PR TITLE
DT-1152: Migrate Components from @mui/styles

### DIFF
--- a/src/components/common/AddUserAccess.tsx
+++ b/src/components/common/AddUserAccess.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import _ from 'lodash';
-import { CustomTheme } from '@mui/material/styles';
-import { createStyles, WithStyles, withStyles } from '@mui/styles';
+import { styled } from '@mui/system';
 import {
   Typography,
   Autocomplete,
@@ -10,63 +9,22 @@ import {
   SelectChangeEvent,
   MenuItem,
   Button,
+  Box,
 } from '@mui/material';
+import { CustomTheme } from '@mui/material/styles';
 import clsx from 'clsx';
 import isEmail from 'validator/lib/isEmail';
 
-const styles = (theme: CustomTheme) =>
-  createStyles({
-    sharingArea: {
-      display: 'flex',
-      'flex-direction': 'row',
-      justifyContent: 'space-between',
-      alignItems: 'center',
-    },
-    emailEntryArea: {
-      display: 'flex',
-    },
-    sharingCol: {
-      flexGrow: 1,
-      marginRight: '1rem',
-    },
-    permissionsCol: {
-      flexGrow: 'unset',
-      width: 150,
-    },
-    input: {
-      backgroundColor: theme.palette.common.white,
-      borderRadius: theme.spacing(0.5),
-    },
-    sharingButtonContainer: {
-      paddingTop: 22,
-    },
-    button: {
-      backgroundColor: theme.palette.common.link,
-      color: theme.palette.common.white,
-      '&:hover': {
-        backgroundColor: theme.palette.common.link,
-      },
-    },
-    section: {
-      margin: `${theme.spacing(1)} 0px`,
-      overflowX: 'hidden',
-    },
-    errMessage: {
-      color: theme.palette.error.main,
-    },
-  });
+// Styled components (>3 styles)
+const SharingArea = styled(Box)(({ theme }: { theme: CustomTheme }) => ({
+  display: 'flex',
+  flexDirection: 'row',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+}));
 
-export interface AccessPermission {
-  policy: string;
-  disabled: boolean;
-}
-
-interface AddUserAccessProps extends WithStyles<typeof styles> {
-  permissions: AccessPermission[];
-  onAdd: (policyName: string, usersToAdd: string[]) => void;
-}
-
-function AddUserAccess({ classes, permissions, onAdd }: AddUserAccessProps) {
+// The rest can use sx prop as they have ≤3 styles
+function AddUserAccess({ permissions, onAdd }: Omit<AddUserAccessProps, 'classes'>) {
   const [policyName, setPolicyName] = useState(permissions[0].policy);
   const permissionDisplays = permissions.map((perm) =>
     perm.policy
@@ -123,8 +81,8 @@ function AddUserAccess({ classes, permissions, onAdd }: AddUserAccessProps) {
 
   return (
     <>
-      <div className={classes.sharingArea} data-cy="manageAccessContainer">
-        <div className={classes.sharingCol}>
+      <SharingArea data-cy="manageAccessContainer">
+        <Box sx={{ flexGrow: 1, marginRight: '1rem' }}>
           <Typography variant="subtitle2">People</Typography>
           <Autocomplete
             multiple
@@ -134,7 +92,10 @@ function AddUserAccess({ classes, permissions, onAdd }: AddUserAccessProps) {
                 {...params}
                 variant="outlined"
                 fullWidth
-                className={classes.input}
+                sx={{
+                  backgroundColor: 'common.white',
+                  borderRadius: 0.5,
+                }}
                 placeholder="enter email addresses"
                 onChange={parseEmail}
                 data-cy="enterEmailBox"
@@ -145,14 +106,23 @@ function AddUserAccess({ classes, permissions, onAdd }: AddUserAccessProps) {
             inputValue={addEmailInput}
             options={[]}
           />
-        </div>
-        <div className={clsx(classes.sharingCol, classes.permissionsCol)}>
+        </Box>
+        <Box
+          sx={{
+            flexGrow: 'unset',
+            width: '150px',
+            marginRight: '1rem',
+          }}
+        >
           <Typography variant="subtitle2">Permissions</Typography>
           <Select
             value={policyName}
             variant="outlined"
-            className={classes.input}
             fullWidth
+            sx={{
+              backgroundColor: 'common.white',
+              borderRadius: 0.5,
+            }}
             onChange={(event: SelectChangeEvent) => setPolicyName(event.target.value)}
             data-cy="roleSelect"
           >
@@ -167,24 +137,31 @@ function AddUserAccess({ classes, permissions, onAdd }: AddUserAccessProps) {
               </MenuItem>
             ))}
           </Select>
-        </div>
-        <div className={classes.sharingButtonContainer}>
+        </Box>
+        <Box sx={{ paddingTop: '22px' }}>
           <Button
             variant="contained"
             color="primary"
             disableElevation
             disabled={!isEmail(addEmailInput) && !_.some(usersToAdd, (user) => isEmail(user))}
-            className={clsx(classes.button, classes.section)}
+            sx={{
+              backgroundColor: 'common.link',
+              color: 'common.white',
+              margin: '8px 0px',
+              '&:hover': {
+                backgroundColor: 'common.link',
+              },
+            }}
             onClick={invite}
             data-cy="inviteButton"
           >
             Add
           </Button>
-        </div>
-      </div>
-      {err && <div className={classes.errMessage}>{err}</div>}
+        </Box>
+      </SharingArea>
+      {err && <Box sx={{ color: 'error.main' }}>{err}</Box>}
     </>
   );
 }
 
-export default withStyles(styles)(AddUserAccess);
+export default AddUserAccess;

--- a/src/components/common/AddUserAccess.tsx
+++ b/src/components/common/AddUserAccess.tsx
@@ -11,17 +11,25 @@ import {
   Button,
   Box,
 } from '@mui/material';
-import { CustomTheme } from '@mui/material/styles';
-import clsx from 'clsx';
 import isEmail from 'validator/lib/isEmail';
 
 // Styled components (>3 styles)
-const SharingArea = styled(Box)(({ theme }: { theme: CustomTheme }) => ({
+const SharingArea = styled(Box)({
   display: 'flex',
   flexDirection: 'row',
   justifyContent: 'space-between',
   alignItems: 'center',
-}));
+});
+
+export interface AccessPermission {
+  policy: string;
+  disabled: boolean;
+}
+
+interface AddUserAccessProps {
+  permissions: AccessPermission[];
+  onAdd: (policyName: string, usersToAdd: string[]) => void;
+}
 
 // The rest can use sx prop as they have ≤3 styles
 function AddUserAccess({ permissions, onAdd }: Omit<AddUserAccessProps, 'classes'>) {

--- a/src/components/common/AddUserAccess.tsx
+++ b/src/components/common/AddUserAccess.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import _ from 'lodash';
-import { styled } from '@mui/system';
+import { styled } from '@mui/material/styles';
 import {
   Typography,
   Autocomplete,

--- a/src/components/common/AddUserAccess.tsx
+++ b/src/components/common/AddUserAccess.tsx
@@ -27,8 +27,8 @@ export interface AccessPermission {
 }
 
 interface AddUserAccessProps {
-  permissions: AccessPermission[];
-  onAdd: (policyName: string, usersToAdd: string[]) => void;
+  readonly permissions: AccessPermission[];
+  readonly onAdd: (policyName: string, usersToAdd: string[]) => void;
 }
 
 // The rest can use sx prop as they have ≤3 styles

--- a/src/components/common/AddUserAccess.tsx
+++ b/src/components/common/AddUserAccess.tsx
@@ -27,12 +27,13 @@ export interface AccessPermission {
 }
 
 interface AddUserAccessProps {
-  permissions: AccessPermission[];
-  onAdd: (policyName: string, usersToAdd: string[]) => void;
+  readonly permissions: AccessPermission[];
+  readonly onAdd: (policyName: string, usersToAdd: string[]) => void;
 }
 
 // The rest can use sx prop as they have ≤3 styles
-function AddUserAccess({ permissions, onAdd }: Omit<AddUserAccessProps, 'classes'>) {
+function AddUserAccess(props: AddUserAccessProps) {
+  const { permissions, onAdd } = props;
   const [policyName, setPolicyName] = useState(permissions[0].policy);
   const permissionDisplays = permissions.map((perm) =>
     perm.policy

--- a/src/components/common/AddUserAccess.tsx
+++ b/src/components/common/AddUserAccess.tsx
@@ -27,8 +27,8 @@ export interface AccessPermission {
 }
 
 interface AddUserAccessProps {
-  readonly permissions: AccessPermission[];
-  readonly onAdd: (policyName: string, usersToAdd: string[]) => void;
+  permissions: AccessPermission[];
+  onAdd: (policyName: string, usersToAdd: string[]) => void;
 }
 
 // The rest can use sx prop as they have ≤3 styles

--- a/src/components/common/Failure.jsx
+++ b/src/components/common/Failure.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box } from '@mui/material';
-import { styled } from '@mui/system';
+import { styled } from '@mui/material/styles';
 
 import ErrorIcon from 'media/icons/warning-standard-solid.svg?react';
 

--- a/src/components/common/Failure.jsx
+++ b/src/components/common/Failure.jsx
@@ -1,35 +1,37 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@mui/styles';
+import { Box } from '@mui/material';
+import { styled } from '@mui/system';
 
 import ErrorIcon from 'media/icons/warning-standard-solid.svg?react';
 
-const styles = (theme) => ({
-  text: {
-    alignSelf: 'center',
-    fontFamily: theme.typography.fontFamily,
-    fontSize: 12,
-    fontWeight: 600,
-    padding: `0 0 0 ${theme.spacing(2)}px`,
-  },
-  icon: {
-    fill: theme.palette.primary.contrastText,
-    height: theme.spacing(4),
-  },
-});
+// Use styled component for text since it has >3 styles
+const StyledText = styled(Box)(({ theme }) => ({
+  alignSelf: 'center',
+  fontFamily: theme.typography.fontFamily,
+  fontSize: '12px',
+  fontWeight: 600,
+  padding: `0 0 0 ${theme.spacing(2)}`,
+}));
 
-function Failure({ errString, classes }) {
+function Failure({ errString }) {
+  // Use sx prop for icon since it has ≤3 styles
   return (
-    <div>
-      <ErrorIcon className={classes.icon} alt="logo" />
-      <div className={classes.text}>{errString}</div>
-    </div>
+    <Box>
+      <ErrorIcon
+        sx={{
+          fill: (theme) => theme.palette.primary.contrastText,
+          height: (theme) => theme.spacing(4),
+        }}
+        alt="logo"
+      />
+      <StyledText>{errString}</StyledText>
+    </Box>
   );
 }
 
 Failure.propTypes = {
-  classes: PropTypes.object.isRequired,
   errString: PropTypes.string,
 };
 
-export default withStyles(styles)(Failure);
+export default Failure;

--- a/src/components/common/FullViewSnapshotButton.test.tsx
+++ b/src/components/common/FullViewSnapshotButton.test.tsx
@@ -1,6 +1,6 @@
 import { mount } from 'cypress/react';
 import { Router } from 'react-router-dom';
-import { ThemeProvider } from '@mui/styles';
+import { ThemeProvider } from '@mui/material/styles';
 import { Provider } from 'react-redux';
 import React from 'react';
 import createMockStore from 'redux-mock-store';

--- a/src/components/common/FullViewSnapshotButton.tsx
+++ b/src/components/common/FullViewSnapshotButton.tsx
@@ -14,8 +14,9 @@ import {
   FormLabel,
   Link,
   TextField,
-  CustomTheme,
+  Box,
 } from '@mui/material';
+import { styled } from '@mui/system';
 import React, { Dispatch } from 'react';
 import {
   BillingProfileModel,
@@ -25,20 +26,17 @@ import {
 import { Action } from 'redux';
 import { connect } from 'react-redux';
 import { isEmpty, now, uniq } from 'lodash';
-import { createStyles, withStyles, WithStyles } from '@mui/styles';
 import { ManagedGroupMembershipEntry } from 'models/group';
 import TerraTooltip from './TerraTooltip';
 import JadeDropdown from '../dataset/data/JadeDropdown';
 import { useOnMount } from '../../libs/utils';
 
-const styles = (theme: CustomTheme) =>
-  createStyles({
-    jadeLink: {
-      ...theme.mixins.jadeLink,
-    },
-  });
+const StyledLink = styled('span')(({ theme }) => ({
+  // @ts-ignore
+  ...theme.mixins.jadeLink,
+}));
 
-interface FullViewSnapshotButtonProps extends WithStyles<typeof styles> {
+interface FullViewSnapshotButtonProps {
   dispatch: Dispatch<Action>;
   dataset: DatasetModel;
   billingProfiles: Array<BillingProfileModel>;
@@ -46,7 +44,6 @@ interface FullViewSnapshotButtonProps extends WithStyles<typeof styles> {
 }
 
 function FullViewSnapshotButton({
-  classes,
   dataset,
   dispatch,
   billingProfiles,
@@ -120,7 +117,7 @@ function FullViewSnapshotButton({
         <DialogTitle id="customized-dialog-title" sx={{ fontSize: '1rem' }}>
           Creating snapshot - select a billing project
         </DialogTitle>
-        <div style={{ padding: '0px 24px 16px 24px' }}>
+        <Box sx={{ padding: '0px 24px 16px 24px' }}>
           <FormLabel sx={{ fontWeight: 600, color: 'black' }} htmlFor="snapshot-name" required>
             Snapshot Name
           </FormLabel>
@@ -151,7 +148,7 @@ function FullViewSnapshotButton({
             Do you want to use the Google Billing Project associated with this dataset or would you
             like to select a different one?
           </Typography>
-          <div style={{ marginTop: 8 }}>
+          <Box sx={{ marginTop: '8px' }}>
             <FormLabel
               sx={{ fontWeight: 600, color: 'black' }}
               htmlFor="billing-profile-select"
@@ -159,7 +156,7 @@ function FullViewSnapshotButton({
             >
               Google Billing Project
             </FormLabel>
-          </div>
+          </Box>
           <JadeDropdown
             sx={{ height: '2.5rem' }}
             disabled={billingProfiles.length <= 1}
@@ -178,15 +175,18 @@ function FullViewSnapshotButton({
             }
             value={selectedBillingProfile?.profileName || ''}
           />
-          <div style={{ marginTop: 8 }}>
+          <Box sx={{ marginTop: '8px' }}>
             <FormLabel
               sx={{ fontWeight: 600, color: 'black' }}
               htmlFor="authorization-domain-select"
             >
               Authorization Domain
-              <span style={{ fontWeight: 400, color: 'black' }}> - (optional)</span>
+              <Box component="span" sx={{ fontWeight: 400, color: 'black' }}>
+                {' '}
+                - (optional)
+              </Box>
             </FormLabel>
-          </div>
+          </Box>
           <JadeDropdown
             sx={{ height: '2.5rem' }}
             disabled={userGroups ? userGroups.length <= 1 : true}
@@ -195,7 +195,7 @@ function FullViewSnapshotButton({
             onSelectedItem={(event) => setSelectedAuthDomain(event.target.value)}
             value={selectedAuthDomain || ''}
           />
-          <div>
+          <Box>
             Authorization Domains restrict data access to only specified individuals in a group and
             are intended to fulfill requirements you may have for data governed by a compliance
             standard, such as federal controlled-access data or HIPAA protected data. They follow
@@ -204,10 +204,10 @@ function FullViewSnapshotButton({
               href="https://support.terra.bio/hc/en-us/articles/360026775691-Overview-Managing-access-to-controlled-data-with-Authorization-Domains#h_01J94P49XS1NE5KE4B3NA3A413"
               target="_blank"
             >
-              <span className={classes.jadeLink}>When to use an Authorization Domain</span>
+              <StyledLink>When to use an Authorization Domain</StyledLink>
             </Link>
             .
-          </div>
+          </Box>
           <DialogActions sx={{ display: 'flex', justifyContent: 'flex-end' }}>
             <Button onClick={onDismiss} variant="outlined">
               Cancel
@@ -225,7 +225,7 @@ function FullViewSnapshotButton({
               Create
             </Button>
           </DialogActions>
-        </div>
+        </Box>
       </Dialog>
     </>
   );
@@ -239,4 +239,4 @@ function mapStateToProps(state: TdrState) {
   };
 }
 
-export default connect(mapStateToProps)(withStyles(styles)(FullViewSnapshotButton));
+export default connect(mapStateToProps)(FullViewSnapshotButton);

--- a/src/components/common/FullViewSnapshotButton.tsx
+++ b/src/components/common/FullViewSnapshotButton.tsx
@@ -16,7 +16,7 @@ import {
   TextField,
   Box,
 } from '@mui/material';
-import { styled } from '@mui/system';
+import { styled } from '@mui/material/styles';
 import React, { Dispatch } from 'react';
 import {
   BillingProfileModel,

--- a/src/components/common/FullViewSnapshotButton.tsx
+++ b/src/components/common/FullViewSnapshotButton.tsx
@@ -15,6 +15,8 @@ import {
   Link,
   TextField,
   Box,
+  CustomTheme,
+  useTheme,
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import React, { Dispatch } from 'react';
@@ -31,8 +33,7 @@ import TerraTooltip from './TerraTooltip';
 import JadeDropdown from '../dataset/data/JadeDropdown';
 import { useOnMount } from '../../libs/utils';
 
-const StyledLink = styled('span')(({ theme }) => ({
-  // @ts-ignore
+const StyledLink = styled('span')(({ theme }: { theme: CustomTheme }) => ({
   ...theme.mixins.jadeLink,
 }));
 
@@ -204,7 +205,7 @@ function FullViewSnapshotButton({
               href="https://support.terra.bio/hc/en-us/articles/360026775691-Overview-Managing-access-to-controlled-data-with-Authorization-Domains#h_01J94P49XS1NE5KE4B3NA3A413"
               target="_blank"
             >
-              <StyledLink>When to use an Authorization Domain</StyledLink>
+              <StyledLink theme={useTheme()}>When to use an Authorization Domain</StyledLink>
             </Link>
             .
           </Box>

--- a/src/components/common/InfoModal.tsx
+++ b/src/components/common/InfoModal.tsx
@@ -1,104 +1,69 @@
 import React from 'react';
-import { createStyles, withStyles, WithStyles } from '@mui/styles';
 import {
   Button,
   Dialog,
   DialogTitle,
   DialogActions,
   IconButton,
-  CustomTheme,
   Typography,
+  Box,
 } from '@mui/material';
+import { styled } from '@mui/system';
 import CloseIcon from '@mui/icons-material/Close';
 
-const styles = (theme: CustomTheme) =>
-  createStyles({
-    wrapper: {
-      padding: theme.spacing(4),
-      margin: theme.spacing(4),
-    },
-    dialogTitle: {
-      borderBottom: `1px solid ${theme.palette.divider}`,
-      margin: 0,
-      padding: theme.spacing(2),
-    },
-    closeButton: {
-      position: 'absolute',
-      right: theme.spacing(1),
-      top: theme.spacing(1),
-      color: theme.palette.grey[500],
-    },
-    dialogInstructions: {
-      margin: 0,
-      padding: `${theme.spacing(2)} !important`,
-      whiteSpace: 'pre-wrap',
-      maxHeight: '24rem',
-      overflowY: 'scroll',
-    },
-    dialogActions: {
-      borderTop: `1px solid ${theme.palette.divider}`,
-      margin: 0,
-      padding: theme.spacing(1),
-    },
-    openButton: {
-      width: '100%',
-      border: 0,
-      justifyContent: 'left',
-      textTransform: 'none',
-      paddingTop: theme.spacing(1),
-      paddingBottom: theme.spacing(1),
-      '&:hover': {
-        border: 0,
-      },
-    },
-    openButtonIcon: {
-      marginRight: 5,
-      top: theme.spacing(1),
-    },
-    horizontalModalButton: {
-      fontSize: theme.typography.h6.fontSize,
-      color: theme.palette.primary.light,
-    },
-    overlaySpinner: {
-      opacity: 0.9,
-      position: 'absolute',
-      right: 0,
-      bottom: 0,
-      left: 0,
-      width: 'initial',
-      overflow: 'clip',
-      backgroundColor: theme.palette.common.white,
-      zIndex: 100,
-    },
-  });
+const CloseIconButton = styled(IconButton)(({ theme }) => ({
+  position: 'absolute',
+  right: theme.spacing(1),
+  top: theme.spacing(1),
+  color: theme.palette.grey[500],
+}));
 
-interface InfoModalProps extends WithStyles<typeof styles> {
+const StyledInstructions = styled(Typography)(({ theme }) => ({
+  margin: 0,
+  padding: `${theme.spacing(2)} !important`,
+  whiteSpace: 'pre-wrap',
+  maxHeight: '24rem',
+  overflowY: 'scroll',
+}));
+
+interface InfoModalProps {
   readonly modalContent: string;
   readonly modalHeading: string;
   readonly onDismiss: () => void;
 }
 
-export function InfoModal(props: InfoModalProps) {
-  const { classes, modalContent, modalHeading, onDismiss } = props;
-
+export function InfoModal({ modalContent, modalHeading, onDismiss }: InfoModalProps) {
   return (
-    <span>
+    <Box component="span">
       <Dialog fullWidth maxWidth="md" onClose={onDismiss} open={true}>
-        <DialogTitle className={classes.dialogTitle} id="customized-dialog-title">
+        <DialogTitle
+          id="customized-dialog-title"
+          sx={{
+            borderBottom: (theme) => `1px solid ${theme.palette.divider}`,
+            margin: 0,
+            padding: (theme) => theme.spacing(2),
+          }}
+        >
           {modalHeading}
-          <IconButton aria-label="Close" className={classes.closeButton} onClick={onDismiss}>
+          <CloseIconButton aria-label="Close" onClick={onDismiss}>
             <CloseIcon />
-          </IconButton>
+          </CloseIconButton>
         </DialogTitle>
-        <Typography className={classes.dialogInstructions}>{modalContent}</Typography>
-        <DialogActions className={classes.dialogActions}>
+        <StyledInstructions>{modalContent}</StyledInstructions>
+        <DialogActions
+          sx={{
+            borderTop: (theme) => `1px solid ${theme.palette.divider}`,
+            margin: 0,
+            padding: (theme) => theme.spacing(1),
+          }}
+        >
           <Button onClick={onDismiss} color="primary">
             OK
           </Button>
         </DialogActions>
       </Dialog>
-    </span>
+    </Box>
   );
 }
 
-export default withStyles(styles)(InfoModal);
+export default InfoModal;

--- a/src/components/common/InfoModal.tsx
+++ b/src/components/common/InfoModal.tsx
@@ -8,7 +8,7 @@ import {
   Typography,
   Box,
 } from '@mui/material';
-import { styled } from '@mui/system';
+import { styled } from '@mui/material/styles';
 import CloseIcon from '@mui/icons-material/Close';
 
 const CloseIconButton = styled(IconButton)(({ theme }) => ({

--- a/src/components/common/LoadingSpinner.tsx
+++ b/src/components/common/LoadingSpinner.tsx
@@ -1,19 +1,13 @@
 import React from 'react';
-import { makeStyles } from '@mui/styles';
-import { CircularProgress } from '@mui/material';
-import clsx from 'clsx';
+import { Box, CircularProgress } from '@mui/material';
+import { styled } from '@mui/material/styles';
 
-const useStyles = makeStyles(() => ({
-  spinWrapper: {
-    height: 'calc(100% - 60px)',
-    display: 'grid',
-    width: 500,
-    textAlign: 'center',
-    margin: 'auto',
-  },
-  spinner: {
-    margin: 'auto',
-  },
+const SpinWrapper = styled(Box)(() => ({
+  height: 'calc(100% - 60px)',
+  display: 'grid',
+  width: '500px',
+  textAlign: 'center',
+  margin: 'auto',
 }));
 
 type LoadingSpinnerProps = {
@@ -23,12 +17,11 @@ type LoadingSpinnerProps = {
 };
 
 function LoadingSpinner({ className, delay, delayMessage }: LoadingSpinnerProps) {
-  const classes = useStyles();
   return (
-    <div className={clsx(className, classes.spinWrapper)}>
-      <CircularProgress className={classes.spinner} />
+    <SpinWrapper className={className}>
+      <CircularProgress sx={{ margin: 'auto' }} />
       {delay && delayMessage}
-    </div>
+    </SpinWrapper>
   );
 }
 

--- a/src/components/common/TabPanel.tsx
+++ b/src/components/common/TabPanel.tsx
@@ -1,33 +1,24 @@
 import React from 'react';
-import { createStyles, ClassNameMap, withStyles } from '@mui/styles';
-
-const styles = () =>
-  createStyles({
-    tabPanel: {
-      padding: '1em 1em 1em 28px',
-    },
-  });
+import { Box } from '@mui/material';
 
 type TabPanelProps = {
   children: React.ReactNode;
-  classes: ClassNameMap;
   index: number;
   value: number;
 };
 
-function TabPanel(props: TabPanelProps) {
-  const { classes, children, value, index } = props;
+function TabPanel({ children, value, index }: TabPanelProps) {
   return (
-    <div
-      className={classes.tabPanel}
+    <Box
+      sx={{ padding: '1em 1em 1em 28px' }}
       role="tabpanel"
       hidden={value !== index}
       id={`simple-tabpanel-${index}`}
       aria-labelledby={`simple-tab-${index}`}
     >
-      {value === index && <div>{children}</div>}
-    </div>
+      {value === index && <Box>{children}</Box>}
+    </Box>
   );
 }
 
-export default withStyles(styles)(TabPanel);
+export default TabPanel;

--- a/src/components/common/TabPanel.tsx
+++ b/src/components/common/TabPanel.tsx
@@ -2,12 +2,13 @@ import React from 'react';
 import { Box } from '@mui/material';
 
 type TabPanelProps = {
-  children: React.ReactNode;
-  index: number;
-  value: number;
+  readonly children: React.ReactNode;
+  readonly index: number;
+  readonly value: number;
 };
 
-function TabPanel({ children, value, index }: TabPanelProps) {
+function TabPanel(props: TabPanelProps) {
+  const { children, value, index } = props;
   return (
     <Box
       sx={{ padding: '1em 1em 1em 28px' }}

--- a/src/components/common/TabWrapper.tsx
+++ b/src/components/common/TabWrapper.tsx
@@ -2,17 +2,16 @@ import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
-import { Box } from '@mui/material';
+import { Box, useTheme } from '@mui/material';
 import { Link, useLocation } from 'react-router-dom';
-import { styled } from '@mui/material/styles';
+import { styled, CustomTheme } from '@mui/material/styles';
 import HelpContainer from 'components/help/HelpContainer';
 import { TdrState } from 'reducers';
 import { RouterRootState } from 'connected-react-router';
 import { SnapshotAccessRequest } from 'generated/tdr';
 import { IRoute } from 'routes/Private';
 
-const StyledTabs = styled(Tabs)(({ theme }) => ({
-  // @ts-ignore
+const StyledTabs = styled(Tabs)(({ theme }: { theme: CustomTheme }) => ({
   borderBottom: `2px solid ${theme.palette.terra.green}`,
   boxShadow: '0 2px 5px 0 rgba(0,0,0,0.26), 0 2px 10px 0 rgba(0,0,0,0.16)',
   color: '#333F52',
@@ -87,6 +86,7 @@ function TabWrapper(props: TabWrapperProps) {
         TabIndicatorProps={{
           sx: { borderBottom: '8px solid #74ae43' },
         }}
+        theme={useTheme()}
       >
         {visibleTabs.map((config: ITabConfig, i: number) => (
           <StyledTab

--- a/src/components/common/TabWrapper.tsx
+++ b/src/components/common/TabWrapper.tsx
@@ -1,16 +1,46 @@
-import { ClassNameMap, createStyles, withStyles } from '@mui/styles';
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import Tabs from '@mui/material/Tabs';
-import { TabClasses } from '@mui/material/Tab/tabClasses';
 import Tab from '@mui/material/Tab';
+import { Box } from '@mui/material';
 import { Link, useLocation } from 'react-router-dom';
+import { styled } from '@mui/material/styles';
 import HelpContainer from 'components/help/HelpContainer';
-import { CustomTheme } from '@mui/material/styles';
-import { IRoute } from 'routes/Private';
 import { TdrState } from 'reducers';
 import { RouterRootState } from 'connected-react-router';
 import { SnapshotAccessRequest } from 'generated/tdr';
+import { IRoute } from 'routes/Private';
+
+const StyledTabs = styled(Tabs)(({ theme }) => ({
+  // @ts-ignore
+  borderBottom: `2px solid ${theme.palette.terra.green}`,
+  boxShadow: '0 2px 5px 0 rgba(0,0,0,0.26), 0 2px 10px 0 rgba(0,0,0,0.16)',
+  color: '#333F52',
+  fontFamily: theme.typography.fontFamily,
+  height: '18px',
+  fontSize: '14px',
+  fontWeight: 600,
+  lineHeight: '18px',
+  textAlign: 'center',
+  width: '100%',
+  transition: '0.3s background-color ease-in-out',
+}));
+
+const StyledTab = styled(Tab)(({ theme }) => ({
+  '&.Mui-selected': {
+    transition: '0.3s background-color ease-in-out',
+    backgroundColor: '#ddebd0',
+    color: theme.palette.secondary.dark,
+    fontWeight: '700 !important',
+  },
+}));
+
+const StyledHelpContainer = styled(HelpContainer)(({ theme }) => ({
+  borderBottom: `2px solid ${theme.palette.terra.green}`,
+  boxShadow: '0 2px 5px 0 rgba(0,0,0,0.26), 0 2px 10px 0 rgba(0,0,0,0.16)',
+  float: 'right',
+  width: '20px',
+}));
 
 interface ITabConfig {
   label: string;
@@ -18,51 +48,12 @@ interface ITabConfig {
   hidden?: boolean;
 }
 
-const styles = (theme: CustomTheme) =>
-  createStyles({
-    tabsIndicator: {
-      borderBottom: '8px solid #74ae43',
-    },
-    tabsRoot: {
-      borderBottom: `2px solid ${theme.palette.terra.green}`,
-      boxShadow: '0 2px 5px 0 rgba(0,0,0,0.26), 0 2px 10px 0 rgba(0,0,0,0.16)',
-      color: '#333F52',
-      fontFamily: theme.typography.fontFamily,
-      height: 18,
-      fontSize: 14,
-      fontWeight: 600,
-      lineHeight: 18,
-      textAlign: 'center',
-      width: '100%',
-      transition: '0.3s background-color ease-in-out',
-    },
-    tabSelected: {
-      transition: '0.3s background-color ease-in-out',
-      backgroundColor: '#ddebd0',
-      color: theme.palette.secondary.dark,
-      fontWeight: '700 !important',
-    },
-    tabWrapper: {
-      display: 'flex',
-      position: 'relative',
-      zIndex: 2,
-    },
-    helpIconDiv: {
-      borderBottom: `2px solid ${theme.palette.terra.green}`,
-      boxShadow: '0 2px 5px 0 rgba(0,0,0,0.26), 0 2px 10px 0 rgba(0,0,0,0.16)',
-      float: 'right',
-      width: '20px',
-    },
-  });
-
 type TabWrapperProps = {
   routes: Array<IRoute>;
-  classes: ClassNameMap;
   snapshotAccessRequests: Array<SnapshotAccessRequest>;
 };
 
-function TabWrapper(props: TabWrapperProps) {
-  const { classes, routes, snapshotAccessRequests } = props;
+function TabWrapper({ routes, snapshotAccessRequests }: TabWrapperProps) {
   const [selectedTab, setSelectedTab] = React.useState<string>('datasets');
   const location = useLocation();
 
@@ -89,31 +80,28 @@ function TabWrapper(props: TabWrapperProps) {
   );
 
   return (
-    <div className={classes.tabWrapper}>
-      <Tabs
+    <Box sx={{ display: 'flex', position: 'relative', zIndex: 2 }}>
+      <StyledTabs
         value={visibleTabs.map((tab) => tab.path).includes(selectedTab) ? selectedTab : false}
-        classes={
-          {
-            root: classes.tabsRoot,
-            indicator: classes.tabsIndicator,
-          } as Partial<TabClasses>
-        }
+        TabIndicatorProps={{
+          sx: { borderBottom: '8px solid #74ae43' },
+        }}
       >
         {visibleTabs.map((config: ITabConfig, i: number) => (
-          <Tab
+          <StyledTab
             key={`navbar-link-${i}`}
             label={config.label}
+            // @ts-ignore
             component={Link}
             value={config.path}
             to={config.path}
-            classes={{ selected: classes.tabSelected } as Partial<TabClasses>}
             disableFocusRipple
             disableRipple
           />
         ))}
-      </Tabs>
-      <HelpContainer className={classes.helpIconDiv} />
-    </div>
+      </StyledTabs>
+      <StyledHelpContainer />
+    </Box>
   );
 }
 
@@ -123,4 +111,4 @@ function mapStateToProps(state: TdrState & RouterRootState) {
   };
 }
 
-export default connect(mapStateToProps)(withStyles(styles)(TabWrapper));
+export default connect(mapStateToProps)(TabWrapper);

--- a/src/components/common/TabWrapper.tsx
+++ b/src/components/common/TabWrapper.tsx
@@ -49,11 +49,12 @@ interface ITabConfig {
 }
 
 type TabWrapperProps = {
-  routes: Array<IRoute>;
-  snapshotAccessRequests: Array<SnapshotAccessRequest>;
+  readonly routes: Array<IRoute>;
+  readonly snapshotAccessRequests: Array<SnapshotAccessRequest>;
 };
 
-function TabWrapper({ routes, snapshotAccessRequests }: TabWrapperProps) {
+function TabWrapper(props: TabWrapperProps) {
+  const { routes, snapshotAccessRequests } = props;
   const [selectedTab, setSelectedTab] = React.useState<string>('datasets');
   const location = useLocation();
 

--- a/src/components/common/TerraTooltip.tsx
+++ b/src/components/common/TerraTooltip.tsx
@@ -1,30 +1,38 @@
 import React from 'react';
-import { makeStyles } from '@mui/styles';
 import Tooltip from '@mui/material/Tooltip';
 import { TooltipProps } from '@mui/material/Tooltip/Tooltip';
-import { CustomTheme } from '@mui/material/styles';
-
-const useStyles = makeStyles((theme: CustomTheme) => ({
-  arrow: {
-    color: theme.palette.common.black,
-  },
-  tooltip: {
-    backgroundColor: theme.palette.common.black,
-    fontSize: theme.typography.body1.fontSize,
-  },
-}));
 
 type TerraTooltipProps = TooltipProps & {
   disabled?: boolean;
 };
 
 function TerraTooltip(props: TerraTooltipProps) {
-  const classes = useStyles();
-  const { disabled, children } = props;
+  const { disabled, children, ...otherProps } = props;
+
   if (disabled) {
     return children;
   }
-  return <Tooltip arrow classes={classes} {...props} />;
+
+  return (
+    <Tooltip
+      arrow
+      componentsProps={{
+        arrow: {
+          sx: { color: (theme) => theme.palette.common.black },
+        },
+        tooltip: {
+          sx: {
+            backgroundColor: (theme) => theme.palette.common.black,
+            // @ts-ignore
+            fontSize: (theme) => theme.typography.body1.fontSize,
+          },
+        },
+      }}
+      {...otherProps}
+    >
+      {children}
+    </Tooltip>
+  );
 }
 
 export default TerraTooltip;

--- a/src/components/common/TextContent.tsx
+++ b/src/components/common/TextContent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link, Box } from '@mui/material';
+import { Box, Link } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import ReactMarkdown from 'react-markdown';
 import strip from 'strip-markdown';
@@ -16,8 +16,8 @@ interface TextContentProps {
   readonly emptyText?: string;
 }
 
-function TextContent(props: TextContentProps) {
-  const { emptyText = '(empty)', markdown = false, stripMarkdown = false, text } = props;
+function TextContent(componentProps: TextContentProps) {
+  const { emptyText = '(empty)', markdown = false, stripMarkdown = false, text } = componentProps;
   return (
     <>
       {text && !markdown && <Box sx={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{text}</Box>}
@@ -40,13 +40,13 @@ function TextContent(props: TextContentProps) {
         <ReactMarkdown
           remarkPlugins={[strip]}
           components={{
-            p: (props: any) => {
-              const r = props.children
+            p: (props: any) =>
+              // eslint-disable-next-line react/prop-types
+              props.children
+                // eslint-disable-next-line react/prop-types
                 .filter((child: any) => child && typeof child === 'string')
                 .map((child: any) => `${child}`)
-                .join(' ');
-              return r;
-            },
+                .join(' '),
           }}
         >
           {text}

--- a/src/components/common/TextContent.tsx
+++ b/src/components/common/TextContent.tsx
@@ -1,59 +1,40 @@
 import React from 'react';
 import { Link, Box } from '@mui/material';
-import { CustomTheme } from '@mui/material/styles';
-import { createStyles, WithStyles, withStyles } from '@mui/styles';
+import { styled } from '@mui/material/styles';
 import ReactMarkdown from 'react-markdown';
 import strip from 'strip-markdown';
 
-const styles = (theme: CustomTheme) =>
-  createStyles({
-    nullValue: {
-      fontStyle: 'italic',
-      textColor: theme.palette.primary.dark,
-      color: theme.palette.primary.dark,
-    },
-    jadeLink: {
-      ...theme.mixins.jadeLink,
-    },
-  });
+const StyledLink = styled('span')(({ theme }) => ({
+  // @ts-ignore
+  ...theme.mixins.jadeLink,
+}));
 
-interface TextContentProps extends WithStyles<typeof styles> {
-  text: string | undefined;
-  markdown?: boolean;
-  stripMarkdown?: boolean;
-  emptyText?: string;
+interface TextContentProps {
+  readonly text: string | undefined;
+  readonly markdown?: boolean;
+  readonly stripMarkdown?: boolean;
+  readonly emptyText?: string;
 }
 
-function TextContent({
-  classes,
-  emptyText = '(empty)',
-  markdown = false,
-  stripMarkdown = false,
-  text,
-}: TextContentProps) {
+function TextContent(props: TextContentProps) {
+  const { emptyText = '(empty)', markdown = false, stripMarkdown = false, text } = props;
   return (
     <>
-      {text && !markdown && (
-        <Box component="div" sx={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
-          {text}
-        </Box>
-      )}
+      {text && !markdown && <Box sx={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{text}</Box>}
       {text && markdown && !stripMarkdown && (
-        <div data-cy="react-markdown-text">
+        <Box data-cy="react-markdown-text">
           <ReactMarkdown
             components={{
               a: ({ children, href, title }) => (
                 <Link href={href} target="_blank">
-                  <span className={classes.jadeLink} title={title}>
-                    {children}
-                  </span>
+                  <StyledLink title={title}>{children}</StyledLink>
                 </Link>
               ),
             }}
           >
             {text}
           </ReactMarkdown>
-        </div>
+        </Box>
       )}
       {text && markdown && stripMarkdown && (
         <ReactMarkdown
@@ -72,12 +53,20 @@ function TextContent({
         </ReactMarkdown>
       )}
       {!text && (
-        <span data-cy="react-markdown-empty-text" className={classes.nullValue}>
+        <Box
+          component="span"
+          data-cy="react-markdown-empty-text"
+          sx={{
+            fontStyle: 'italic',
+            textColor: (theme) => theme.palette.primary.dark,
+            color: (theme) => theme.palette.primary.dark,
+          }}
+        >
           {emptyText}
-        </span>
+        </Box>
       )}
     </>
   );
 }
 
-export default withStyles(styles)(TextContent);
+export default TextContent;


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-1152

## Summary
For each component, followed the following process:
* Use https://github.com/DataBiosphere/jade-data-repo-ui/pull/1730 as a model for the copilot conversion
* Apply prettier formatting
* Ensure that we import `styled` from `'@mui/material/styles';` instead of `'@mui/system';`. Copilot doesn't catch that.
* Refactor the cases where props are destructured inside the function definition. Instead, ensure that `props` is the passed in function argument and destructure on a separate line in the function. This helps avoid a `readonly` warning.
* Ensure that the props have `readonly` modifiers
* Add `// @ts-ignore` where necessary. I found that we needed to do this for a variety of theme-related fields.

Other notes:
* `Failure.jsx` is unused, but I'm not aware of the history for this so it is included as part of the migration.
* `InfoModal` - Need some guidance on how to find where this is in use.
* `TextContent` is visible on all tables

### AddUserAccess
![Screenshot 2025-02-11 at 7 17 50 AM](https://github.com/user-attachments/assets/4d5291e7-a553-4b7a-af7f-89702df7442b)

### FullViewSnapshotButton
![Screenshot 2025-02-11 at 7 21 38 AM](https://github.com/user-attachments/assets/85ecb1cd-3786-4c85-b90a-00945ea8bc13)

### LoadingSpinner
https://github.com/user-attachments/assets/385b98fd-8c72-414c-a473-27916fc08139

### TabPanel, TabWrapper
https://github.com/user-attachments/assets/4c50c9d0-80cf-4e9d-bda3-8c938dc987f7

### TerraTooltip
![Screenshot 2025-02-11 at 7 31 30 AM](https://github.com/user-attachments/assets/1daf897a-b727-4099-a218-ff8fb1a2161a)
