### PR TITLE
[DDO-4001] Use GAR repo name in cherry-pick step

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -101,6 +101,7 @@ jobs:
     uses: DataBiosphere/jade-data-repo/.github/workflows/cherry-pick-image.yaml@2.237.0
     secrets: inherit
     with:
+      # Can't use the workflow env vars here, thus the explicit reference.
       source_gcr_url: 'gcr.io/broad-jade-dev/jade-data-repo-ui'
       source_gcr_tag: ${{ needs.bump_version.outputs.tag }}
       target_gcr_url: 'gcr.io/datarepo-public-gcr/jade-data-repo-ui'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -101,9 +101,9 @@ jobs:
     uses: DataBiosphere/jade-data-repo/.github/workflows/cherry-pick-image.yaml@2.237.0
     secrets: inherit
     with:
-      source_gcr_url: ${GOOGLE_DOCKER_REPOSITORY}/${DEV_GCR_GOOGLE_PROJECT}/${IMAGE_NAME}
+      source_gcr_url: ${{ env.GOOGLE_DOCKER_REPOSITORY }}/${{ env.DEV_GCR_GOOGLE_PROJECT }}/${{ env.IMAGE_NAME }}
       source_gcr_tag: ${{ needs.bump_version.outputs.tag }}
-      target_gcr_url: ${GOOGLE_DOCKER_REPOSITORY}/${PUBLIC_GCR_GOOGLE_PROJECT}/${IMAGE_NAME}
+      target_gcr_url: ${{ env.GOOGLE_DOCKER_REPOSITORY }}/${{ env.PUBLIC_GCR_GOOGLE_PROJECT }}/${{ env.IMAGE_NAME }}
       target_gcr_tag: ${{ needs.bump_version.outputs.tag }}
 
   report-to-sherlock:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -101,9 +101,9 @@ jobs:
     uses: DataBiosphere/jade-data-repo/.github/workflows/cherry-pick-image.yaml@2.237.0
     secrets: inherit
     with:
-      source_gcr_url: ${{ env.GOOGLE_DOCKER_REPOSITORY }}/${{ env.DEV_GCR_GOOGLE_PROJECT }}/${{ env.IMAGE_NAME }}
+      source_gcr_url: 'gcr.io/broad-jade-dev/jade-data-repo-ui'
       source_gcr_tag: ${{ needs.bump_version.outputs.tag }}
-      target_gcr_url: ${{ env.GOOGLE_DOCKER_REPOSITORY }}/${{ env.PUBLIC_GCR_GOOGLE_PROJECT }}/${{ env.IMAGE_NAME }}
+      target_gcr_url: 'gcr.io/datarepo-public-gcr/jade-data-repo-ui'
       target_gcr_tag: ${{ needs.bump_version.outputs.tag }}
 
   report-to-sherlock:


### PR DESCRIPTION
You can’t use env vars when calling an action from a job directly instead of as a step. Sorry for the repeat PRs everyone!