### PR TITLE
DT-1794: return [] instead of [null] for auth domains when creating a snapshot

### DIFF
--- a/src/reducers/snapshot.ts
+++ b/src/reducers/snapshot.ts
@@ -317,7 +317,7 @@ export default {
           name,
           description,
           mode,
-          dataAccessControlGroups: [authDomain],
+          dataAccessControlGroups: authDomain == null ? [] : [authDomain],
           billingProfileId,
         };
         if (mode === SnapshotRequestContentsModelModeEnum.ByQuery) {


### PR DESCRIPTION
We don't allow creating a snapshot with an auth domain if the source dataset has inherit steward enabled. 

In the UI, we were passing through a list when the value "null" as an auth domain. This was not passing the check in the backend for "no auth domains". ([jade-data-repo check](https://github.com/DataBiosphere/jade-data-repo/blob/9e556f3f52529b50e522564bb878e8d191d54e99/src/main/java/bio/terra/service/snapshot/SnapshotService.java#L218))

<img width="1387" alt="Screenshot 2025-06-04 at 12 17 26 PM" src="https://github.com/user-attachments/assets/4faee033-30cd-4ee4-bac0-10db4bc2d937" />

Solution: Instead provide an empty array if the user does not select any auth domains in the UI on snapshot create.