### PR TITLE
[DC-1801] repository.ts calls a DUOS autocomplete endpoint that doesn't exist

### DIFF
--- a/src/components/snapshot/overview/SnapshotOverview.test.tsx
+++ b/src/components/snapshot/overview/SnapshotOverview.test.tsx
@@ -1,0 +1,378 @@
+import { mount } from 'cypress/react';
+import { Router } from 'react-router-dom';
+import { ThemeProvider } from '@mui/material/styles';
+import { Provider } from 'react-redux';
+import React from 'react';
+import createMockStore from 'redux-mock-store';
+import { routerMiddleware } from 'connected-react-router';
+import _ from 'lodash';
+import history from '../../../modules/hist';
+import globalTheme from '../../../modules/theme';
+import SnapshotOverview from './SnapshotOverview';
+import { initialUserState } from '../../../reducers/user';
+import { initialQueryState } from '../../../reducers/query';
+import { initialSnapshotState } from '../../../reducers/snapshot';
+import { initialDuosState } from '../../../reducers/duos';
+import { SnapshotIncludeOptions } from '../../../constants';
+
+const mockSnapshot = {
+  id: 'test-snapshot-id-123',
+  name: 'Test Snapshot',
+  description: 'A test snapshot for unit testing',
+  createdDate: '2023-01-01T00:00:00Z',
+  cloudPlatform: 'gcp',
+  tables: [
+    {
+      name: 'test_table',
+      columns: [
+        { name: 'id', type: 'string' },
+        { name: 'name', type: 'string' },
+      ],
+    },
+  ],
+  source: [
+    {
+      dataset: {
+        id: 'source-dataset-id',
+        name: 'Source Dataset',
+      },
+    },
+  ],
+};
+
+const mockSnapshotPolicies = [
+  {
+    name: 'reader',
+    members: ['test-user@example.com'],
+  },
+  {
+    name: 'discoverer',
+    members: ['discoverer@example.com'],
+  },
+];
+
+const mockDuosDatasets = [
+  {
+    datasetId: 1,
+    datasetName: 'Test DUOS Dataset 1',
+    datasetIdentifier: 'DUOS-001',
+  },
+  {
+    datasetId: 2,
+    datasetName: 'Test DUOS Dataset 2',
+    datasetIdentifier: 'DUOS-002',
+  },
+];
+
+const mockUserRoles = ['reader'];
+
+const mockStore = createMockStore([routerMiddleware(history)]);
+
+const createInitialState = (overrides = {}) =>
+  _.merge(
+    {
+      user: {
+        ...initialUserState,
+        isAuthenticated: true,
+        email: 'test@example.com',
+      },
+      snapshots: {
+        ...initialSnapshotState,
+        snapshot: { ...mockSnapshot, id: 'test-snapshot-id-123' }, // Ensure ID matches
+        snapshotByIdLoading: false,
+        snapshotPolicies: mockSnapshotPolicies,
+        userRoles: mockUserRoles,
+        snapshotAuthDomains: ['test-auth-domain'],
+        pendingSave: {
+          consentCode: false,
+          description: false,
+          duosDataset: false,
+        },
+      },
+      duos: {
+        ...initialDuosState,
+        datasets: mockDuosDatasets,
+        loading: false,
+      },
+      query: initialQueryState,
+      router: {
+        location: {
+          pathname: '/snapshots/test-snapshot-id-123',
+          query: {},
+        },
+      },
+    },
+    overrides,
+  );
+
+const mountComponent = (snapshotId = 'test-snapshot-id-123', stateOverrides = {}) => {
+  // Ensure the snapshot ID in state matches the route parameter
+  const mergedOverrides = _.merge(
+    {
+      snapshots: {
+        snapshot: { ...mockSnapshot, id: snapshotId },
+      },
+    },
+    stateOverrides,
+  );
+
+  const initialState = createInitialState(mergedOverrides);
+  const store = mockStore(initialState);
+
+  // Spy on dispatch to verify action calls
+  cy.spy(store, 'dispatch').as('dispatchSpy');
+
+  // Mock route params
+  const mockMatch = {
+    params: { uuid: snapshotId },
+    isExact: true,
+    path: '/snapshots/:uuid',
+    url: `/snapshots/${snapshotId}`,
+  };
+
+  mount(
+    <Provider store={store}>
+      <Router history={history}>
+        <ThemeProvider theme={globalTheme}>
+          <SnapshotOverview match={mockMatch} history={history} location={history.location} />
+        </ThemeProvider>
+      </Router>
+    </Provider>,
+  );
+
+  return store;
+};
+
+describe('SnapshotOverview Component', () => {
+  describe('Component Mount and Initial Actions', () => {
+    it('should mount successfully and dispatch required actions on load', () => {
+      mountComponent();
+
+      // Verify component renders
+      cy.get('[data-testid="snapshot-overview"], h3').should('exist');
+
+      // Verify all required actions are dispatched on mount
+      cy.get('@dispatchSpy').should(
+        'have.been.calledWith',
+        Cypress.sinon.match({
+          type: 'GET_SNAPSHOT_BY_ID',
+          payload: Cypress.sinon.match({
+            snapshotId: 'test-snapshot-id-123',
+            include: [
+              SnapshotIncludeOptions.SOURCES,
+              SnapshotIncludeOptions.TABLES,
+              SnapshotIncludeOptions.ACCESS_INFORMATION,
+              SnapshotIncludeOptions.PROFILE,
+              SnapshotIncludeOptions.DATA_PROJECT,
+              SnapshotIncludeOptions.DUOS,
+            ],
+          }),
+        }),
+      );
+
+      cy.get('@dispatchSpy').should(
+        'have.been.calledWith',
+        Cypress.sinon.match({
+          type: 'GET_SNAPSHOT_POLICY',
+          payload: 'test-snapshot-id-123',
+        }),
+      );
+
+      cy.get('@dispatchSpy').should(
+        'have.been.calledWith',
+        Cypress.sinon.match({
+          type: 'GET_USER_SNAPSHOT_ROLES',
+          payload: 'test-snapshot-id-123',
+        }),
+      );
+
+      cy.get('@dispatchSpy').should(
+        'have.been.calledWith',
+        Cypress.sinon.match({
+          type: 'GET_DUOS_DATASETS',
+        }),
+      );
+    });
+  });
+
+  describe('Loading States', () => {
+    it('should show loading spinner when snapshot is loading', () => {
+      mountComponent('test-snapshot-id-123', {
+        snapshots: {
+          snapshotByIdLoading: true,
+          snapshot: {},
+          snapshotPolicies: [],
+        },
+      });
+
+      // Should show loading spinner
+      cy.get('.MuiCircularProgress-root').should('exist');
+
+      // Should not show main content when loading
+      cy.contains(mockSnapshot.name).should('not.exist');
+    });
+
+    it('should not render content when snapshot policies are missing', () => {
+      mountComponent('test-snapshot-id-123', {
+        snapshots: {
+          snapshotByIdLoading: false,
+          snapshot: mockSnapshot,
+          snapshotPolicies: null,
+        },
+      });
+
+      // Should render empty box when conditions not met (no main content)
+      cy.contains(mockSnapshot.name).should('not.exist');
+    });
+
+    it('should not render content when snapshot is missing', () => {
+      mountComponent('test-snapshot-id-123', {
+        snapshots: {
+          snapshotByIdLoading: false,
+          snapshot: null,
+          snapshotPolicies: mockSnapshotPolicies,
+        },
+      });
+
+      // Should render empty box when conditions not met (no main content)
+      cy.contains(mockSnapshot.name).should('not.exist');
+    });
+
+    it('should not render content when snapshot tables are missing', () => {
+      mountComponent('test-snapshot-id-123', {
+        snapshots: {
+          snapshotByIdLoading: false,
+          snapshot: { ...mockSnapshot, tables: null },
+          snapshotPolicies: mockSnapshotPolicies,
+        },
+      });
+
+      // Should render empty box when conditions not met (no main content)
+      cy.contains(mockSnapshot.name).should('not.exist');
+    });
+
+    it('should not render content when snapshot ID does not match route param', () => {
+      mountComponent('different-snapshot-id', {
+        snapshots: {
+          snapshotByIdLoading: false,
+          snapshot: mockSnapshot, // has id: 'test-snapshot-id-123'
+          snapshotPolicies: mockSnapshotPolicies,
+        },
+      });
+
+      // Should render empty box when IDs don't match (no main content)
+      cy.contains(mockSnapshot.name).should('not.exist');
+    });
+  });
+
+  describe('Content Display', () => {
+    it('should display snapshot information when all conditions are met', () => {
+      mountComponent();
+      // Should display snapshot name as title
+      cy.get('h3').should('contain.text', mockSnapshot.name);
+    });
+  });
+
+  describe('State Integration', () => {
+    it('should integrate with DUOS datasets state correctly', () => {
+      const customDuosState = {
+        duos: {
+          datasets: [
+            {
+              datasetId: 999,
+              datasetName: 'Custom DUOS Dataset',
+              datasetIdentifier: 'CUSTOM-001',
+            },
+          ],
+          loading: true,
+        },
+      };
+
+      mountComponent('test-snapshot-id-123', customDuosState);
+
+      // Component should handle different DUOS states without errors
+      cy.contains(mockSnapshot.name).should('exist');
+    });
+
+    it('should handle pending save states correctly', () => {
+      const pendingSaveState = {
+        snapshots: {
+          pendingSave: {
+            consentCode: true,
+            description: true,
+            duosDataset: false,
+          },
+        },
+      };
+
+      mountComponent('test-snapshot-id-123', pendingSaveState);
+
+      // Component should render with pending save states
+      cy.contains(mockSnapshot.name).should('exist');
+    });
+
+    it('should handle empty user roles correctly', () => {
+      const stewardRoleState = {
+        snapshots: {
+          userRoles: [],
+        },
+      };
+
+      mountComponent('test-snapshot-id-123', stewardRoleState);
+
+      // Component should render with different user roles
+      cy.contains(mockSnapshot.name).should('exist');
+    });
+
+    it('should handle empty snapshot policies correctly', () => {
+      const emptyPoliciesState = {
+        snapshots: {
+          snapshotPolicies: [],
+        },
+      };
+
+      mountComponent('test-snapshot-id-123', emptyPoliciesState);
+
+      // Component should render main content even with empty policies array ([] is truthy)
+      cy.contains(mockSnapshot.name).should('exist');
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should handle snapshot without source dataset gracefully', () => {
+      const snapshotWithoutSource = {
+        ...mockSnapshot,
+        source: [],
+      };
+
+      mountComponent('test-snapshot-id-123', {
+        snapshots: {
+          snapshot: snapshotWithoutSource,
+        },
+      });
+
+      // Should still render the main structure
+      cy.contains(mockSnapshot.name).should('exist');
+    });
+
+    it('should handle missing snapshot data gracefully', () => {
+      const incompleteSnapshot = {
+        id: 'test-snapshot-id-123',
+        name: 'Incomplete Snapshot',
+        tables: [], // Empty tables but still an array
+        // Missing other properties
+      };
+
+      mountComponent('test-snapshot-id-123', {
+        snapshots: {
+          snapshot: incompleteSnapshot,
+          snapshotPolicies: mockSnapshotPolicies,
+        },
+      });
+
+      // Should handle missing data without crashing and render something
+      cy.get('body').should('exist');
+      cy.contains(incompleteSnapshot.name).should('exist');
+    });
+  });
+});

--- a/src/components/snapshot/overview/SnapshotOverviewPanel.test.tsx
+++ b/src/components/snapshot/overview/SnapshotOverviewPanel.test.tsx
@@ -25,9 +25,9 @@ const dataset: DatasetModel = {
 };
 
 const duosDatasets: Array<DuosDatasetModel> = [
-  { id: 1, name: 'DS1', identifier: 'DUOS-0001' },
-  { id: 2, name: 'DS2', identifier: 'DUOS-0002' },
-  { id: 3, name: 'DS3', identifier: 'DUOS-0003' },
+  { datasetId: 1, datasetName: 'DS1', datasetIdentifier: 'DUOS-0001' },
+  { datasetId: 2, datasetName: 'DS2', datasetIdentifier: 'DUOS-0002' },
+  { datasetId: 3, datasetName: 'DS3', datasetIdentifier: 'DUOS-0003' },
 ];
 
 function createSnapshot(duosFirecloudGroup?: DuosFirecloudGroupModel): SnapshotModel {

--- a/src/components/snapshot/overview/SnapshotOverviewPanel.tsx
+++ b/src/components/snapshot/overview/SnapshotOverviewPanel.tsx
@@ -37,7 +37,7 @@ function a11yProps(index: number) {
 }
 
 function getDuosDatasetValue(option?: DuosDatasetModel) {
-  return option ? `${option.identifier} - ${option.name}` : '';
+  return option ? `${option.datasetIdentifier} - ${option.datasetName}` : '';
 }
 
 interface SnapshotOverviewPanelProps {
@@ -69,7 +69,7 @@ function SnapshotOverviewPanel(props: SnapshotOverviewPanelProps) {
   const duosDatasetsLoaded = !_.isEmpty(duosDatasets);
 
   const selectedDuosDataset = duosDatasets.find(
-    (ds) => ds.identifier === snapshot.duosFirecloudGroup?.duosId,
+    (ds) => ds.datasetIdentifier === snapshot.duosFirecloudGroup?.duosId,
   );
   const handleChange = (_event: SyntheticEvent, newValue: number) => {
     setValue(newValue);
@@ -187,7 +187,9 @@ function SnapshotOverviewPanel(props: SnapshotOverviewPanelProps) {
                   options={duosDatasets}
                   // Setting to null instead of undefined if unset to make sure that this is always a controlled component
                   value={selectedDuosDataset ?? null}
-                  isOptionEqualToValue={(option, val) => option?.identifier === val?.identifier}
+                  isOptionEqualToValue={(option, val) =>
+                    option?.datasetIdentifier === val?.datasetIdentifier
+                  }
                   renderInput={(params: any) => (
                     <TextField
                       {...params}
@@ -200,7 +202,7 @@ function SnapshotOverviewPanel(props: SnapshotOverviewPanelProps) {
                   )}
                   getOptionLabel={getDuosDatasetValue}
                   onChange={(_event: any, change) => {
-                    dispatch(updateDuosDataset(snapshot.id, change?.identifier));
+                    dispatch(updateDuosDataset(snapshot.id, change?.datasetIdentifier));
                   }}
                   title={
                     pendingSave?.duosDataset

--- a/src/reducers/duos.ts
+++ b/src/reducers/duos.ts
@@ -6,9 +6,9 @@ import { ActionTypes } from '../constants/index';
 // Note: this is a subset of the full DUOS dataset object
 // https://github.com/DataBiosphere/consent/blob/develop/src/main/resources/assets/schemas/Dataset.yaml
 export interface DuosDatasetModel {
-  id: number;
-  name: string;
-  identifier: string;
+  datasetId: number;
+  datasetName: string;
+  datasetIdentifier: string;
 }
 export interface DuosState {
   datasets: Array<DuosDatasetModel>; // Assume an empty list means that the user could not read from DUOS

--- a/src/sagas/repository.ts
+++ b/src/sagas/repository.ts
@@ -949,19 +949,18 @@ export function* getDuosDatasets(): any {
   try {
     const duosUrl = yield select(getDuosUrl);
     const url = `${duosUrl}/api/dataset/search/index`;
-    const params = {
-      query: {
-        bool: {
-          must: [
-            {
-              match: {
-                _type: 'dataset',
-              },
-            },
-          ],
-        },
-      },
+    const params = 
+    {
+      "query":
+      {"bool":
+        {"must":
+          [{"match":{"_type":"dataset"}},
+           {"term":{"study.publicVisibility": true}},
+           {"term":{"dataLocation.keyword": "TDR Location"}}]
+        }
+      }
     };
+
     const response = yield call(authPost, url, params);
     yield put({
       type: ActionTypes.GET_DUOS_DATASETS_SUCCESS,

--- a/src/sagas/repository.ts
+++ b/src/sagas/repository.ts
@@ -949,16 +949,16 @@ export function* getDuosDatasets(): any {
   try {
     const duosUrl = yield select(getDuosUrl);
     const url = `${duosUrl}/api/dataset/search/index`;
-    const params = 
-    {
-      "query":
-      {"bool":
-        {"must":
-          [{"match":{"_type":"dataset"}},
-           {"term":{"study.publicVisibility": true}},
-           {"term":{"dataLocation.keyword": "TDR Location"}}]
-        }
-      }
+    const params = {
+      query: {
+        bool: {
+          must: [
+            { match: { _type: 'dataset' } },
+            { term: { 'study.publicVisibility': true } },
+            { term: { 'dataLocation.keyword': 'TDR Location' } },
+          ],
+        },
+      },
     };
 
     const response = yield call(authPost, url, params);

--- a/src/sagas/repository.ts
+++ b/src/sagas/repository.ts
@@ -948,8 +948,21 @@ export function* changePage(page: number): any {
 export function* getDuosDatasets(): any {
   try {
     const duosUrl = yield select(getDuosUrl);
-    const url = `${duosUrl}/api/dataset/autocomplete`;
-    const response = yield call(authGet, url);
+    const url = `${duosUrl}/api/dataset/search/index`;
+    const params = {
+      query: {
+        bool: {
+          must: [
+            {
+              match: {
+                _type: 'dataset',
+              },
+            },
+          ],
+        },
+      },
+    };
+    const response = yield call(authPost, url, params);
     yield put({
       type: ActionTypes.GET_DUOS_DATASETS_SUCCESS,
       datasets: { data: response },


### PR DESCRIPTION
### Why
TDR UI was calling an endpoint in DUOS that had been removed. The impact of this was that no DUOS datasets were viewable in the TDR UI and it always gave the message that users did not have access to any DUOS datasets. This also meant that the DUOS datasets could not be linked to a TDR snapshot on TDR UI either.

### Summary of Changes
Call the a different endpoint the search/index endpoint and filter for datasets.
Update the DUOS Dataset Model in TDR UI to match the response

### Testing
Adds unit tests for the SnapshotOverviewPanel