### PR TITLE
[DC-1783] Assign code reviewers correctly 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,3 @@
 
 # These owners will be the default owners for everything in the repo.
 *       @DataBiosphere/jadeteam
-*       @DataBiosphere/dsp-data-team-eng


### PR DESCRIPTION
Addresses:
Shift in ownership of the repository

Summary
Remove data-team as codeowner