### PR TITLE
[DDO-4001] Allow for / in branch names

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -72,7 +72,7 @@ jobs:
           if [ ${{ github.ref_name }} == ${{ github.event.repository.default_branch }} ]; then
             TAGS="${DEV_VERSION_TAG}"
           else
-            BRANCH_TAG="${DEV_NAME}:${GITHUB_HEAD_REF}"
+            BRANCH_TAG="${DEV_NAME}:${GITHUB_HEAD_REF//[\/]/_}"
             TAGS="${DEV_VERSION_TAG},${BRANCH_TAG}"
           fi
           echo "TAGS: ${TAGS}"


### PR DESCRIPTION
## What

With the recent workflow changes, using `/` in a PR branch name now breaks container pushes to GAR since image tags cannot have `/` in them.

## Testing

This PR tests if the changes work, since the branch name has a `/` in it.