### PR TITLE
DT-1232: Show inherited stewards on snapshot roles tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,11 @@ To run end-to-end tests: `npx cypress run` or `npx cypress open` (interactive mo
 
 To run unit tests: `npx cypress run --component` or `npx cypress open --component` (interactive mode)
 
+To see console output from cypress test runs using the electron browser, set `ELECTRON_ENABLE_LOGGING=1`
+```shell
+ELECTRON_ENABLE_LOGGING=1 npx cypress open
+```
+
 ## skaffold
 
 To render your own local skaffold.yaml run the following with your initials

--- a/cypress/integration/snapshotCreation.spec.js
+++ b/cypress/integration/snapshotCreation.spec.js
@@ -36,7 +36,7 @@ describe('test snapshot creation', () => {
         id: 'snapshotId',
         createdDate: '2020-06-24',
         profileId: 'profileId',
-        source: [{ name: 'dataset' }],
+        source: [{ dataset: { id: 'datasetId' } }],
         tables: [{ rowCount: 2 }],
       },
     });

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -147,7 +147,7 @@ export const { getDatasetById } = createActions({
 });
 
 export const { getDatasetPolicy } = createActions({
-  [ActionTypes.GET_DATASET_POLICY]: (policy) => policy,
+  [ActionTypes.GET_DATASET_POLICY]: (datasetId, options) => ({ datasetId, options }),
   [ActionTypes.GET_DATASET_POLICY_SUCCESS]: (policy) => policy,
 });
 

--- a/src/components/ManageUsersView.test.tsx
+++ b/src/components/ManageUsersView.test.tsx
@@ -8,6 +8,11 @@ import history from '../modules/hist';
 import globalTheme from '../modules/theme';
 import ManageUsersView from './ManageUsersView';
 
+const user1 = 'user1';
+const user2 = 'user2';
+const user3 = 'user3';
+const readOnlyUser1 = 'readOnlyUser1';
+const readOnlyUser2 = 'readOnlyUser2';
 const mountComponent = (canManageUsers) => {
   const mockStore = createMockStore([]);
   const store = mockStore({});
@@ -18,8 +23,8 @@ const mountComponent = (canManageUsers) => {
           <ManageUsersView
             classes={{}}
             removeUser={canManageUsers ? () => <div /> : undefined}
-            users={['authdomain1', 'authdomain2', 'authdomain3']}
-            readOnlyUsers={['user1', 'user2']}
+            users={[user1, user2, user3]}
+            readOnlyUsers={[readOnlyUser1, readOnlyUser2]}
             readOnlyUserTooltip="read only user tooltip"
           />
         </ThemeProvider>
@@ -33,15 +38,20 @@ describe('ManageUsersView', () => {
     it('Renders user list independent of whether you can manage users', () => {
       mountComponent(canManageUsers);
       cy.get('[data-cy=chip-container]').within(() => {
-        cy.contains('authdomain1').should('exist');
-        cy.contains('authdomain2').should('exist');
-        cy.contains('authdomain3').should('exist');
-        cy.contains('user1').should('exist');
-        cy.contains('user2').should('exist');
+        cy.contains(user1).should('exist');
+        cy.contains(user2).should('exist');
+        cy.contains(user3).should('exist');
+        cy.contains(readOnlyUser1).should('exist');
+        cy.contains(readOnlyUser2).should('exist');
       });
-      cy.contains('user1').trigger('mouseover'); // to show the tooltip for read-only users
-      cy.contains('read only user tooltip').should('be.visible');
     });
+  });
+  it('Does not render remove user button for readOnly users even if canManageUsers is true', () => {
+    mountComponent(true);
+    cy.get(`[data-cy="chip-${user1}"]`).find('[data-testid="CancelIcon"]').should('exist');
+    cy.get(`[data-cy="chip-${readOnlyUser1}"]`)
+      .contains('[data-testid="CancelIcon"]')
+      .should('not.exist');
   });
   it('No container when there are no users', () => {
     const mockStore = createMockStore([]);

--- a/src/components/ManageUsersView.test.tsx
+++ b/src/components/ManageUsersView.test.tsx
@@ -21,6 +21,7 @@ describe('ManageUsersView', () => {
                 classes={{}}
                 removeUser={canManageUsers ? () => <div /> : undefined}
                 users={['authdomain1', 'authdomain2', 'authdomain3']}
+                readOnlyUsers={['user1', 'user2']}
               />
             </ThemeProvider>
           </Provider>
@@ -30,6 +31,8 @@ describe('ManageUsersView', () => {
         cy.contains('authdomain1').should('exist');
         cy.contains('authdomain2').should('exist');
         cy.contains('authdomain3').should('exist');
+        cy.contains('user1').should('exist');
+        cy.contains('user2').should('exist');
       });
     });
   });

--- a/src/components/ManageUsersView.test.tsx
+++ b/src/components/ManageUsersView.test.tsx
@@ -43,13 +43,6 @@ describe('ManageUsersView', () => {
       cy.contains('read only user tooltip').should('be.visible');
     });
   });
-  it('Does not render remove user button for readOnly users even if canManageUsers is true', () => {
-    mountComponent(true);
-    cy.get('[data-cy=chip-container]').within(() => {
-      // three removable users, does not render for the two read-only users
-      cy.get('.MuiChip-deleteIcon').should('have.length', 3);
-    });
-  });
   it('No container when there are no users', () => {
     const mockStore = createMockStore([]);
     const store = mockStore({});

--- a/src/components/ManageUsersView.test.tsx
+++ b/src/components/ManageUsersView.test.tsx
@@ -8,25 +8,30 @@ import history from '../modules/hist';
 import globalTheme from '../modules/theme';
 import ManageUsersView from './ManageUsersView';
 
+const mountComponent = (canManageUsers) => {
+  const mockStore = createMockStore([]);
+  const store = mockStore({});
+  mount(
+    <Router history={history}>
+      <Provider store={store}>
+        <ThemeProvider theme={globalTheme}>
+          <ManageUsersView
+            classes={{}}
+            removeUser={canManageUsers ? () => <div /> : undefined}
+            users={['authdomain1', 'authdomain2', 'authdomain3']}
+            readOnlyUsers={['user1', 'user2']}
+            readOnlyUserTooltip="read only user tooltip"
+          />
+        </ThemeProvider>
+      </Provider>
+    </Router>,
+  );
+};
+
 describe('ManageUsersView', () => {
   [true, false].forEach((canManageUsers) => {
     it('Renders user list independent of whether you can manage users', () => {
-      const mockStore = createMockStore([]);
-      const store = mockStore({});
-      mount(
-        <Router history={history}>
-          <Provider store={store}>
-            <ThemeProvider theme={globalTheme}>
-              <ManageUsersView
-                classes={{}}
-                removeUser={canManageUsers ? () => <div /> : undefined}
-                users={['authdomain1', 'authdomain2', 'authdomain3']}
-                readOnlyUsers={['user1', 'user2']}
-              />
-            </ThemeProvider>
-          </Provider>
-        </Router>,
-      );
+      mountComponent(canManageUsers);
       cy.get('[data-cy=chip-container]').within(() => {
         cy.contains('authdomain1').should('exist');
         cy.contains('authdomain2').should('exist');
@@ -34,6 +39,15 @@ describe('ManageUsersView', () => {
         cy.contains('user1').should('exist');
         cy.contains('user2').should('exist');
       });
+      cy.contains('user1').trigger('mouseover'); // to show the tooltip for read-only users
+      cy.contains('read only user tooltip').should('be.visible');
+    });
+  });
+  it('Does not render remove user button for readOnly users even if canManageUsers is true', () => {
+    mountComponent(true);
+    cy.get('[data-cy=chip-container]').within(() => {
+      // three removable users, does not render for the two read-only users
+      cy.get('.MuiChip-deleteIcon').should('have.length', 3);
     });
   });
   it('No container when there are no users', () => {

--- a/src/components/ManageUsersView.tsx
+++ b/src/components/ManageUsersView.tsx
@@ -15,38 +15,44 @@ function ManageUsersView({
   readOnlyUsers,
   readOnlyUserTooltip,
 }: ManageUsersProps) {
-  const userChips = users.map((user) => (
+  const createUserChip = (
+    user: string,
+    options: {
+      color: 'primary' | 'secondary';
+      onDelete?: () => void;
+      title?: string;
+    },
+  ) => (
     <Box data-cy="chip-item" key={user}>
       <Chip
         sx={(theme) => ({
           marginBottom: theme.spacing(1),
         })}
-        color="primary"
+        color={options.color}
         label={user}
         key={user}
-        onDelete={removeUser ? () => removeUser?.(user) : undefined}
+        onDelete={options.onDelete}
+        title={options.title}
         variant="outlined"
         data-cy={`chip-${user}`}
       />
     </Box>
-  ));
-  const readOnlyUserChips =
-    readOnlyUsers?.map((user) => (
-      <Box data-cy="chip-item" key={user}>
-        <Chip
-          title={readOnlyUserTooltip}
-          sx={(theme) => ({
-            marginBottom: theme.spacing(1),
-          })}
-          color="secondary"
-          label={user}
-          key={user}
-          variant="outlined"
-          data-cy={`chip-${user}`}
-        />
-      </Box>
-    )) || [];
+  );
 
+  const userChips = users.map((user) =>
+    createUserChip(user, {
+      color: 'primary',
+      onDelete: removeUser ? () => removeUser(user) : undefined,
+    }),
+  );
+
+  const readOnlyUserChips =
+    readOnlyUsers?.map((user) =>
+      createUserChip(user, {
+        color: 'secondary',
+        title: readOnlyUserTooltip,
+      }),
+    ) || [];
   return (
     <Box data-cy="chip-container">
       {(userChips.length > 0 || readOnlyUserChips.length > 0) && (

--- a/src/components/ManageUsersView.tsx
+++ b/src/components/ManageUsersView.tsx
@@ -3,32 +3,53 @@ import { Box } from '@mui/material';
 import Chip from '@mui/material/Chip';
 
 interface ManageUsersProps {
-  removeUser?: (removableEmail: string) => void;
-  users: Array<string>;
+  readonly removeUser?: (removableEmail: string) => void;
+  readonly users: Array<string>;
+  readonly readOnlyUsers?: Array<string>;
+  readonly readOnlyUserTooltip?: string;
 }
 
-function ManageUsersView({ removeUser, users }: ManageUsersProps) {
-  const userChips =
-    !!users &&
-    users.map((user) => (
+function ManageUsersView({
+  removeUser,
+  users,
+  readOnlyUsers,
+  readOnlyUserTooltip,
+}: ManageUsersProps) {
+  const userChips = users.map((user) => (
+    <Box data-cy="chip-item" key={user}>
+      <Chip
+        sx={(theme) => ({
+          marginBottom: theme.spacing(1),
+        })}
+        color="primary"
+        label={user}
+        key={user}
+        onDelete={removeUser ? () => removeUser?.(user) : undefined}
+        variant="outlined"
+        data-cy={`chip-${user}`}
+      />
+    </Box>
+  ));
+  const readOnlyUserChips =
+    readOnlyUsers?.map((user) => (
       <Box data-cy="chip-item" key={user}>
         <Chip
+          title={readOnlyUserTooltip}
           sx={(theme) => ({
             marginBottom: theme.spacing(1),
           })}
-          color="primary"
+          color="secondary"
           label={user}
           key={user}
-          onDelete={removeUser ? () => removeUser?.(user) : undefined}
           variant="outlined"
           data-cy={`chip-${user}`}
         />
       </Box>
-    ));
+    )) || [];
 
   return (
     <Box data-cy="chip-container">
-      {users && users.length > 0 && (
+      {(userChips.length > 0 || readOnlyUserChips.length > 0) && (
         <Box
           sx={{
             margin: 0,
@@ -36,6 +57,7 @@ function ManageUsersView({ removeUser, users }: ManageUsersProps) {
           }}
         >
           {userChips}
+          {readOnlyUserChips}
         </Box>
       )}
     </Box>

--- a/src/components/UserList.tsx
+++ b/src/components/UserList.tsx
@@ -49,7 +49,7 @@ function UserList({
           readOnlyUsers={readOnlyUsers}
           readOnlyUserTooltip={readOnlyUserTooltip}
         />
-        {users.length === 0 && readOnlyUsers?.length === 0 && (
+        {users.length === 0 && (!readOnlyUsers || readOnlyUsers.length === 0) && (
           <Typography
             sx={{
               fontStyle: 'italic',

--- a/src/components/UserList.tsx
+++ b/src/components/UserList.tsx
@@ -11,6 +11,8 @@ interface UserListProps {
   readonly removeUser?: (removableEmail: string) => void;
   readonly typeOfUsers: string;
   readonly users: Array<string>;
+  readonly readOnlyUsers?: Array<string>;
+  readonly readOnlyUserTooltip?: string;
 }
 
 function UserList({
@@ -20,6 +22,8 @@ function UserList({
   removeUser,
   typeOfUsers,
   users,
+  readOnlyUsers,
+  readOnlyUserTooltip,
 }: UserListProps) {
   return (
     <Accordion defaultExpanded={defaultOpen}>
@@ -39,8 +43,13 @@ function UserList({
         {message && (
           <Typography sx={{ marginTop: '-16px', paddingBottom: '12px' }}>{message}</Typography>
         )}
-        <ManageUsersView removeUser={canManageUsers ? removeUser : undefined} users={users} />
-        {users.length === 0 && (
+        <ManageUsersView
+          removeUser={canManageUsers ? removeUser : undefined}
+          users={users}
+          readOnlyUsers={readOnlyUsers}
+          readOnlyUserTooltip={readOnlyUserTooltip}
+        />
+        {users.length === 0 && readOnlyUsers?.length === 0 && (
           <Typography
             sx={{
               fontStyle: 'italic',

--- a/src/components/common/FullViewSnapshotModal.test.tsx
+++ b/src/components/common/FullViewSnapshotModal.test.tsx
@@ -11,11 +11,13 @@ import { initialQueryState } from 'reducers/query';
 import { ManagedGroupMembershipEntry } from 'models/group';
 import FullViewSnapshotModal from 'components/common/FullViewSnapshotModal';
 import { initialSnapshotState } from 'reducers/snapshot';
+import { initialDatasetState } from 'reducers/dataset';
 import history from '../../modules/hist';
 import globalTheme from '../../modules/theme';
 
 const initialState = {
   snapshots: initialSnapshotState,
+  datasets: initialDatasetState,
   user: _.cloneDeep(initialUserState),
   query: _.cloneDeep(initialQueryState),
   router: { location: {} },
@@ -34,9 +36,9 @@ const mountFullViewSnapshotModal = (
   });
 
   // Intercept the getBillingProfiles API call onMount
-  cy.intercept('GET', '/api/resources/v1/profiles?offset=0&limit=1000').as('getBillingProfiles');
+  cy.intercept('GET', '/api/resources/v1/profiles?offset=0&limit=1000');
 
-  cy.intercept('GET', 'https://sam.dsde-dev.broadinstitute.org/api/groups/v1').as('getUserGroups');
+  cy.intercept('GET', 'https://sam.dsde-dev.broadinstitute.org/api/groups/v1');
 
   mount(
     <Router history={history}>
@@ -88,8 +90,10 @@ describe('FullViewSnapshotModal', () => {
   });
 
   it('allows changing the name and description', () => {
-    cy.get('#snapshot-name').clear().type('New Name');
-    cy.get('#snapshot-description').clear().type('New Description');
+    cy.get('#snapshot-name').clear();
+    cy.get('#snapshot-name').type('New Name');
+    cy.get('#snapshot-description').clear();
+    cy.get('#snapshot-description').type('New Description');
     cy.get('#snapshot-name').should('have.value', 'New Name');
     cy.get('#snapshot-description').should('have.value', 'New Description');
   });

--- a/src/components/snapshot/ManagedSnapshotAccess.test.tsx
+++ b/src/components/snapshot/ManagedSnapshotAccess.test.tsx
@@ -68,9 +68,6 @@ const setup = (state) => {
             addUsers={cy.stub().as('addUsers')}
             removeUser={cy.stub()}
             requestPolicies={snapshotRequestPolicies}
-            // datasetPolicies={datasetPolicies}
-            // userRoles={state.snapshots.userRoles}
-            // snapshot={state.snapshots.snapshot}
           />
         </ThemeProvider>
       </Provider>

--- a/src/components/snapshot/ManagedSnapshotAccess.test.tsx
+++ b/src/components/snapshot/ManagedSnapshotAccess.test.tsx
@@ -5,13 +5,24 @@ import { Provider } from 'react-redux';
 import React from 'react';
 import createMockStore from 'redux-mock-store';
 import { initialDatasetState } from 'reducers/dataset';
+import { cloneDeep } from 'lodash';
 import history from '../../modules/hist';
 import globalTheme from '../../modules/theme';
 import ManagedSnapshotAccess from './ManagedSnapshotAccess';
 
 const snapshot = {
   id: 'uuid',
+  source: [{ dataset: { id: 'datasetId', inheritSteward: true } }],
 };
+
+const datasetPolicies = [
+  {
+    name: 'custodian',
+    members: ['custodian@gmail.com'],
+  },
+];
+
+const datasetState = { ...initialDatasetState, datasetPolicies };
 
 const initialState = {
   snapshots: {
@@ -36,40 +47,46 @@ const initialState = {
     ],
     userRoles: ['steward', 'reader', 'discoverer', 'aggregate_data_reader'],
   },
-  datasets: initialDatasetState,
+  datasets: datasetState,
+};
+
+const setup = (state) => {
+  const mockStore = createMockStore([]);
+  const store = mockStore(state);
+  const snapshotRequestPolicies = {
+    stewards: ['steward@gmail.com'],
+    readers: ['reader@gmail.com'],
+    discoverers: [],
+    aggregateDataReaders: ['datareader@gmail.com'],
+  };
+  mount(
+    <Router history={history}>
+      <Provider store={store}>
+        <ThemeProvider theme={globalTheme}>
+          <ManagedSnapshotAccess
+            createMode={false}
+            addUsers={cy.stub().as('addUsers')}
+            removeUser={cy.stub()}
+            requestPolicies={snapshotRequestPolicies}
+            // datasetPolicies={datasetPolicies}
+            // userRoles={state.snapshots.userRoles}
+            // snapshot={state.snapshots.snapshot}
+          />
+        </ThemeProvider>
+      </Provider>
+    </Router>,
+  );
 };
 
 describe('ManagedSnapshotAccess', () => {
-  beforeEach(() => {
-    const mockStore = createMockStore([]);
-    const store = mockStore(initialState);
-    const snapshotRequestPolicies = {
-      stewards: ['steward@gmail.com'],
-      readers: ['reader@gmail.com'],
-      discoverers: [],
-      aggregateDataReaders: ['datareader@gmail.com'],
-    };
-    mount(
-      <Router history={history}>
-        <Provider store={store}>
-          <ThemeProvider theme={globalTheme}>
-            <ManagedSnapshotAccess
-              createMode={false}
-              addUsers={cy.stub().as('addUsers')}
-              removeUser={cy.stub()}
-              requestPolicies={snapshotRequestPolicies}
-            />
-          </ThemeProvider>
-        </Provider>
-      </Router>,
-    );
-  });
   it('Displays snapshot policies and emails', () => {
+    setup(initialState);
     cy.get('[data-cy="snapshot-stewards"]')
       .should('contain.text', 'Stewards')
       .within(() => {
-        cy.get('[data-cy="user-email"]').then((user) => {
-          cy.wrap(user[0]).should('contain.text', 'steward@gmail.com');
+        cy.get('[data-cy="user-email"]').then((userList) => {
+          cy.wrap(userList).should('contain.text', 'steward@gmail.com');
+          cy.wrap(userList).should('contain.text', 'custodian@gmail.com');
         });
       });
     cy.get('[data-cy="snapshot-readers"]')
@@ -94,7 +111,18 @@ describe('ManagedSnapshotAccess', () => {
         });
       });
   });
+  it('Does not display dataset custodians if user does not have permission on the snapshot', () => {
+    const noPermissionState = cloneDeep(initialState);
+    noPermissionState.datasets.datasetPolicies = [{ name: 'ERROR', members: [] }];
+    setup(noPermissionState);
+    cy.get('[data-cy="snapshot-stewards"]')
+      .should('contain.text', 'Stewards')
+      .within(() => {
+        cy.contains('custodian@gmail.com').should('not.exist');
+      });
+  });
   it('Allows adding users', () => {
+    setup(initialState);
     cy.get('[data-cy="enterEmailBox"]').type('newemail@gmail.com');
     cy.get('[data-cy="inviteButton"]').click();
     cy.get('@addUsers').should('be.calledWith', 'steward', ['newemail@gmail.com']);

--- a/src/components/snapshot/ManagedSnapshotAccess.test.tsx
+++ b/src/components/snapshot/ManagedSnapshotAccess.test.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider } from '@mui/material/styles';
 import { Provider } from 'react-redux';
 import React from 'react';
 import createMockStore from 'redux-mock-store';
+import { initialDatasetState } from 'reducers/dataset';
 import history from '../../modules/hist';
 import globalTheme from '../../modules/theme';
 import ManagedSnapshotAccess from './ManagedSnapshotAccess';
@@ -35,6 +36,7 @@ const initialState = {
     ],
     userRoles: ['steward', 'reader', 'discoverer', 'aggregate_data_reader'],
   },
+  datasets: initialDatasetState,
 };
 
 describe('ManagedSnapshotAccess', () => {
@@ -54,7 +56,7 @@ describe('ManagedSnapshotAccess', () => {
             <ManagedSnapshotAccess
               createMode={false}
               addUsers={cy.stub().as('addUsers')}
-              removeUser={cy.stub().as('removeUser')}
+              removeUser={cy.stub()}
               requestPolicies={snapshotRequestPolicies}
             />
           </ThemeProvider>

--- a/src/components/snapshot/ManagedSnapshotAccess.tsx
+++ b/src/components/snapshot/ManagedSnapshotAccess.tsx
@@ -1,14 +1,16 @@
 import { Grid, Typography } from '@mui/material';
 import AddUserAccess, { AccessPermission } from 'components/common/AddUserAccess';
 import UserList from 'components/UserList';
-import React from 'react';
+import React, { Dispatch, useEffect } from 'react';
 import { getRoleMembersFromPolicies } from 'libs/utils';
 import _ from 'lodash';
-import { PolicyModel, SnapshotRequestModelPolicies } from 'generated/tdr';
+import { PolicyModel, SnapshotModel, SnapshotRequestModelPolicies } from 'generated/tdr';
 import { connect } from 'react-redux';
 import { TdrState } from 'reducers';
 import { SnapshotRoles } from 'constants';
 import { styled } from '@mui/material/styles';
+import { getDatasetPolicy } from 'actions';
+import { Action } from 'redux';
 
 export const transformRoleToCreatePolicy = (role: string): string => `${_.camelCase(role)}s`;
 
@@ -26,10 +28,30 @@ interface ManagedSnapshotAccessProps {
   readonly userRoles: string[];
   readonly policies: Array<PolicyModel>;
   readonly requestPolicies: SnapshotRequestModelPolicies;
+  readonly snapshot: SnapshotModel;
+  readonly datasetPolicies: Array<PolicyModel>;
+  readonly dispatch: Dispatch<Action>;
 }
 
 function ManagedSnapshotAccess(props: ManagedSnapshotAccessProps) {
-  const { createMode, addUsers, removeUser, userRoles, policies, requestPolicies } = props;
+  const {
+    dispatch,
+    createMode,
+    addUsers,
+    removeUser,
+    userRoles,
+    policies,
+    requestPolicies,
+    datasetPolicies,
+    snapshot,
+  } = props;
+
+  const datasetId = snapshot.source?.[0].dataset.id;
+
+  useEffect(() => {
+    dispatch(getDatasetPolicy(datasetId));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [datasetId]);
 
   const getUsers = (role: string): string[] =>
     createMode
@@ -40,6 +62,9 @@ function ManagedSnapshotAccess(props: ManagedSnapshotAccessProps) {
   const readers = getUsers(SnapshotRoles.READER);
   const discoverers = getUsers(SnapshotRoles.DISCOVERER);
   const aggregateDataReaders = getUsers(SnapshotRoles.AGGREGATE_DATA_READER);
+  const inheritedStewards = snapshot.source?.[0].dataset.inheritSteward
+    ? datasetPolicies.find((policy) => policy.name === SnapshotRoles.STEWARD)?.members
+    : [];
 
   const canManageUsers = userRoles.includes(SnapshotRoles.STEWARD) || createMode;
   const permissions: AccessPermission[] = [
@@ -60,6 +85,8 @@ function ManagedSnapshotAccess(props: ManagedSnapshotAccessProps) {
       <Grid item xs={12} data-cy="snapshot-stewards">
         <UserList
           users={stewards}
+          readOnlyUsers={inheritedStewards}
+          readOnlyUserTooltip="This steward has inherited access as a parent dataset custodian, to remove access, remove their role from the dataset"
           typeOfUsers="Stewards"
           canManageUsers={canManageUsers}
           removeUser={removeUser(SnapshotRoles.STEWARD)}
@@ -101,6 +128,8 @@ function mapStateToProps(state: TdrState) {
   return {
     policies: state.snapshots.snapshotPolicies,
     userRoles: state.snapshots.userRoles,
+    snapshot: state.snapshots.snapshot,
+    datasetPolicies: state.datasets.datasetPolicies,
   };
 }
 

--- a/src/components/snapshot/ManagedSnapshotAccess.tsx
+++ b/src/components/snapshot/ManagedSnapshotAccess.tsx
@@ -65,9 +65,8 @@ function ManagedSnapshotAccess(props: ManagedSnapshotAccessProps) {
   const inheritedStewards = snapshot.source?.[0].dataset.inheritSteward
     ? datasetPolicies.find((policy) => policy.name === DatasetRoles.CUSTODIAN)?.members
     : [];
-  const datasetPolicyError = datasetPolicies.find((policy) => policy.name === 'ERROR');
   const datasetPolicyErrorMessage =
-    datasetPolicyError &&
+    datasetPolicies.find((policy) => policy.name === 'ERROR') &&
     'Beacause its source dataset has Inherit Steward enabled, this snapshot may have additional stewards that are not listed here.';
 
   const canManageUsers = userRoles.includes(SnapshotRoles.STEWARD) || createMode;
@@ -91,7 +90,7 @@ function ManagedSnapshotAccess(props: ManagedSnapshotAccessProps) {
           users={stewards}
           message={datasetPolicyErrorMessage}
           readOnlyUsers={inheritedStewards}
-          readOnlyUserTooltip="This steward has inherited access as a parent dataset custodian, to remove access, remove their role from the dataset"
+          readOnlyUserTooltip="This steward has inherited access as a parent dataset custodian. To remove access, remove their role from the dataset"
           typeOfUsers="Stewards"
           canManageUsers={canManageUsers}
           removeUser={removeUser(SnapshotRoles.STEWARD)}

--- a/src/components/snapshot/ManagedSnapshotAccess.tsx
+++ b/src/components/snapshot/ManagedSnapshotAccess.tsx
@@ -7,7 +7,7 @@ import _ from 'lodash';
 import { PolicyModel, SnapshotModel, SnapshotRequestModelPolicies } from 'generated/tdr';
 import { connect } from 'react-redux';
 import { TdrState } from 'reducers';
-import { SnapshotRoles } from 'constants';
+import { DatasetRoles, SnapshotRoles } from 'constants';
 import { styled } from '@mui/material/styles';
 import { getDatasetPolicy } from 'actions';
 import { Action } from 'redux';
@@ -63,7 +63,7 @@ function ManagedSnapshotAccess(props: ManagedSnapshotAccessProps) {
   const discoverers = getUsers(SnapshotRoles.DISCOVERER);
   const aggregateDataReaders = getUsers(SnapshotRoles.AGGREGATE_DATA_READER);
   const inheritedStewards = snapshot.source?.[0].dataset.inheritSteward
-    ? datasetPolicies.find((policy) => policy.name === SnapshotRoles.STEWARD)?.members
+    ? datasetPolicies.find((policy) => policy.name === DatasetRoles.CUSTODIAN)?.members
     : [];
 
   const canManageUsers = userRoles.includes(SnapshotRoles.STEWARD) || createMode;

--- a/src/components/snapshot/ManagedSnapshotAccess.tsx
+++ b/src/components/snapshot/ManagedSnapshotAccess.tsx
@@ -69,7 +69,7 @@ function ManagedSnapshotAccess(props: ManagedSnapshotAccessProps) {
     : [];
   const datasetPolicyErrorMessage =
     datasetPolicies.find((policy) => policy.name === 'ERROR') &&
-    'Beacause its source dataset has Inherit Steward enabled, this snapshot may have additional stewards that are not listed here.';
+    'Because its source dataset has Inherit Steward enabled, this snapshot may have additional stewards that are not listed here.';
 
   const canManageUsers = userRoles.includes(SnapshotRoles.STEWARD) || createMode;
   const permissions: AccessPermission[] = [

--- a/src/components/snapshot/ManagedSnapshotAccess.tsx
+++ b/src/components/snapshot/ManagedSnapshotAccess.tsx
@@ -49,7 +49,9 @@ function ManagedSnapshotAccess(props: ManagedSnapshotAccessProps) {
   const datasetId = snapshot.source?.[0].dataset.id;
 
   useEffect(() => {
-    dispatch(getDatasetPolicy(datasetId, { suppressErrorNotification: true }));
+    if (snapshot.source?.[0].dataset.inheritSteward) {
+      dispatch(getDatasetPolicy(datasetId, { suppressErrorNotification: true }));
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [datasetId]);
 

--- a/src/components/snapshot/ManagedSnapshotAccess.tsx
+++ b/src/components/snapshot/ManagedSnapshotAccess.tsx
@@ -7,10 +7,10 @@ import _ from 'lodash';
 import { PolicyModel, SnapshotModel, SnapshotRequestModelPolicies } from 'generated/tdr';
 import { connect } from 'react-redux';
 import { TdrState } from 'reducers';
-import { DatasetRoles, SnapshotRoles } from 'constants';
 import { styled } from '@mui/material/styles';
 import { getDatasetPolicy } from 'actions';
 import { Action } from 'redux';
+import { DatasetRoles, SnapshotRoles } from 'src/constants';
 
 export const transformRoleToCreatePolicy = (role: string): string => `${_.camelCase(role)}s`;
 
@@ -49,7 +49,7 @@ function ManagedSnapshotAccess(props: ManagedSnapshotAccessProps) {
   const datasetId = snapshot.source?.[0].dataset.id;
 
   useEffect(() => {
-    dispatch(getDatasetPolicy(datasetId));
+    dispatch(getDatasetPolicy(datasetId, { suppressErrorNotification: true }));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [datasetId]);
 
@@ -65,6 +65,10 @@ function ManagedSnapshotAccess(props: ManagedSnapshotAccessProps) {
   const inheritedStewards = snapshot.source?.[0].dataset.inheritSteward
     ? datasetPolicies.find((policy) => policy.name === DatasetRoles.CUSTODIAN)?.members
     : [];
+  const datasetPolicyError = datasetPolicies.find((policy) => policy.name === 'ERROR');
+  const datasetPolicyErrorMessage =
+    datasetPolicyError &&
+    'Beacause its source dataset has Inherit Steward enabled, this snapshot may have additional stewards that are not listed here.';
 
   const canManageUsers = userRoles.includes(SnapshotRoles.STEWARD) || createMode;
   const permissions: AccessPermission[] = [
@@ -85,6 +89,7 @@ function ManagedSnapshotAccess(props: ManagedSnapshotAccessProps) {
       <Grid item xs={12} data-cy="snapshot-stewards">
         <UserList
           users={stewards}
+          message={datasetPolicyErrorMessage}
           readOnlyUsers={inheritedStewards}
           readOnlyUserTooltip="This steward has inherited access as a parent dataset custodian, to remove access, remove their role from the dataset"
           typeOfUsers="Stewards"

--- a/src/components/snapshot/SnapshotAccess.test.tsx
+++ b/src/components/snapshot/SnapshotAccess.test.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider } from '@mui/material/styles';
 import { Provider } from 'react-redux';
 import React from 'react';
 import createMockStore from 'redux-mock-store';
+import { initialDatasetState } from 'reducers/dataset';
 import history from '../../modules/hist';
 import globalTheme from '../../modules/theme';
 import SnapshotAccess from './SnapshotAccess';
@@ -35,6 +36,7 @@ const initialState = {
     ],
     userRoles: ['steward', 'reader', 'discoverer', 'aggregate_data_reader'],
   },
+  datasets: initialDatasetState,
 };
 
 describe('Snapshot access info', () => {

--- a/src/components/snapshot/SnapshotAccess.test.tsx
+++ b/src/components/snapshot/SnapshotAccess.test.tsx
@@ -19,7 +19,7 @@ const initialState = {
     snapshotPolicies: [
       {
         name: 'steward',
-        members: ['steward@gmail.com'],
+        members: ['steward@gmail.com', 'steward1@gmail.com'],
       },
       {
         name: 'reader',
@@ -59,6 +59,7 @@ describe('Snapshot access info', () => {
       .within(() => {
         cy.get('[data-cy="user-email"]').then((user) => {
           cy.wrap(user[0]).should('contain.text', 'steward@gmail.com');
+          cy.wrap(user[0]).should('contain.text', 'steward1@gmail.com');
         });
       });
     cy.get('[data-cy="snapshot-readers"]')

--- a/src/sagas/repository.ts
+++ b/src/sagas/repository.ts
@@ -551,7 +551,7 @@ export function* getDatasetById({ payload }: any): any {
 }
 
 export function* getDatasetPolicy({ payload }: any): any {
-  const datasetId = payload;
+  const { datasetId, options } = payload;
   try {
     const response = yield call(authGet, `/api/repository/v1/datasets/${datasetId}/policies`);
     yield put({
@@ -559,7 +559,14 @@ export function* getDatasetPolicy({ payload }: any): any {
       policy: response,
     });
   } catch (err) {
-    showNotification(err);
+    if (options?.suppressErrorNotification) {
+      yield put({
+        type: ActionTypes.GET_DATASET_POLICY_SUCCESS,
+        policy: { data: { policies: [{ name: 'ERROR', members: [] }] } },
+      });
+    } else {
+      showNotification(err);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

https://broadworkbench.atlassian.net/browse/DT-1232

For snapshots whose source dataset have `inherit steward` enabled, add the dataset custodian users to the snapshot's list of stewards. These inherited stewards are read-only in the snapshot view. If inherit steward isn't enabled, or if there are no custodians, the steward list is unchanged.

Not yet done/bugs

- tests

## Screenshots

User has permission to view the source dataset; inherited stewards are visible. The inherited stewards can't be removed and have a tooltip.

![inherited steward](https://github.com/user-attachments/assets/089b9130-dac2-424b-8219-6f2033fcfd16)

User doesn't have permission to view the source dataset. An error is shown in the Stewards list.

![image](https://github.com/user-attachments/assets/ab8779bd-1735-4e39-b58e-15ced03821e2)

