### PR TITLE
DT-1219: Allow un-selecting auth domains on snapshot create

### DIFF
--- a/src/components/common/FullViewSnapshotButton.test.tsx
+++ b/src/components/common/FullViewSnapshotButton.test.tsx
@@ -94,9 +94,9 @@ describe('FullViewSnapshotButton', () => {
 
     it('allows selecting an auth domain', () => {
       cy.get('button').click();
-      cy.get('#authorization-domain-select').parent().click();
+      cy.get('#select-authorization-domain-select').parent().click();
       cy.get('[data-cy=menuItem-group2]').click();
-      cy.get('#authorization-domain-select').should('have.value', 'group2');
+      cy.get('#select-authorization-domain-select').should('have.value', 'group2');
     });
 
     it('allows changing the name and description', () => {

--- a/src/components/common/FullViewSnapshotButton.tsx
+++ b/src/components/common/FullViewSnapshotButton.tsx
@@ -191,9 +191,10 @@ function FullViewSnapshotButton({
             sx={{ height: '2.5rem' }}
             disabled={userGroups ? userGroups.length <= 1 : true}
             options={userGroups ? userGroups.map((group) => group.groupName) : []}
-            name="authorization-domain"
+            name="Select Authorization Domain"
             onSelectedItem={(event) => setSelectedAuthDomain(event.target.value)}
             value={selectedAuthDomain || ''}
+            includeNoneOption={true}
           />
           <div>
             Authorization Domains restrict data access to only specified individuals in a group and

--- a/src/components/common/FullViewSnapshotButton.tsx
+++ b/src/components/common/FullViewSnapshotButton.tsx
@@ -181,7 +181,7 @@ function FullViewSnapshotButton({
           <div style={{ marginTop: 8 }}>
             <FormLabel
               sx={{ fontWeight: 600, color: 'black' }}
-              htmlFor="authorization-domain-select"
+              htmlFor="select-authorization-domain-select"
             >
               Authorization Domain
               <span style={{ fontWeight: 400, color: 'black' }}> - (optional)</span>

--- a/src/components/dataset/data/JadeDropdown.tsx
+++ b/src/components/dataset/data/JadeDropdown.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import _ from 'lodash';
-import { MenuItem, FormControl, Select, SelectChangeEvent } from '@mui/material';
+import { MenuItem, FormControl, Select, SelectChangeEvent, Box } from '@mui/material';
 
 type IProps<T> = {
   disabled: boolean;
@@ -9,9 +9,18 @@ type IProps<T> = {
   options: T[];
   value: T;
   sx?: React.CSSProperties;
+  includeNoneOption?: boolean;
 };
 
-function JadeDropdown({ disabled, name, onSelectedItem, options, value, sx }: IProps<string>) {
+function JadeDropdown({
+  disabled,
+  name,
+  onSelectedItem,
+  options,
+  value,
+  sx,
+  includeNoneOption,
+}: IProps<string>) {
   return (
     <form autoComplete="off">
       <FormControl disabled={disabled} variant="outlined" fullWidth>
@@ -27,6 +36,11 @@ function JadeDropdown({ disabled, name, onSelectedItem, options, value, sx }: IP
           data-cy={_.camelCase(name)}
           sx={sx}
         >
+          {includeNoneOption && (
+            <MenuItem key="None" value="">
+              <Box sx={{ fontStyle: 'italic' }}>None</Box>
+            </MenuItem>
+          )}
           {options.map((opt) => (
             <MenuItem key={opt} value={opt} data-cy={`menuItem-${opt}`}>
               {opt}

--- a/src/components/dataset/data/JadeDropdown.tsx
+++ b/src/components/dataset/data/JadeDropdown.tsx
@@ -29,7 +29,7 @@ function JadeDropdown({
           onChange={(event) => onSelectedItem(event)}
           inputProps={{
             name,
-            id: `${name}-select`,
+            id: `${_.kebabCase(name)}-select`,
           }}
           displayEmpty
           renderValue={(val) => (!val ? name : val)}


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DT-1219
__________
**Before:** 
https://drive.google.com/file/d/1SLNW12OJjLjTDkf8dQMae2NUKb_qVbc-/view?usp=drive_link
**After:**
https://drive.google.com/file/d/1yzDz2hJyQWYRWGvi7jVZ2nsC1JZ67iVx/view?usp=drive_link

### Included Changes
1) Update the placeholder text to say "Select Authorization Domain" - This follows patterns used in other dropdowns around TDR
2) Add a "None" option that unselects auth domains
<img width="598" alt="image" src="https://github.com/user-attachments/assets/a0f60b9f-2908-4448-b2b4-f8342d06c0e7" />
<img width="596" alt="image" src="https://github.com/user-attachments/assets/86cc5070-231b-4e4e-b2b5-82a6a3f7dd17" />
