### PR TITLE
DT-1186: Fix server error display

### DIFF
--- a/src/components/ServerErrorView.jsx
+++ b/src/components/ServerErrorView.jsx
@@ -30,25 +30,23 @@ const MainContent = styled(Box)(({ theme }) => ({
 }));
 
 function ServerErrorView({ status }) {
-  let systemsCount = 0;
   let systemRows = [];
   if (status.apiIsUp) {
     const { systems } = status.serverStatus;
-    systemsCount = Object.keys(systems).length;
-    systemRows = Object.keys(status.serverStatus.systems).map((member) => ({
+    systemRows = Object.keys(systems).map((member) => ({
       system: member,
-      system_is_up: status.serverStatus.systems[member].ok,
+      system_is_up: systems[member].ok,
     }));
   }
 
   const columns = [
     {
       label: 'System',
-      property: 'system',
+      name: 'system',
     },
     {
       label: 'Status',
-      property: 'system_status',
+      name: 'system_status',
       render: (row) => {
         if (row.system_is_up) {
           return '✅';
@@ -73,12 +71,7 @@ function ServerErrorView({ status }) {
             >
               It looks like the Data Repository server is up, but some required services are down.
             </Typography>
-            <LightTable
-              columns={columns}
-              rows={systemRows}
-              totalCount={systemsCount}
-              loading={false}
-            />
+            <LightTable columns={columns} rows={systemRows} loading={false} hidePagination={true} />
           </Box>
         )}
         {!status.apiIsUp && (

--- a/src/components/ServerErrorView.test.tsx
+++ b/src/components/ServerErrorView.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { mount } from 'cypress/react';
+import { Provider } from 'react-redux';
+import { StatusState } from 'reducers/status';
+import createMockStore from 'redux-mock-store';
+import { routerMiddleware } from 'connected-react-router';
+import history from 'modules/hist';
+import { ThemeProvider } from '@mui/material/styles';
+import globalTheme from 'modules/theme';
+import { initialQueryState } from 'reducers/query';
+import _ from 'lodash';
+import ServerErrorView from './ServerErrorView';
+
+describe('ServerErrorView', () => {
+  it('should render correctly when API is up but some systems are down', () => {
+    const status: StatusState = {
+      tdrOperational: true,
+      apiIsUp: true,
+      serverStatus: {
+        ok: true,
+        systems: {
+          database: { ok: true },
+          service1: { ok: false },
+          service2: { ok: true },
+        },
+      },
+    };
+
+    const mockStore = createMockStore([routerMiddleware(history)]);
+    const store = mockStore({ status, query: _.cloneDeep(initialQueryState) });
+
+    mount(
+      <Provider store={store}>
+        <ThemeProvider theme={globalTheme}>
+          <ServerErrorView />
+        </ThemeProvider>
+      </Provider>,
+    );
+
+    // Verify title is displayed
+    cy.contains('Uh oh, something went wrong!').should('be.visible');
+
+    // Verify message about services down is displayed
+    cy.contains(
+      'It looks like the Data Repository server is up, but some required services are down.',
+    ).should('be.visible');
+
+    // Verify table is displayed with correct data
+    cy.contains('System').should('be.visible');
+    cy.contains('Status').should('be.visible');
+    cy.contains('database').should('be.visible');
+    cy.contains('service1').should('be.visible');
+    cy.contains('service2').should('be.visible');
+
+    // Check for correct status indicators
+    cy.get('tr').eq(1).should('contain', '✅'); // database row
+    cy.get('tr').eq(2).should('contain', '❌'); // service1 row
+    cy.get('tr').eq(3).should('contain', '✅'); // service2 row
+  });
+
+  it('should render correctly when API is down', () => {
+    const mockStore = createMockStore([routerMiddleware(history)]);
+    const store = mockStore({ status: { tdrOperational: false, apiIsUp: false } });
+
+    mount(
+      <Provider store={store}>
+        <ThemeProvider theme={globalTheme}>
+          <ServerErrorView />
+        </ThemeProvider>
+      </Provider>,
+    );
+
+    // Verify title is displayed
+    cy.contains('Uh oh, something went wrong!').should('be.visible');
+
+    // Verify message about server being down is displayed
+    cy.contains('The Data Repository server is down!').should('be.visible');
+    cy.contains('Please check back in later.').should('be.visible');
+
+    // Verify table is not displayed
+    cy.contains('System').should('not.exist');
+  });
+});

--- a/src/components/table/LightTable.tsx
+++ b/src/components/table/LightTable.tsx
@@ -136,6 +136,7 @@ type LightTableProps<RowType> = {
     refreshCnt: number,
   ) => void;
   infinitePaging?: boolean;
+  hidePagination?: boolean;
   loading: boolean;
   orderDirection: OrderDirectionOptions;
   orderProperty: string;
@@ -157,6 +158,7 @@ function LightTable({
   filteredCount,
   handleEnumeration,
   infinitePaging,
+  hidePagination,
   loading,
   noRowsMessage,
   orderDirection,
@@ -289,7 +291,7 @@ function LightTable({
     0,
   );
   const effectiveTableWidth = _.isNaN(tableWidth) || !supportsResize ? '100%' : tableWidth;
-  const showPagination = (rows && rows.length > 0) || infinitePaging;
+  const showPagination = (rows?.length > 0 || infinitePaging) && !hidePagination;
 
   return (
     <div>

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -109,7 +109,7 @@ function bootstrap() {
 function render(Component) {
   const root = document.getElementById('react');
   const { configuration } = store.getState();
-  const isGoogleAuthority = configuration.configObject.authorityEndpoint.startsWith(
+  const isGoogleAuthority = configuration.configObject.authorityEndpoint?.startsWith(
     'https://accounts.google.com',
   );
   const metadata = {


### PR DESCRIPTION
Fix an issue where the TDR server error table wouldn't render properly. This table is shown when the TDR index page is initially loaded if the server `/status` response indicates an error. It's possible this has been broken for a while.

Before

![before](https://github.com/user-attachments/assets/7fa66dc0-b3b4-4479-88c0-c6b145d69a22)

After

![after1](https://github.com/user-attachments/assets/3ea1e3e0-e098-4244-a755-4e1708c50362)

Note that this error page is only shown if a critical subsystem is down. If a non-critical subsystem is down (such as DUOS), no error is shown.

If the TDR host itself isn't responding, a message is shown instead

![all down](https://github.com/user-attachments/assets/6445d686-fc68-4a99-9f9a-96fc4a9b7c9b)
