### PR TITLE
[DT-1205]DC inherit: On datasets, if inheritSteward is true, add messaging to data custodian role area

### DIFF
--- a/src/components/UserList.tsx
+++ b/src/components/UserList.tsx
@@ -5,12 +5,12 @@ import Typography from '@mui/material/Typography';
 import ManageUsersView from './ManageUsersView';
 
 interface UserListProps {
-  message?: string;
-  canManageUsers: boolean;
-  defaultOpen?: boolean;
-  removeUser?: (removableEmail: string) => void;
-  typeOfUsers: string;
-  users: Array<string>;
+  readonly message?: string;
+  readonly canManageUsers: boolean;
+  readonly defaultOpen?: boolean;
+  readonly removeUser?: (removableEmail: string) => void;
+  readonly typeOfUsers: string;
+  readonly users: Array<string>;
 }
 
 function UserList({

--- a/src/components/UserList.tsx
+++ b/src/components/UserList.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { Accordion, AccordionDetails, AccordionSummary, Box } from '@mui/material';
+import { Accordion, AccordionDetails, AccordionSummary } from '@mui/material';
 import { ExpandMore } from '@mui/icons-material';
 import Typography from '@mui/material/Typography';
 import ManageUsersView from './ManageUsersView';
 
 interface UserListProps {
+  message?: string;
   canManageUsers: boolean;
   defaultOpen?: boolean;
   removeUser?: (removableEmail: string) => void;
@@ -12,7 +13,14 @@ interface UserListProps {
   users: Array<string>;
 }
 
-function UserList({ canManageUsers, defaultOpen, removeUser, typeOfUsers, users }: UserListProps) {
+function UserList({
+  message,
+  canManageUsers,
+  defaultOpen,
+  removeUser,
+  typeOfUsers,
+  users,
+}: UserListProps) {
   return (
     <Accordion defaultExpanded={defaultOpen}>
       <AccordionSummary
@@ -28,6 +36,9 @@ function UserList({ canManageUsers, defaultOpen, removeUser, typeOfUsers, users 
         {typeOfUsers}
       </AccordionSummary>
       <AccordionDetails data-cy="user-email" sx={canManageUsers ? { paddingTop: 0 } : undefined}>
+        {message && (
+          <Typography sx={{ marginTop: '-16px', paddingBottom: '12px' }}>{message}</Typography>
+        )}
         <ManageUsersView removeUser={canManageUsers ? removeUser : undefined} users={users} />
         {users.length === 0 && (
           <Typography

--- a/src/components/dataset/DatasetAccess.test.tsx
+++ b/src/components/dataset/DatasetAccess.test.tsx
@@ -73,18 +73,16 @@ describe('DataAccess Component', () => {
     cy.contains('custodian2@example.com').should('exist');
   });
 
-  describe('renders Dataset Custodian information correctly when inherit steward is false or undefined', () => {
-    [false, undefined].forEach((inheritSteward) => {
-      it('custodians should appear without message about inheriting stewardship', () => {
-        mockDataset.inheritSteward = inheritSteward;
-        setUp(mockDataset);
-        cy.contains('Custodians').click();
-        cy.contains(
-          'All dataset custodians are stewards on all snapshots created from this dataset.',
-        ).should('not.exist');
-        cy.contains('custodian1@example.com').should('exist');
-        cy.contains('custodian2@example.com').should('exist');
-      });
+  [false, undefined].forEach((inheritSteward) => {
+    it(`custodians should appear without message about inheriting stewardship when inherit steward is ${inheritSteward}`, () => {
+      mockDataset.inheritSteward = inheritSteward;
+      setUp(mockDataset);
+      cy.contains('Custodians').click();
+      cy.contains(
+        'All dataset custodians are stewards on all snapshots created from this dataset.',
+      ).should('not.exist');
+      cy.contains('custodian1@example.com').should('exist');
+      cy.contains('custodian2@example.com').should('exist');
     });
   });
 });

--- a/src/components/dataset/DatasetAccess.test.tsx
+++ b/src/components/dataset/DatasetAccess.test.tsx
@@ -18,7 +18,7 @@ describe('DataAccess Component', () => {
   const mockPolicies: Array<PolicyModel> = [
     {
       name: 'steward',
-      members: ['steward1@example.com', 'steward2@example.com'],
+      members: [],
     },
     {
       name: 'custodian',

--- a/src/components/dataset/DatasetAccess.test.tsx
+++ b/src/components/dataset/DatasetAccess.test.tsx
@@ -1,0 +1,90 @@
+import { mount } from 'cypress/react';
+import { Router } from 'react-router-dom';
+import { ThemeProvider } from '@mui/material/styles';
+import { Provider } from 'react-redux';
+import React from 'react';
+import createMockStore from 'redux-mock-store';
+import { DatasetModel, PolicyModel } from 'generated/tdr';
+import history from '../../modules/hist';
+import globalTheme from '../../modules/theme';
+import DatasetAccess from './DatasetAccess';
+
+describe('DataAccess Component', () => {
+  const mockDataset: DatasetModel = {
+    id: '1',
+    name: 'Test Dataset',
+  };
+
+  const mockPolicies: Array<PolicyModel> = [
+    {
+      name: 'steward',
+      members: ['steward1@example.com', 'steward2@example.com'],
+    },
+    {
+      name: 'custodian',
+      members: ['custodian1@example.com', 'custodian2@example.com'],
+    },
+    {
+      name: 'snapshot_creator',
+      members: [],
+    },
+  ];
+
+  const mockUserRoles: Array<string> = ['steward', 'custodian'];
+
+  const initialState = {
+    datasets: {
+      dataset: mockDataset,
+      datasetPolicies: mockPolicies,
+      userRoles: mockUserRoles,
+    },
+  };
+
+  const setUp = (dataset) => {
+    const mockStore = createMockStore([]);
+    const store = mockStore(initialState);
+    mount(
+      <Router history={history}>
+        <Provider store={store}>
+          <ThemeProvider theme={globalTheme}>
+            <DatasetAccess dataset={dataset} policies={mockPolicies} userRoles={mockUserRoles} />
+          </ThemeProvider>
+        </Provider>
+      </Router>,
+    );
+  };
+
+  it('renders DataAccess component correctly', () => {
+    setUp(mockDataset);
+    cy.get('[data-cy="manageAccessContainer"]').should('exist');
+    cy.contains('Stewards').should('exist');
+    cy.contains('Custodians').should('exist');
+    cy.contains('Snapshot Creators').should('exist');
+  });
+
+  it('renders Dataset Custodian information correctly when inherit steward is true', () => {
+    mockDataset.inheritSteward = true;
+    setUp(mockDataset);
+    cy.contains('Custodians').click();
+    cy.contains(
+      'All dataset custodians are stewards on all snapshots created from this dataset.',
+    ).should('exist');
+    cy.contains('custodian1@example.com').should('exist');
+    cy.contains('custodian2@example.com').should('exist');
+  });
+
+  describe('renders Dataset Custodian information correctly when inherit steward is false or undefined', () => {
+    [false, undefined].forEach((inheritSteward) => {
+      it('custodians should appear without message about inheriting stewardship', () => {
+        mockDataset.inheritSteward = inheritSteward;
+        setUp(mockDataset);
+        cy.contains('Custodians').click();
+        cy.contains(
+          'All dataset custodians are stewards on all snapshots created from this dataset.',
+        ).should('not.exist');
+        cy.contains('custodian1@example.com').should('exist');
+        cy.contains('custodian2@example.com').should('exist');
+      });
+    });
+  });
+});

--- a/src/components/dataset/DatasetAccess.tsx
+++ b/src/components/dataset/DatasetAccess.tsx
@@ -30,7 +30,7 @@ function DatasetAccess(props: DatasetAccessProps) {
       dispatch(removeDatasetPolicyMember(dataset.id, removableEmail, role));
     };
   };
-  const { policies, userRoles } = props;
+  const { dataset, policies, userRoles } = props;
   const stewards = getRoleMembersFromPolicies(policies, DatasetRoles.STEWARD);
   const custodians = getRoleMembersFromPolicies(policies, DatasetRoles.CUSTODIAN);
   const snapshotCreators = getRoleMembersFromPolicies(policies, DatasetRoles.SNAPSHOT_CREATOR);
@@ -38,6 +38,9 @@ function DatasetAccess(props: DatasetAccessProps) {
   const canManageStewards = userRoles.includes(DatasetRoles.STEWARD);
   const canManageUsers =
     userRoles.includes(DatasetRoles.STEWARD) || userRoles.includes(DatasetRoles.CUSTODIAN);
+  const message = dataset.inheritSteward
+    ? 'All dataset custodians are stewards on all snapshots created from this dataset.'
+    : undefined;
 
   const permissions: AccessPermission[] = [
     { policy: 'custodian', disabled: !canManageUsers },
@@ -62,6 +65,7 @@ function DatasetAccess(props: DatasetAccessProps) {
       </Grid>
       <Grid item xs={12}>
         <UserList
+          message={message}
           users={custodians}
           typeOfUsers="Custodians"
           canManageUsers={canManageUsers}


### PR DESCRIPTION
Summary:
Increase visibility for new inherit steward feature by adding messaging on the roles and memberships tab for a dataset.

Changes:
In UserList: add optional message. 
In DatasetAccess: pass in message to UserList if inherit steward is enabled.

Testing:
Add DatasetAccess.test.tsx to check basic rendering and conditional rendering of the new message.

Visual Aids:
When enabled: 
<img width="1512" alt="Screenshot 2025-03-24 at 1 15 04 PM" src="https://github.com/user-attachments/assets/bf0dcc4b-cfcc-4641-9715-613ae389cd23" />

When disabled: 
<img width="1512" alt="Screenshot 2025-03-24 at 1 17 54 PM" src="https://github.com/user-attachments/assets/d2b8502d-7eb3-4c25-a3de-a4322127f2d6" />
