### PR TITLE
DT-2156: Replace the need for an outdated library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jade-data-repo-ui",
-  "version": "0.435.0",
+  "version": "0.437.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jade-data-repo-ui",
-      "version": "0.435.0",
+      "version": "0.437.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/runtime": "^7.28.2",
@@ -16,7 +16,6 @@
         "@emotion/styled": "^11.14.1",
         "@fortawesome/fontawesome-svg-core": "^7.0.0",
         "@fortawesome/free-solid-svg-icons": "^7.0.0",
-        "@fortawesome/react-fontawesome": "^0.2.3",
         "@mui/icons-material": "5.11.11",
         "@mui/lab": "^5.0.0-alpha.126",
         "@mui/material": "5.10.14",
@@ -3007,19 +3006,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/react-fontawesome": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.3.tgz",
-      "integrity": "sha512-HlJco8RDY8NrzFVjy23b/7mNS4g9NegcrBG3n7jinwpc2x/AmSVk53IhWniLYM4szYLxRAFTAGwGn0EIlclDeQ==",
-      "license": "MIT",
-      "dependencies": {
-        "prop-types": "^15.8.1"
-      },
-      "peerDependencies": {
-        "@fortawesome/fontawesome-svg-core": "~1 || ~6 || ~7",
-        "react": "^16.3 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@emotion/styled": "^11.14.1",
     "@fortawesome/fontawesome-svg-core": "^7.0.0",
     "@fortawesome/free-solid-svg-icons": "^7.0.0",
-    "@fortawesome/react-fontawesome": "^0.2.3",
     "@mui/icons-material": "5.11.11",
     "@mui/lab": "^5.0.0-alpha.126",
     "@mui/material": "5.10.14",

--- a/src/components/table/LightTableHead.tsx
+++ b/src/components/table/LightTableHead.tsx
@@ -5,8 +5,8 @@ import _ from 'lodash';
 import { SortDirection, TableCell, TableHead, TableRow, TableSortLabel, Box } from '@mui/material';
 import { CustomTheme, styled } from '@mui/material/styles';
 import Draggable, { DraggableEventHandler } from 'react-draggable';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faLongArrowAltDown, faLongArrowAltUp } from '@fortawesome/free-solid-svg-icons';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 
 import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
 import { EllipsisBox, EllipsisSpan } from 'components/common/Ellipsis';
@@ -52,11 +52,13 @@ const ColumnResizer = styled(DragIndicatorIcon)(({ theme }) => ({
   cursor: 'ew-resize',
 }));
 
-const SortIcon = styled(FontAwesomeIcon)(({ theme }) => ({
+const SortIcon = styled('div')(({ theme }) => ({
   color: `${theme.palette.primary.main} !important`,
   width: '16px',
   height: '16px',
   marginRight: `-${theme.spacing(1)}`,
+  display: 'flex',
+  alignItems: 'center',
 }));
 
 const Label = styled('span')(({ theme }) => ({
@@ -64,13 +66,38 @@ const Label = styled('span')(({ theme }) => ({
   ...(theme as CustomTheme).mixins.ellipsis,
 }));
 
-type LightTableHeadProps = {
+function SortIconComponent({
+  sortDir,
+  allowResize,
+}: {
+  readonly sortDir: SortDirection;
+  readonly allowResize?: boolean;
+}) {
+  return (
+    <SortIcon
+      sx={{
+        marginRight: allowResize ? (theme) => theme.spacing(1) : 0,
+      }}
+    >
+      {sortDir === 'asc' ? <KeyboardArrowDownIcon /> : <KeyboardArrowUpIcon />}
+    </SortIcon>
+  );
+}
+
+const createSortIconComponent = (sortDir: SortDirection, allowResize?: boolean) => {
+  function SortIconWrapper() {
+    return <SortIconComponent sortDir={sortDir} allowResize={allowResize} />;
+  }
+  return SortIconWrapper;
+};
+
+type LightTableHeadProps = Readonly<{
   columns: Array<TableColumnType>;
   onRequestSort: (event: any, property: string) => void;
   onResizeColumn: (event: any, property: string, size: number) => void;
   orderDirection: OrderDirectionOptions;
   orderProperty: string;
-};
+}>;
 
 function LightTableHead({
   columns,
@@ -171,16 +198,7 @@ function LightTableHead({
                       direction={sortDir || TABLE_DEFAULT_SORT_ORDER}
                       onClick={createSortHandler(col.name)}
                       IconComponent={
-                        !sortDir
-                          ? undefined
-                          : () => (
-                              <SortIcon
-                                icon={sortDir === 'asc' ? faLongArrowAltDown : faLongArrowAltUp}
-                                sx={{
-                                  marginRight: col.allowResize ? (theme) => theme.spacing(1) : 0,
-                                }}
-                              />
-                            )
+                        !sortDir ? undefined : createSortIconComponent(sortDir, col.allowResize)
                       }
                       style={{ width: maxWidth, flex: 1 }}
                     >

--- a/src/components/table/LightTableHead.tsx
+++ b/src/components/table/LightTableHead.tsx
@@ -5,8 +5,8 @@ import _ from 'lodash';
 import { SortDirection, TableCell, TableHead, TableRow, TableSortLabel, Box } from '@mui/material';
 import { CustomTheme, styled } from '@mui/material/styles';
 import Draggable, { DraggableEventHandler } from 'react-draggable';
-import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
-import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
+import ArrowDownward from '@mui/icons-material/ArrowDownward';
+import ArrowUpward from '@mui/icons-material/ArrowUpward';
 
 import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
 import { EllipsisBox, EllipsisSpan } from 'components/common/Ellipsis';
@@ -79,7 +79,7 @@ function SortIconComponent({
         marginRight: allowResize ? (theme) => theme.spacing(1) : 0,
       }}
     >
-      {sortDir === 'asc' ? <KeyboardArrowDownIcon /> : <KeyboardArrowUpIcon />}
+      {sortDir === 'asc' ? <ArrowDownward /> : <ArrowUpward />}
     </SortIcon>
   );
 }


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-2156

## Summary
This PR replaces the need for a failing dependabot PR: https://github.com/DataBiosphere/jade-data-repo-ui/pull/1818
This PR replaces the single usage of a very old library with a similar version in material ui which is up to date.

### New sort icons
<img width="1497" height="988" alt="Screenshot 2025-08-27 at 11 42 49 AM" src="https://github.com/user-attachments/assets/42b4f273-6bdc-48e6-a385-445acaeb7304" />
<img width="1497" height="988" alt="Screenshot 2025-08-27 at 11 42 58 AM" src="https://github.com/user-attachments/assets/cde7df61-ee5a-4231-8c7d-ad78eed9c54c" />

### Old sort icons
<img width="1497" height="988" alt="Screenshot 2025-08-27 at 11 43 08 AM" src="https://github.com/user-attachments/assets/eaff478b-1bee-459d-a912-8fd2865f6a26" />
<img width="1497" height="988" alt="Screenshot 2025-08-27 at 11 43 11 AM" src="https://github.com/user-attachments/assets/c2e03753-ac9a-4fea-b09d-359b24dc6b54" />


